### PR TITLE
Add admin review moderation workflow and reminders

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://json.schemastore.org/eslintrc",
+  "extends": ["next/core-web-vitals"],
+  "rules": {}
+}

--- a/app/admin/reviews/page.tsx
+++ b/app/admin/reviews/page.tsx
@@ -1,0 +1,13 @@
+import ReviewModerationDashboard from "@/components/admin/reviews/ReviewModerationDashboard";
+
+export const metadata = {
+  title: "Review moderation",
+};
+
+export default function AdminReviewsPage() {
+  return (
+    <main className="p-6 lg:p-8">
+      <ReviewModerationDashboard />
+    </main>
+  );
+}

--- a/app/api/admin/reviews/[id]/route.ts
+++ b/app/api/admin/reviews/[id]/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from "next/server";
+import { checkAdminPermissions } from "@/lib/auth/admin-middleware";
+import { recordReviewFlag, respondToReview, updateReviewStatus } from "@/lib/models/reviews";
+import type { ReviewStatus } from "@/lib/types";
+
+interface PatchPayload {
+  status?: ReviewStatus;
+  moderationNotes?: string;
+  notifyCustomer?: boolean;
+  response?: string;
+  flagReason?: string;
+  flagNotes?: string;
+}
+
+export async function PATCH(request: NextRequest, { params }: { params: { id: string } }) {
+  const auth = await checkAdminPermissions(request);
+  if (!auth.success) {
+    return NextResponse.json({ success: false, error: auth.error }, { status: 401 });
+  }
+
+  try {
+    const { id } = params;
+    if (!id) {
+      return NextResponse.json({ success: false, error: "Review ID is required" }, { status: 400 });
+    }
+
+    const payload = (await request.json()) as PatchPayload;
+    let review = null;
+
+    if (payload.flagReason) {
+      review = await recordReviewFlag({
+        reviewId: id,
+        reason: payload.flagReason,
+        notes: payload.flagNotes,
+        flaggedBy: auth.userId ?? "admin",
+      });
+    }
+
+    if (payload.status) {
+      review = await updateReviewStatus({
+        reviewId: id,
+        status: payload.status,
+        moderationNotes: payload.moderationNotes,
+        notifyCustomer: payload.notifyCustomer,
+        moderatorId: auth.userId ?? "admin",
+      });
+    }
+
+    if (typeof payload.response === "string") {
+      review = await respondToReview({
+        reviewId: id,
+        response: payload.response,
+        notifyCustomer: payload.notifyCustomer,
+        adminId: auth.userId ?? "admin",
+      });
+    }
+
+    if (!review) {
+      return NextResponse.json({ success: false, error: "No updates were applied" }, { status: 400 });
+    }
+
+    return NextResponse.json({ success: true, data: review });
+  } catch (error) {
+    console.error("Failed to update review", error);
+    const message = error instanceof Error ? error.message : "Unable to update review";
+    return NextResponse.json({ success: false, error: message }, { status: 500 });
+  }
+}

--- a/app/api/admin/reviews/reminders/route.ts
+++ b/app/api/admin/reviews/reminders/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from "next/server";
+import { checkAdminPermissions } from "@/lib/auth/admin-middleware";
+import { findReviewReminderCandidates, sendReviewReminders } from "@/lib/models/reviews";
+
+interface ReminderPayload {
+  limit?: number;
+  minDaysSinceDelivery?: number;
+  maxDaysSinceDelivery?: number;
+}
+
+export async function GET(request: NextRequest) {
+  const auth = await checkAdminPermissions(request);
+  if (!auth.success) {
+    return NextResponse.json({ success: false, error: auth.error }, { status: 401 });
+  }
+
+  try {
+    const { searchParams } = new URL(request.url);
+    const limit = Number.parseInt(searchParams.get("limit") || "25", 10);
+    const minDays = Number.parseInt(searchParams.get("minDays") || "3", 10);
+    const maxDays = Number.parseInt(searchParams.get("maxDays") || "30", 10);
+
+    const candidates = await findReviewReminderCandidates({
+      limit: Number.isFinite(limit) ? limit : 25,
+      minDaysSinceDelivery: Number.isFinite(minDays) ? minDays : 3,
+      maxDaysSinceDelivery: Number.isFinite(maxDays) ? maxDays : 30,
+    });
+
+    return NextResponse.json({ success: true, data: candidates });
+  } catch (error) {
+    console.error("Failed to load reminder candidates", error);
+    return NextResponse.json(
+      { success: false, error: "Unable to load reminder candidates" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const auth = await checkAdminPermissions(request);
+  if (!auth.success) {
+    return NextResponse.json({ success: false, error: auth.error }, { status: 401 });
+  }
+
+  try {
+    const payload = (await request.json().catch(() => ({}))) as ReminderPayload;
+    const result = await sendReviewReminders({
+      limit: payload.limit,
+      minDaysSinceDelivery: payload.minDaysSinceDelivery,
+      maxDaysSinceDelivery: payload.maxDaysSinceDelivery,
+    });
+
+    return NextResponse.json({ success: true, ...result });
+  } catch (error) {
+    console.error("Failed to send reminder emails", error);
+    return NextResponse.json(
+      { success: false, error: "Unable to send reminders" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/admin/reviews/route.ts
+++ b/app/api/admin/reviews/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from "next/server";
+import { checkAdminPermissions } from "@/lib/auth/admin-middleware";
+import { getReviewModerationMetrics, getReviewQueue } from "@/lib/models/reviews";
+import type { ReviewStatus } from "@/lib/types";
+
+function parseStatuses(value: string | null): ReviewStatus[] | undefined {
+  if (!value) return undefined;
+  const parts = value
+    .split(",")
+    .map((part) => part.trim())
+    .filter(Boolean);
+  const allowed: ReviewStatus[] = [
+    "pending",
+    "needs_review",
+    "published",
+    "suppressed",
+    "auto_rejected",
+  ];
+  const statuses = parts.filter((part): part is ReviewStatus =>
+    (allowed as string[]).includes(part)
+  );
+  return statuses.length ? statuses : undefined;
+}
+
+export async function GET(request: NextRequest) {
+  const auth = await checkAdminPermissions(request);
+  if (!auth.success) {
+    return NextResponse.json({ success: false, error: auth.error }, { status: 401 });
+  }
+
+  try {
+    const { searchParams } = new URL(request.url);
+    const limitParam = Number.parseInt(searchParams.get("limit") || "20", 10);
+    const offsetParam = Number.parseInt(searchParams.get("offset") || "0", 10);
+    const includeMetrics = searchParams.get("includeMetrics") === "true";
+    const response = await getReviewQueue({
+      statuses: parseStatuses(searchParams.get("status")),
+      flaggedOnly: searchParams.get("flagged") === "true",
+      productId: searchParams.get("productId") ?? undefined,
+      search: searchParams.get("search") ?? undefined,
+      limit: Number.isFinite(limitParam) ? limitParam : 20,
+      offset: Number.isFinite(offsetParam) ? offsetParam : 0,
+    });
+
+    const payload: Record<string, unknown> = {
+      success: true,
+      data: response.items,
+      meta: {
+        total: response.total,
+        limit: Number.isFinite(limitParam) ? limitParam : 20,
+        offset: Number.isFinite(offsetParam) ? offsetParam : 0,
+      },
+    };
+
+    if (includeMetrics) {
+      payload.metrics = await getReviewModerationMetrics();
+    }
+
+    return NextResponse.json(payload);
+  } catch (error) {
+    console.error("Failed to load review queue", error);
+    return NextResponse.json(
+      { success: false, error: "Unable to load review queue" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/orders/[id]/reviews/route.ts
+++ b/app/api/orders/[id]/reviews/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '@clerk/nextjs/server';
+import { getReviewsForOrder, submitReviewForOrderItem } from '@/lib/models';
+
+function resolveStatusFromError(message: string): number {
+  const normalized = message.toLowerCase();
+  if (normalized.includes('not found')) return 404;
+  if (normalized.includes('only review products from your own orders')) return 403;
+  if (normalized.includes('only review items after the order has been delivered')) return 409;
+  if (normalized.includes('already submitted')) return 409;
+  if (normalized.includes('prohibited content')) return 422;
+  if (normalized.includes('required') || normalized.includes('must be')) return 400;
+  return 400;
+}
+
+export async function GET(_req: NextRequest, { params }: { params: { id: string } }) {
+  const { userId } = await auth();
+  if (!userId) {
+    return NextResponse.json({ error: 'Authentication required.' }, { status: 401 });
+  }
+
+  try {
+    const { id: orderId } = params;
+    if (!orderId) {
+      return NextResponse.json({ error: 'Order ID is required.' }, { status: 400 });
+    }
+
+    const reviews = await getReviewsForOrder(orderId, userId);
+    return NextResponse.json({ data: reviews });
+  } catch (error) {
+    console.error('Failed to fetch order reviews', error);
+    return NextResponse.json({ error: 'Unable to load reviews.' }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest, { params }: { params: { id: string } }) {
+  const { userId } = await auth();
+  if (!userId) {
+    return NextResponse.json({ error: 'Authentication required.' }, { status: 401 });
+  }
+
+  try {
+    const { id: orderId } = params;
+    if (!orderId) {
+      return NextResponse.json({ error: 'Order ID is required.' }, { status: 400 });
+    }
+
+    const payload = await request.json();
+    const review = await submitReviewForOrderItem({
+      ...payload,
+      orderId,
+      customerId: userId,
+    });
+
+    return NextResponse.json({ data: review });
+  } catch (error) {
+    console.error('Failed to submit review', error);
+    const message = error instanceof Error ? error.message : 'Unable to submit review.';
+    return NextResponse.json({ error: message }, { status: resolveStatusFromError(message) });
+  }
+}

--- a/app/product/[slug]/ProductDisplay.tsx
+++ b/app/product/[slug]/ProductDisplay.tsx
@@ -29,21 +29,25 @@
  *
  * === Usage ===
  * ```tsx
- * <ProductDisplay product={productData} />
+ * <ProductDisplay product={productData} reviews={reviewList} />
  * ```
  *
  * === Props ===
  * @param product - Product object containing all product information
+ * @param reviews - Published product reviews to surface on the product page
  */
 
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
+import Link from "next/link";
 import Image from "next/image";
 import ProductRecommendations from "@/components/ProductRecommendations";
+import { StarRating } from "@/components/reviews/StarRating";
 import { useCartStore } from "@/lib/stores/cart-store";
+import { normalizeProductRating } from "@/lib/utils/ratings";
 import { toast } from "sonner";
-import type { Product } from "@/lib/types/";
+import type { Product, Review } from "@/lib/types";
 import {
   Select,
   SelectContent,
@@ -52,7 +56,25 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 
-export default function ProductDisplay({ product }: { product: Product }) {
+function formatReviewDate(value?: string) {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function getReviewTimestamp(review: Review): number {
+  const candidate = review.published_at ?? review.submitted_at ?? review.created_at ?? null;
+  if (!candidate) return 0;
+  const date = new Date(candidate);
+  return Number.isNaN(date.getTime()) ? 0 : date.getTime();
+}
+
+export default function ProductDisplay({ product, reviews }: { product: Product; reviews: Review[] }) {
   // Helper to get the best image URL from a MACH Media object
   function getMediaUrl(media: any): string {
     if (!media) return "/placeholder.jpg";
@@ -99,6 +121,110 @@ export default function ProductDisplay({ product }: { product: Product }) {
   // Stock logic (MACH: inventory is on variant)
   const quantityInStock = selectedVariant?.inventory?.quantity ?? 0;
   const available = quantityInStock > 0;
+
+  const [ratingFilter, setRatingFilter] = useState<'all' | number>('all');
+  const [sortBy, setSortBy] = useState<'recent' | 'highest' | 'lowest'>('recent');
+
+  const reviewList = useMemo(() => (Array.isArray(reviews) ? [...reviews] : []), [reviews]);
+
+  const highlightPositive = useMemo(() => {
+    return (
+      reviewList
+        .filter((review) => review.rating >= 4 && (review.body?.trim().length ?? 0) > 0)
+        .sort((a, b) => {
+          if (b.rating !== a.rating) return b.rating - a.rating;
+          return getReviewTimestamp(b) - getReviewTimestamp(a);
+        })[0] ?? null
+    );
+  }, [reviewList]);
+
+  const highlightCritical = useMemo(() => {
+    const severe = reviewList
+      .filter((review) => review.rating <= 2 && (review.body?.trim().length ?? 0) > 0)
+      .sort((a, b) => {
+        if (a.rating !== b.rating) return a.rating - b.rating;
+        return getReviewTimestamp(b) - getReviewTimestamp(a);
+      });
+
+    if (severe.length) {
+      return severe[0];
+    }
+
+    return (
+      reviewList
+        .filter((review) => review.rating <= 3 && (review.body?.trim().length ?? 0) > 0)
+        .sort((a, b) => {
+          if (a.rating !== b.rating) return a.rating - b.rating;
+          return getReviewTimestamp(b) - getReviewTimestamp(a);
+        })[0] ?? null
+    );
+  }, [reviewList]);
+
+  const highlightEntries = useMemo(() => {
+    const entries: Array<{ key: string; tone: 'positive' | 'critical'; review: Review; label: string }> = [];
+    if (highlightPositive) {
+      entries.push({
+        key: `positive-${highlightPositive.id}`,
+        tone: 'positive',
+        review: highlightPositive,
+        label: 'Top positive review',
+      });
+    }
+    if (highlightCritical && (!highlightPositive || highlightCritical.id !== highlightPositive.id)) {
+      entries.push({
+        key: `critical-${highlightCritical.id}`,
+        tone: 'critical',
+        review: highlightCritical,
+        label: 'Top critical review',
+      });
+    }
+    return entries;
+  }, [highlightPositive, highlightCritical]);
+
+  const sortedReviews = useMemo(() => {
+    const list = [...reviewList];
+    if (!list.length) return list;
+
+    switch (sortBy) {
+      case 'highest':
+        return list.sort((a, b) => {
+          if (b.rating !== a.rating) return b.rating - a.rating;
+          return getReviewTimestamp(b) - getReviewTimestamp(a);
+        });
+      case 'lowest':
+        return list.sort((a, b) => {
+          if (a.rating !== b.rating) return a.rating - b.rating;
+          return getReviewTimestamp(b) - getReviewTimestamp(a);
+        });
+      case 'recent':
+      default:
+        return list.sort((a, b) => getReviewTimestamp(b) - getReviewTimestamp(a));
+    }
+  }, [reviewList, sortBy]);
+
+  const filteredReviews = useMemo(() => {
+    if (ratingFilter === 'all') {
+      return sortedReviews;
+    }
+    return sortedReviews.filter((review) => review.rating === ratingFilter);
+  }, [sortedReviews, ratingFilter]);
+
+  const reviewCount = reviewList.length;
+  const ratingSelectValue = ratingFilter === 'all' ? 'all' : String(ratingFilter);
+
+  const ratingSummary = normalizeProductRating(product.rating);
+  const hasRatings = Boolean(ratingSummary && ratingSummary.count > 0);
+  const ratingDistribution = hasRatings
+    ? [5, 4, 3, 2, 1].map((bucket) => {
+        const count = ratingSummary!.distribution?.[bucket] ?? 0;
+        const percent = ratingSummary!.count > 0 ? Math.round((count / ratingSummary!.count) * 100) : 0;
+        return { bucket, count, percent };
+      })
+    : [];
+  const hasDistribution = ratingDistribution.some((entry) => entry.count > 0);
+  const lastPublishedLabel = hasRatings && ratingSummary?.lastPublishedAt
+    ? formatReviewDate(ratingSummary.lastPublishedAt)
+    : null;
 
   return (
     <>
@@ -151,6 +277,227 @@ export default function ProductDisplay({ product }: { product: Product }) {
               ? product.description
               : Object.values(product.description || {})[0] || ""}
           </p>
+
+          {hasRatings ? (
+            <section className="mb-6 rounded-lg border border-neutral-800 bg-neutral-900 p-4">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div className="flex items-center gap-4">
+                  <StarRating value={ratingSummary!.average} size="lg" />
+                  <div>
+                    <p className="text-3xl font-semibold text-white">
+                      {ratingSummary!.average.toFixed(1)}
+                    </p>
+                    <p className="text-sm text-gray-400">
+                      {ratingSummary!.count} review{ratingSummary!.count === 1 ? "" : "s"}
+                    </p>
+                  </div>
+                </div>
+                {lastPublishedLabel && (
+                  <p className="text-xs text-gray-500 sm:text-right">
+                    Last review {lastPublishedLabel}
+                  </p>
+                )}
+              </div>
+              {hasDistribution && (
+                <dl className="mt-4 space-y-2">
+                  {ratingDistribution.map(({ bucket, count, percent }) => (
+                    <div key={bucket} className="flex items-center gap-3 text-xs text-gray-300">
+                      <dt className="w-10 font-medium text-gray-400">{bucket}★</dt>
+                      <dd className="flex-1">
+                        <div className="h-2 rounded-full bg-neutral-800">
+                          <div
+                            className="h-full rounded-full bg-yellow-400"
+                            style={{ width: `${percent}%` }}
+                          />
+                        </div>
+                      </dd>
+                      <span className="w-10 text-right text-gray-500">{count}</span>
+                    </div>
+                  ))}
+                </dl>
+              )}
+            </section>
+          ) : (
+            <p className="mb-6 text-sm text-gray-500">
+              No reviews yet — be the first to share your experience after delivery.
+            </p>
+          )}
+
+          <div className="mb-6 rounded-lg border border-neutral-800 bg-neutral-900 p-4">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <h2 className="text-base font-semibold text-white">Share your experience</h2>
+                <p className="text-sm text-gray-400">
+                  Reviews are limited to verified purchases—visit your order history once delivery is confirmed.
+                </p>
+              </div>
+              <Link
+                href="/account/orders"
+                className="inline-flex items-center justify-center rounded-md bg-orange-500 px-4 py-2 text-sm font-semibold text-black transition hover:bg-orange-400"
+              >
+                Review your order
+              </Link>
+            </div>
+          </div>
+
+          {highlightEntries.length > 0 && (
+            <section className="mb-6 rounded-lg border border-neutral-800 bg-neutral-900 p-4">
+              <div className="mb-4">
+                <h2 className="text-lg font-semibold text-white">Review highlights</h2>
+                <p className="text-sm text-gray-400">Balanced perspective from shoppers at both ends of the rating scale.</p>
+              </div>
+              <div className="grid gap-4 sm:grid-cols-2">
+                {highlightEntries.map(({ key, tone, review, label }) => (
+                  <article
+                    key={key}
+                    className="rounded-md border border-neutral-700 bg-neutral-950 p-4"
+                    aria-label={label}
+                  >
+                    <div className="flex items-center justify-between gap-2">
+                      <div>
+                        <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">{label}</p>
+                        <div className="mt-1 flex items-center gap-2">
+                          <StarRating value={review.rating} size="sm" />
+                          <span className="text-sm font-semibold text-white">{review.rating.toFixed(1)}</span>
+                        </div>
+                      </div>
+                      <span
+                        className={`text-xs font-medium ${
+                          tone === 'positive' ? 'text-green-300' : 'text-amber-300'
+                        }`}
+                      >
+                        {tone === 'positive' ? 'Positive' : 'Critical'}
+                      </span>
+                    </div>
+                    {review.title && <h3 className="mt-3 text-base font-semibold text-white">{review.title}</h3>}
+                    {review.body && (
+                      <p className="mt-2 text-sm text-gray-300 whitespace-pre-wrap">{review.body}</p>
+                    )}
+                    <p className="mt-3 text-xs text-gray-500">
+                      {formatReviewDate(review.published_at ?? review.submitted_at ?? review.created_at) ?? 'Recently updated'}
+                    </p>
+                  </article>
+                ))}
+              </div>
+            </section>
+          )}
+
+          {reviewCount > 0 && (
+            <section className="mb-6 rounded-lg border border-neutral-800 bg-neutral-900 p-4">
+              <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <h2 className="text-lg font-semibold text-white">All reviews</h2>
+                  <p className="text-sm text-gray-400">
+                    Showing {filteredReviews.length} of {reviewCount} review{reviewCount === 1 ? '' : 's'}.
+                  </p>
+                </div>
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+                  <Select
+                    value={ratingSelectValue}
+                    onValueChange={(value) => setRatingFilter(value === 'all' ? 'all' : Number(value))}
+                  >
+                    <SelectTrigger className="w-full bg-neutral-800 border-neutral-700 text-white hover:bg-neutral-700 sm:w-40">
+                      <SelectValue placeholder="Filter rating" />
+                    </SelectTrigger>
+                    <SelectContent className="bg-neutral-800 border-neutral-700">
+                      <SelectItem value="all" className="text-white hover:bg-neutral-700">
+                        All ratings
+                      </SelectItem>
+                      {[5, 4, 3, 2, 1].map((value) => (
+                        <SelectItem
+                          key={`filter-${value}`}
+                          value={String(value)}
+                          className="text-white hover:bg-neutral-700"
+                        >
+                          {value} star{value === 1 ? '' : 's'}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <Select
+                    value={sortBy}
+                    onValueChange={(value) => setSortBy(value as 'recent' | 'highest' | 'lowest')}
+                  >
+                    <SelectTrigger className="w-full bg-neutral-800 border-neutral-700 text-white hover:bg-neutral-700 sm:w-40">
+                      <SelectValue placeholder="Sort reviews" />
+                    </SelectTrigger>
+                    <SelectContent className="bg-neutral-800 border-neutral-700">
+                      <SelectItem value="recent" className="text-white hover:bg-neutral-700">
+                        Most recent
+                      </SelectItem>
+                      <SelectItem value="highest" className="text-white hover:bg-neutral-700">
+                        Highest rated
+                      </SelectItem>
+                      <SelectItem value="lowest" className="text-white hover:bg-neutral-700">
+                        Lowest rated
+                      </SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+
+              <div className="mt-4 space-y-4">
+                {filteredReviews.length > 0 ? (
+                  filteredReviews.map((review) => {
+                    const submittedLabel =
+                      formatReviewDate(review.published_at ?? review.submitted_at ?? review.created_at) ?? 'Recently updated';
+
+                    return (
+                      <article
+                        key={review.id}
+                        className="rounded-lg border border-neutral-800 bg-neutral-950 p-4"
+                        aria-label={`Review rated ${review.rating} stars`}
+                      >
+                        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                          <div className="flex items-center gap-2">
+                            <StarRating value={review.rating} size="sm" />
+                            <span className="text-sm font-semibold text-white">{review.rating.toFixed(1)}</span>
+                            {review.is_verified && (
+                              <span className="rounded-full bg-green-500/20 px-2 py-1 text-xs font-medium text-green-200">
+                                Verified purchase
+                              </span>
+                            )}
+                          </div>
+                          <p className="text-xs text-gray-500">{submittedLabel}</p>
+                        </div>
+                        {review.title && (
+                          <h3 className="mt-3 text-base font-semibold text-white">{review.title}</h3>
+                        )}
+                        {review.body && (
+                          <p className="mt-2 text-sm text-gray-300 whitespace-pre-wrap">{review.body}</p>
+                        )}
+                        {review.media?.length ? (
+                          <div className="mt-3 flex flex-wrap gap-2">
+                            {review.media.map((media) => (
+                              <a
+                                key={media.id ?? media.url}
+                                href={media.url}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="text-xs font-medium text-orange-300 underline"
+                              >
+                                View {media.type === 'video' ? 'video' : 'photo'}
+                              </a>
+                            ))}
+                          </div>
+                        ) : null}
+                        {review.admin_response && (
+                          <div className="mt-4 rounded-md border border-neutral-700 bg-neutral-900 p-3">
+                            <p className="text-xs font-semibold uppercase tracking-wide text-orange-400">
+                              Merchant response
+                            </p>
+                            <p className="mt-1 text-sm text-gray-200 whitespace-pre-wrap">{review.admin_response}</p>
+                          </div>
+                        )}
+                      </article>
+                    );
+                  })
+                ) : (
+                  <p className="text-sm text-gray-400">No reviews match the selected filters yet.</p>
+                )}
+              </div>
+            </section>
+          )}
 
           {/* Variant Selector */}
           {variants.length > 1 && (

--- a/app/product/[slug]/page.tsx
+++ b/app/product/[slug]/page.tsx
@@ -40,7 +40,7 @@
  * @returns JSX element with product page layout or 404 if not found
  */
 
-import { getProductBySlug } from "@/lib/models";
+import { getProductBySlug, getProductReviews } from "@/lib/models";
 import { notFound } from "next/navigation";
 import ProductDisplay from "./ProductDisplay";
 
@@ -54,10 +54,16 @@ export default async function ProductPage({ params }: any) {
   const product = await getProductBySlug(params.slug);
   if (!product) return notFound();
 
+  const reviews = await getProductReviews({
+    productId: product.id,
+    status: ["published"],
+    limit: 50,
+  });
+
   return (
     <main className="bg-neutral-900 text-white min-h-screen px-4 sm:px-6 lg:px-12 py-12 sm:py-16">
       <div className="max-w-5xl mx-auto">
-        <ProductDisplay product={product} />
+        <ProductDisplay product={product} reviews={reviews} />
       </div>
     </main>
   );

--- a/components/OrderCard.tsx
+++ b/components/OrderCard.tsx
@@ -1,44 +1,126 @@
 "use client";
 
+import { useEffect, useMemo, useState } from "react";
 import { cn } from "@/lib/utils";
-import { Order } from "@/lib/types";
+import { Order, Review } from "@/lib/types";
+import { ReviewForm } from "@/components/reviews/ReviewForm";
 
-type OrderStatus = "pending" | "paid" | "shipped" | "cancelled" | "incomplete";
+type OrderStatus = "pending" | "processing" | "shipped" | "delivered" | "cancelled" | "refunded";
 
-export default function OrderCard({ order }: { order: Order }) {
-  const date = new Date(order.created_at || '').toLocaleDateString(undefined, {
+function formatOrderDate(value?: string) {
+  if (!value) return "";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return date.toLocaleDateString(undefined, {
     year: "numeric",
     month: "short",
     day: "numeric",
   });
+}
 
+function buildReviewKey(review: Review) {
+  return review.order_item_id ?? review.product_id ?? review.id;
+}
+
+export default function OrderCard({ order }: { order: Order }) {
+  const date = formatOrderDate(order.created_at || "");
   const total = (order.total_amount?.amount ?? 0).toFixed(2);
-  const itemCount = Array.isArray(order.items) ? order.items.length : 0;
-  const previewItem = order.items?.[0]?.product_name || "Item";
+  const items = Array.isArray(order.items) ? order.items : [];
+  const itemCount = items.length;
+  const previewItem = items?.[0]?.product_name || "Item";
+  const [expanded, setExpanded] = useState(false);
+  const [reviews, setReviews] = useState<Record<string, Review>>({});
+  const [loadingReviews, setLoadingReviews] = useState(false);
+  const [reviewError, setReviewError] = useState<string | null>(null);
 
   const statusColor =
     {
       pending: "bg-yellow-600 text-white",
-      paid: "bg-green-600 text-white",
-      shipped: "bg-blue-600 text-white",
+      processing: "bg-blue-600 text-white",
+      shipped: "bg-indigo-600 text-white",
+      delivered: "bg-green-600 text-white",
       cancelled: "bg-red-600 text-white",
-      incomplete: "bg-gray-500 text-white",
+      refunded: "bg-purple-600 text-white",
     }[order.status as OrderStatus] ?? "bg-gray-700 text-white";
 
+  const orderId = order.id ?? "";
+  const reviewable = order.status === "delivered" || Boolean(order.delivered_at);
+  const disabledReason = reviewable ? null : "Reviews unlock once delivery is confirmed.";
+
+  useEffect(() => {
+    if (!orderId || !reviewable) return;
+    let cancelled = false;
+
+    async function loadReviews() {
+      setLoadingReviews(true);
+      setReviewError(null);
+      try {
+        const response = await fetch(`/api/orders/${orderId}/reviews`);
+        if (!response.ok) {
+          throw new Error('Unable to load review status.');
+        }
+
+        const payload = await response.json();
+        if (cancelled) return;
+
+        const incoming: Record<string, Review> = {};
+        for (const review of (payload?.data ?? []) as Review[]) {
+          const key = buildReviewKey(review);
+          incoming[key] = review;
+          if (review.product_id) {
+            incoming[review.product_id] = review;
+          }
+        }
+
+        setReviews(incoming);
+      } catch (error) {
+        if (!cancelled) {
+          setReviewError(error instanceof Error ? error.message : 'Unable to load review status.');
+        }
+      } finally {
+        if (!cancelled) {
+          setLoadingReviews(false);
+        }
+      }
+    }
+
+    loadReviews();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [orderId, reviewable]);
+
+  const submittedReviewCount = useMemo(() => {
+    const ids = new Set(Object.values(reviews).map((review) => review.id));
+    return ids.size;
+  }, [reviews]);
+
+  function handleReviewSubmitted(review: Review) {
+    const key = buildReviewKey(review);
+    setReviews((prev) => ({
+      ...prev,
+      [key]: review,
+      ...(review.product_id ? { [review.product_id]: review } : {}),
+    }));
+  }
+
   return (
-    <div className="bg-neutral-800 rounded-lg p-4 sm:p-6 shadow border border-neutral-700">
-      <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center mb-2 gap-2">
-        <h3 className="text-base sm:text-lg font-bold text-orange-400 truncate">
+    <div className="rounded-lg border border-neutral-700 bg-neutral-800 p-4 shadow sm:p-6">
+      <div className="mb-2 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <h3 className="truncate text-base font-bold text-orange-400 sm:text-lg">
           Order ID: <span className="text-white">{order.id}</span>
         </h3>
-        <span className={cn("text-xs px-2 py-1 rounded-full self-start sm:self-center", statusColor)}>
+        <span className={cn("self-start rounded-full px-2 py-1 text-xs sm:self-center", statusColor)}>
           {order.status}
         </span>
       </div>
 
-      <div className="text-sm text-gray-400 mb-1">Placed on {date}</div>
+      <div className="mb-1 text-sm text-gray-400">Placed on {date}</div>
 
-      <div className="text-sm text-gray-300 mb-1">
+      <div className="mb-1 text-sm text-gray-300">
         {itemCount} item{itemCount !== 1 ? "s" : ""}{" "}
         {previewItem && (
           <>
@@ -47,9 +129,66 @@ export default function OrderCard({ order }: { order: Order }) {
         )}
       </div>
 
-      <div className="text-lg font-semibold text-white mt-2">
+      <div className="mt-2 text-lg font-semibold text-white">
         Total: <span className="text-green-400">${total}</span>
       </div>
+
+      <div className="mt-4 flex flex-col gap-2">
+        {!reviewable && (
+          <p className="text-xs text-amber-300">
+            Delivery pending – we’ll invite you to review items once your gear arrives.
+          </p>
+        )}
+        {reviewError && <p className="text-xs text-red-400">{reviewError}</p>}
+        {submittedReviewCount > 0 && (
+          <p className="text-xs text-green-300">
+            {submittedReviewCount} review{submittedReviewCount === 1 ? "" : "s"} submitted for this order.
+          </p>
+        )}
+      </div>
+
+      {itemCount > 0 && (
+        <div className="mt-4">
+          <button
+            type="button"
+            onClick={() => setExpanded((value) => !value)}
+            className="flex w-full items-center justify-between rounded-md border border-neutral-700 bg-neutral-900 px-3 py-2 text-sm font-medium text-white transition hover:border-orange-500 hover:text-orange-300"
+            aria-expanded={expanded}
+          >
+            <span>{expanded ? "Hide order items" : "Review items from this order"}</span>
+            <span className="text-xs text-gray-400">{expanded ? "▲" : "▼"}</span>
+          </button>
+          {expanded && (
+            <div className="mt-4 space-y-4">
+              {items.map((item, index) => {
+                const itemKey = item.id ?? item.product_id ?? `${orderId}-${index}`;
+                const review = reviews[itemKey] ?? (item.product_id ? reviews[item.product_id] : undefined);
+                return (
+                  <div key={itemKey} className="rounded-lg border border-neutral-700 bg-neutral-900 p-4">
+                    <div className="mb-3 flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between">
+                      <div>
+                        <p className="text-sm font-semibold text-white">{item.product_name}</p>
+                        <p className="text-xs text-gray-400">SKU {item.sku}</p>
+                      </div>
+                      <p className="text-xs text-gray-400">Quantity: {item.quantity}</p>
+                    </div>
+                    <ReviewForm
+                      orderId={orderId}
+                      orderItemId={item.id}
+                      productId={item.product_id}
+                      productName={item.product_name}
+                      existingReview={review}
+                      onSubmitted={handleReviewSubmitted}
+                      disabledReason={disabledReason}
+                    />
+                  </div>
+                );
+              })}
+              {loadingReviews && <p className="text-xs text-gray-400">Checking existing reviews…</p>}
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -39,8 +39,10 @@
 
 import Link from "next/link";
 import Image from "next/image";
-import type { Product, ProductVariant } from "@/lib/types/";
+import type { Product, ProductVariant } from "@/lib/types";
 import { getDarkBlurPlaceholder } from "@/lib/utils/image-placeholders";
+import { normalizeProductRating } from "@/lib/utils/ratings";
+import { StarRating } from "@/components/reviews/StarRating";
 
 /**
  * Props interface for ProductCard component
@@ -48,6 +50,17 @@ import { getDarkBlurPlaceholder } from "@/lib/utils/image-placeholders";
 interface ProductCardProps {
   product: Product;
   priority?: boolean; // For above-the-fold images
+}
+
+function formatReviewDate(value?: string) {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
 }
 
 /**
@@ -111,6 +124,11 @@ export default function ProductCard({ product, priority = false }: ProductCardPr
     }
   })();
   const imageAlt = name;
+  const ratingSummary = normalizeProductRating(product.rating);
+  const hasRatings = Boolean(ratingSummary && ratingSummary.count > 0);
+  const lastUpdatedLabel = ratingSummary?.lastPublishedAt
+    ? formatReviewDate(ratingSummary.lastPublishedAt)
+    : null;
 
   return (
     <Link href={`/product/${slug}`} prefetch={true}>
@@ -136,6 +154,24 @@ export default function ProductCard({ product, priority = false }: ProductCardPr
           <p className="text-gray-400 text-sm sm:text-sm line-clamp-2 leading-relaxed">
             {shortDescription}
           </p>
+          <div className="flex items-center justify-between gap-2 text-xs sm:text-sm">
+            {hasRatings ? (
+              <div className="flex items-center gap-2">
+                <StarRating value={ratingSummary!.average} size="sm" />
+                <span className="text-sm font-semibold text-white">
+                  {ratingSummary!.average.toFixed(1)}
+                </span>
+                <span className="text-xs text-gray-400">({ratingSummary!.count})</span>
+              </div>
+            ) : (
+              <span className="text-xs text-gray-500">Be the first to review</span>
+            )}
+            {lastUpdatedLabel && (
+              <span className="hidden text-[11px] text-gray-500 sm:inline">
+                Updated {lastUpdatedLabel}
+              </span>
+            )}
+          </div>
           {price !== null && (
             <div className="text-sm">
               {onSale && compareAt != null ? (

--- a/components/admin/AdminSidebar.tsx
+++ b/components/admin/AdminSidebar.tsx
@@ -39,7 +39,8 @@ import {
   Menu,
   X,
   ClipboardList,
-  FileEdit
+  FileEdit,
+  MessageSquare
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
@@ -74,6 +75,12 @@ const navItems: NavItem[] = [
     href: "/admin/orders",
     icon: ClipboardList,
     description: "Order management"
+  },
+  {
+    label: "Reviews",
+    href: "/admin/reviews",
+    icon: MessageSquare,
+    description: "Moderate customer feedback"
   },
   {
     label: "Promotions",

--- a/components/admin/reviews/ReviewModerationDashboard.tsx
+++ b/components/admin/reviews/ReviewModerationDashboard.tsx
@@ -1,0 +1,745 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { StarRating } from "@/components/reviews/StarRating";
+import type {
+  Review,
+  ReviewModerationMetrics,
+  ReviewReminderCandidate,
+  ReviewStatus,
+} from "@/lib/types";
+import { toast } from "sonner";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Filter,
+  Flag,
+  Mail,
+  MessageCircle,
+  RefreshCw,
+  ShieldBan,
+  Sparkles,
+} from "lucide-react";
+
+const limit = 20;
+
+const statusOptions: Array<{ label: string; value: "all" | ReviewStatus }> = [
+  { label: "All statuses", value: "all" },
+  { label: "Needs review", value: "needs_review" },
+  { label: "Pending", value: "pending" },
+  { label: "Published", value: "published" },
+  { label: "Suppressed", value: "suppressed" },
+  { label: "Auto rejected", value: "auto_rejected" },
+];
+
+const statusStyles: Record<ReviewStatus, string> = {
+  pending: "bg-sky-500/20 text-sky-200",
+  needs_review: "bg-yellow-500/20 text-yellow-200",
+  published: "bg-emerald-500/20 text-emerald-200",
+  suppressed: "bg-slate-500/20 text-slate-200",
+  auto_rejected: "bg-rose-500/20 text-rose-200",
+};
+
+function formatTimestamp(value?: string | null) {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return date.toLocaleString();
+}
+
+function relativeTime(value?: string | null) {
+  if (!value) return "unknown";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  const diffMs = Date.now() - date.getTime();
+  const diffMinutes = Math.round(diffMs / (60 * 1000));
+  if (Math.abs(diffMinutes) < 1) return "just now";
+  const units: Array<[number, Intl.RelativeTimeFormatUnit]> = [
+    [60 * 24 * 365, "year"],
+    [60 * 24 * 30, "month"],
+    [60 * 24 * 7, "week"],
+    [60 * 24, "day"],
+    [60, "hour"],
+    [1, "minute"],
+  ];
+  const rtf = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" });
+  for (const [minutes, unit] of units) {
+    if (Math.abs(diffMinutes) >= minutes) {
+      const value = Math.round(diffMinutes / minutes);
+      return rtf.format(-value, unit);
+    }
+  }
+  return "just now";
+}
+
+function moderationReasons(review: Review) {
+  const reasons = review.automated_moderation?.reasons ?? [];
+  const detected = review.automated_moderation?.detectedPhrases ?? [];
+  const warnings = review.automated_moderation?.warnings ?? [];
+  const tags = new Set<string>();
+  reasons.forEach((reason) => tags.add(reason));
+  warnings.forEach((warning) => tags.add(`warn:${warning}`));
+  detected.forEach((phrase) => tags.add(`match:${phrase}`));
+  return Array.from(tags);
+}
+
+export default function ReviewModerationDashboard() {
+  const [reviews, setReviews] = useState<Review[]>([]);
+  const [metrics, setMetrics] = useState<ReviewModerationMetrics | null>(null);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [statusFilter, setStatusFilter] = useState<"all" | ReviewStatus>("needs_review");
+  const [flaggedOnly, setFlaggedOnly] = useState(true);
+  const [searchDraft, setSearchDraft] = useState("");
+  const [searchTerm, setSearchTerm] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [pendingAction, setPendingAction] = useState<{
+    review: Review;
+    action: "publish" | "needs_review" | "suppressed";
+  } | null>(null);
+  const [actionNotes, setActionNotes] = useState("");
+  const [actionNotify, setActionNotify] = useState(false);
+  const [responseReview, setResponseReview] = useState<Review | null>(null);
+  const [responseText, setResponseText] = useState("");
+  const [responseNotify, setResponseNotify] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [reminders, setReminders] = useState<ReviewReminderCandidate[]>([]);
+  const [loadingReminders, setLoadingReminders] = useState(false);
+  const [reminderError, setReminderError] = useState<string | null>(null);
+  const [sendingReminders, setSendingReminders] = useState(false);
+
+  const fetchQueue = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const params = new URLSearchParams();
+      params.set("limit", String(limit));
+      params.set("offset", String((page - 1) * limit));
+      if (statusFilter !== "all") {
+        params.set("status", statusFilter);
+      }
+      if (flaggedOnly) {
+        params.set("flagged", "true");
+      }
+      if (searchTerm) {
+        params.set("search", searchTerm);
+      }
+      params.set("includeMetrics", "true");
+
+      const response = await fetch(`/api/admin/reviews?${params.toString()}`, {
+        cache: "no-store",
+      });
+
+      if (!response.ok) {
+        throw new Error("Failed to load review queue");
+      }
+
+      const payload = await response.json();
+      setReviews(payload.data ?? []);
+      setTotal(payload.meta?.total ?? 0);
+      if (payload.metrics) {
+        setMetrics(payload.metrics as ReviewModerationMetrics);
+      }
+    } catch (err) {
+      console.error(err);
+      setError(err instanceof Error ? err.message : "Failed to load reviews");
+    } finally {
+      setLoading(false);
+    }
+  }, [flaggedOnly, page, searchTerm, statusFilter]);
+
+  useEffect(() => {
+    fetchQueue();
+  }, [fetchQueue]);
+
+  const totalPages = useMemo(() => {
+    return Math.max(1, Math.ceil(total / limit));
+  }, [total]);
+
+  const fetchReminders = useCallback(async () => {
+    try {
+      setLoadingReminders(true);
+      setReminderError(null);
+      const response = await fetch(`/api/admin/reviews/reminders?limit=25`, {
+        cache: "no-store",
+      });
+      if (!response.ok) {
+        throw new Error("Unable to load reminder candidates");
+      }
+      const payload = await response.json();
+      setReminders(payload.data ?? []);
+    } catch (err) {
+      console.error(err);
+      setReminderError(err instanceof Error ? err.message : "Unable to load reminders");
+    } finally {
+      setLoadingReminders(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchReminders();
+  }, [fetchReminders]);
+
+  useEffect(() => {
+    setPage(1);
+  }, [statusFilter, flaggedOnly]);
+
+  const openActionDialog = (review: Review, action: "publish" | "needs_review" | "suppressed") => {
+    setPendingAction({ review, action });
+    setActionNotes(review.moderation_notes ?? "");
+    setActionNotify(action === "publish");
+  };
+
+  const closeActionDialog = () => {
+    setPendingAction(null);
+    setActionNotes("");
+    setActionNotify(false);
+  };
+
+  const handleActionConfirm = async () => {
+    if (!pendingAction) return;
+    const statusMap: Record<typeof pendingAction.action, ReviewStatus> = {
+      publish: "published",
+      needs_review: "needs_review",
+      suppressed: "suppressed",
+    };
+
+    try {
+      setSaving(true);
+      const response = await fetch(`/api/admin/reviews/${pendingAction.review.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          status: statusMap[pendingAction.action],
+          moderationNotes: actionNotes || undefined,
+          notifyCustomer: actionNotify,
+        }),
+      });
+
+      if (!response.ok) {
+        const payload = await response.json().catch(() => null);
+        throw new Error(payload?.error ?? "Unable to update review");
+      }
+
+      toast.success("Review status updated");
+      closeActionDialog();
+      fetchQueue();
+    } catch (err) {
+      console.error(err);
+      toast.error(err instanceof Error ? err.message : "Failed to update review");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const submitResponse = async () => {
+    if (!responseReview) return;
+    try {
+      setSaving(true);
+      const response = await fetch(`/api/admin/reviews/${responseReview.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          response: responseText,
+          notifyCustomer: responseNotify,
+        }),
+      });
+      if (!response.ok) {
+        const payload = await response.json().catch(() => null);
+        throw new Error(payload?.error ?? "Unable to send response");
+      }
+      toast.success("Response saved");
+      setResponseReview(null);
+      setResponseText("");
+      setResponseNotify(true);
+      fetchQueue();
+    } catch (err) {
+      console.error(err);
+      toast.error(err instanceof Error ? err.message : "Failed to send response");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const sendRemindersNow = async () => {
+    try {
+      setSendingReminders(true);
+      const response = await fetch(`/api/admin/reviews/reminders`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ limit: reminders.length }),
+      });
+      if (!response.ok) {
+        const payload = await response.json().catch(() => null);
+        throw new Error(payload?.error ?? "Unable to send reminders");
+      }
+      const payload = await response.json();
+      toast.success(`Sent ${payload?.sent ?? 0} reminder${payload?.sent === 1 ? "" : "s"}`);
+      fetchReminders();
+    } catch (err) {
+      console.error(err);
+      toast.error(err instanceof Error ? err.message : "Failed to send reminders");
+    } finally {
+      setSendingReminders(false);
+    }
+  };
+
+  const renderStatusBadge = (status: ReviewStatus) => (
+    <Badge className={statusStyles[status]}>{status.replace("_", " ")}</Badge>
+  );
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold">Review moderation</h1>
+          <p className="text-sm text-muted-foreground">
+            Triage incoming feedback, resolve flags, and keep the storefront trustworthy.
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <Button variant="ghost" onClick={fetchQueue} disabled={loading}>
+            <RefreshCw className="mr-2 h-4 w-4" /> Refresh
+          </Button>
+          <Button variant="ghost" onClick={fetchReminders} disabled={loadingReminders}>
+            <Mail className="mr-2 h-4 w-4" /> Refresh reminders
+          </Button>
+        </div>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
+              <AlertTriangle className="h-4 w-4 text-yellow-400" /> Needs attention
+            </CardTitle>
+            <CardDescription className="text-3xl font-semibold text-white">
+              {metrics?.needs_review ?? 0}
+            </CardDescription>
+          </CardHeader>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
+              <Sparkles className="h-4 w-4 text-emerald-400" /> Published reviews
+            </CardTitle>
+            <CardDescription className="text-3xl font-semibold text-white">
+              {metrics?.published ?? 0}
+            </CardDescription>
+          </CardHeader>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
+              <Flag className="h-4 w-4 text-rose-400" /> Flagged items
+            </CardTitle>
+            <CardDescription className="text-3xl font-semibold text-white">
+              {metrics?.flagged ?? 0}
+            </CardDescription>
+          </CardHeader>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
+              <CheckCircle2 className="h-4 w-4 text-sky-400" /> Last publish
+            </CardTitle>
+            <CardDescription className="text-white">
+              {metrics?.last_published_at ? relativeTime(metrics.last_published_at) : "No reviews yet"}
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader className="flex flex-wrap items-end justify-between gap-4">
+          <div>
+            <CardTitle className="flex items-center gap-2 text-lg font-semibold">
+              <Filter className="h-5 w-5 text-muted-foreground" /> Moderation queue
+            </CardTitle>
+            <CardDescription>
+              Filter by status, search for keywords, and review the latest submissions.
+            </CardDescription>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <form
+            className="flex flex-col gap-3 lg:flex-row lg:items-center"
+            onSubmit={(event) => {
+              event.preventDefault();
+              setSearchTerm(searchDraft.trim());
+              setPage(1);
+            }}
+          >
+            <div className="flex items-center gap-2">
+              <Select
+                value={statusFilter}
+                onValueChange={(value) => setStatusFilter(value as typeof statusFilter)}
+              >
+                <SelectTrigger className="w-48">
+                  <SelectValue placeholder="Status" />
+                </SelectTrigger>
+                <SelectContent>
+                  {statusOptions.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <div className="flex items-center gap-2 rounded-md border border-border px-3 py-2">
+                <Switch
+                  id="flagged-toggle"
+                  checked={flaggedOnly}
+                  onCheckedChange={(checked) => setFlaggedOnly(checked)}
+                />
+                <Label htmlFor="flagged-toggle" className="text-sm text-muted-foreground">
+                  Flagged only
+                </Label>
+              </div>
+            </div>
+            <div className="flex flex-1 items-center gap-2">
+              <Input
+                placeholder="Search review text, product, or reason"
+                value={searchDraft}
+                onChange={(event) => setSearchDraft(event.target.value)}
+              />
+              <Button type="submit" variant="secondary">
+                Search
+              </Button>
+            </div>
+            <div className="text-sm text-muted-foreground">
+              Showing {reviews.length} of {total} review{total === 1 ? "" : "s"}
+            </div>
+          </form>
+
+          {error && <p className="text-sm text-rose-400">{error}</p>}
+
+          <div className="overflow-hidden rounded-lg border border-border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Product</TableHead>
+                  <TableHead>Reviewer</TableHead>
+                  <TableHead>Rating</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Submitted</TableHead>
+                  <TableHead>Moderation</TableHead>
+                  <TableHead className="text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {reviews.map((review) => (
+                  <TableRow key={review.id} className="align-top">
+                    <TableCell className="max-w-[220px] whitespace-normal">
+                      <div className="font-semibold text-white">
+                        {review.product_name ?? review.product_id}
+                      </div>
+                      <div className="text-xs text-muted-foreground">
+                        Order #{review.order_id}
+                      </div>
+                      {review.is_verified && (
+                        <Badge variant="outline" className="mt-1 text-xs text-emerald-200">
+                          Verified purchase
+                        </Badge>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      <div className="text-sm text-muted-foreground">{review.customer_id}</div>
+                      {review.admin_response && (
+                        <div className="mt-1 flex items-center gap-1 text-xs text-emerald-200">
+                          <MessageCircle className="h-3 w-3" /> Responded
+                        </div>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex items-center gap-2">
+                        <StarRating value={review.rating} size="sm" />
+                        <span className="text-sm text-white">{review.rating.toFixed(1)}</span>
+                      </div>
+                    </TableCell>
+                    <TableCell>{renderStatusBadge(review.status)}</TableCell>
+                    <TableCell>
+                      <div className="text-sm text-white">{relativeTime(review.submitted_at)}</div>
+                      <div className="text-xs text-muted-foreground">
+                        {formatTimestamp(review.submitted_at)}
+                      </div>
+                    </TableCell>
+                    <TableCell className="max-w-[260px] whitespace-normal">
+                      <div className="space-y-2">
+                        {review.body && (
+                          <p className="text-sm text-muted-foreground line-clamp-3 whitespace-pre-wrap">
+                            {review.body}
+                          </p>
+                        )}
+                        {moderationReasons(review).length > 0 && (
+                          <div className="flex flex-wrap gap-1">
+                            {moderationReasons(review).map((reason) => {
+                              const [type, value] = reason.includes(":") ? reason.split(":") : ["reason", reason];
+                              const label = type === "warn" ? value : type === "match" ? `Match: ${value}` : value;
+                              return (
+                                <Badge key={reason} variant="outline" className="text-xs text-amber-200">
+                                  {label}
+                                </Badge>
+                              );
+                            })}
+                          </div>
+                        )}
+                        {review.flags?.length ? (
+                          <div className="flex items-center gap-1 text-xs text-rose-300">
+                            <ShieldBan className="h-3 w-3" /> {review.flags.length} flag
+                            {review.flags.length === 1 ? "" : "s"}
+                          </div>
+                        ) : null}
+                      </div>
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <div className="flex justify-end gap-2">
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => openActionDialog(review, "needs_review")}
+                          disabled={loading || saving}
+                        >
+                          Send back
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => openActionDialog(review, "suppressed")}
+                          disabled={loading || saving}
+                        >
+                          Suppress
+                        </Button>
+                        <Button
+                          size="sm"
+                          onClick={() => openActionDialog(review, "publish")}
+                          disabled={loading || saving}
+                        >
+                          Approve
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="secondary"
+                          onClick={() => {
+                            setResponseReview(review);
+                            setResponseText(review.admin_response ?? "");
+                            setResponseNotify(true);
+                          }}
+                          disabled={saving}
+                        >
+                          Respond
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))}
+                {reviews.length === 0 && !loading && (
+                  <TableRow>
+                    <TableCell colSpan={7} className="py-10 text-center text-sm text-muted-foreground">
+                      No reviews match the current filters.
+                    </TableCell>
+                  </TableRow>
+                )}
+                {loading && (
+                  <TableRow>
+                    <TableCell colSpan={7} className="py-10 text-center text-sm text-muted-foreground">
+                      Loading reviews…
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </div>
+
+          <div className="flex items-center justify-between">
+            <div className="text-sm text-muted-foreground">
+              Page {page} of {totalPages}
+            </div>
+            <div className="flex gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setPage((prev) => Math.max(1, prev - 1))}
+                disabled={page <= 1 || loading}
+              >
+                Previous
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setPage((prev) => Math.min(totalPages, prev + 1))}
+                disabled={page >= totalPages || loading}
+              >
+                Next
+              </Button>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-lg font-semibold">
+            <Mail className="h-5 w-5 text-muted-foreground" /> Review reminders
+          </CardTitle>
+          <CardDescription>
+            Delivered orders without feedback in the reminder window. Send a follow-up email in one click.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {reminderError && <p className="text-sm text-rose-400">{reminderError}</p>}
+          {loadingReminders ? (
+            <p className="text-sm text-muted-foreground">Checking for reminder candidates…</p>
+          ) : reminders.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No outstanding reminders right now.</p>
+          ) : (
+            <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+              {reminders.map((candidate) => (
+                <div key={`${candidate.orderId}:${candidate.productId}`} className="rounded-lg border border-border p-4">
+                  <div className="text-sm font-semibold text-white">
+                    {candidate.productName ?? candidate.productId}
+                  </div>
+                  <div className="text-xs text-muted-foreground mt-1">
+                    Order #{candidate.orderId}
+                  </div>
+                  <div className="text-xs text-muted-foreground mt-1">
+                    Delivered {relativeTime(candidate.deliveredAt)}
+                  </div>
+                  {candidate.customerEmail && (
+                    <div className="mt-2 flex items-center gap-1 text-xs text-muted-foreground">
+                      <Mail className="h-3 w-3" /> {candidate.customerEmail}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+          <div className="flex flex-wrap gap-2">
+            <Button onClick={sendRemindersNow} disabled={sendingReminders || reminders.length === 0}>
+              {sendingReminders ? "Sending…" : `Send ${reminders.length || ""} reminder${reminders.length === 1 ? "" : "s"}`}
+            </Button>
+            <Button variant="outline" onClick={fetchReminders} disabled={loadingReminders}>
+              Refresh
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      <AlertDialog
+        open={Boolean(pendingAction)}
+        onOpenChange={(open) => {
+          if (!open) {
+            closeActionDialog();
+          }
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {pendingAction?.action === "publish" && "Approve review"}
+              {pendingAction?.action === "needs_review" && "Request moderator review"}
+              {pendingAction?.action === "suppressed" && "Suppress review"}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {pendingAction?.review?.product_name ?? pendingAction?.review?.product_id}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <div className="space-y-3">
+            <Label htmlFor="moderation-notes" className="text-sm text-muted-foreground">
+              Moderation notes (visible to admins)
+            </Label>
+            <Textarea
+              id="moderation-notes"
+              rows={4}
+              value={actionNotes}
+              onChange={(event) => setActionNotes(event.target.value)}
+              placeholder="Explain the decision for future context"
+            />
+            <div className="flex items-center gap-2">
+              <Switch id="notify-customer" checked={actionNotify} onCheckedChange={setActionNotify} />
+              <Label htmlFor="notify-customer" className="text-sm text-muted-foreground">
+                Email the customer about this decision
+              </Label>
+            </div>
+          </div>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={saving}>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={handleActionConfirm} disabled={saving}>
+              {saving ? "Saving…" : "Confirm"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <Dialog
+        open={Boolean(responseReview)}
+        onOpenChange={(open) => {
+          if (!open) {
+            setResponseReview(null);
+            setResponseText("");
+            setResponseNotify(true);
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Respond to customer</DialogTitle>
+            <DialogDescription>
+              Message will appear publicly beneath the review for {responseReview?.product_name ?? responseReview?.product_id}.
+            </DialogDescription>
+          </DialogHeader>
+          <Textarea
+            rows={6}
+            value={responseText}
+            onChange={(event) => setResponseText(event.target.value)}
+            placeholder="Thank you for the feedback!"
+          />
+          <div className="flex items-center gap-2">
+            <Switch id="response-notify" checked={responseNotify} onCheckedChange={setResponseNotify} />
+            <Label htmlFor="response-notify" className="text-sm text-muted-foreground">
+              Email the customer when this response posts
+            </Label>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setResponseReview(null)} disabled={saving}>
+              Cancel
+            </Button>
+            <Button onClick={submitResponse} disabled={saving || !responseText.trim()}>
+              {saving ? "Saving…" : "Send response"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/components/reviews/ReviewForm.tsx
+++ b/components/reviews/ReviewForm.tsx
@@ -1,0 +1,245 @@
+'use client';
+
+import { useEffect, useMemo, useState, FormEvent } from 'react';
+import { cn } from '@/lib/utils';
+import type { Review } from '@/lib/types';
+
+interface ReviewFormProps {
+  orderId: string;
+  orderItemId?: string;
+  productId: string;
+  productName: string;
+  existingReview?: Review;
+  onSubmitted(review: Review): void;
+  disabledReason?: string | null;
+}
+
+const ratingScale = [1, 2, 3, 4, 5];
+
+function formatDate(iso?: string | null) {
+  if (!iso) return null;
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  return date.toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+export function ReviewForm({
+  orderId,
+  orderItemId,
+  productId,
+  productName,
+  existingReview,
+  onSubmitted,
+  disabledReason,
+}: ReviewFormProps) {
+  const [rating, setRating] = useState(existingReview?.rating ?? 5);
+  const [title, setTitle] = useState('');
+  const [body, setBody] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (existingReview) {
+      setRating(existingReview.rating);
+      setTitle(existingReview.title ?? '');
+      setBody(existingReview.body ?? '');
+    }
+  }, [existingReview?.id]);
+
+  const statusLabel = useMemo(() => {
+    if (!existingReview) return null;
+    switch (existingReview.status) {
+      case 'pending':
+        return 'Pending moderation';
+      case 'needs_review':
+        return 'Queued for manual review';
+      case 'published':
+        return 'Published';
+      case 'suppressed':
+        return 'Suppressed';
+      case 'auto_rejected':
+        return 'Automatically rejected';
+      default:
+        return existingReview.status;
+    }
+  }, [existingReview?.status]);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (submitting || existingReview) return;
+    if (disabledReason) {
+      setError(disabledReason);
+      return;
+    }
+
+    setSubmitting(true);
+    setError(null);
+    setSuccess(null);
+
+    try {
+      const response = await fetch(`/api/orders/${orderId}/reviews`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          orderItemId,
+          productId,
+          rating,
+          title: title.trim() || undefined,
+          body: body.trim(),
+        }),
+      });
+
+      const payload = await response.json();
+
+      if (!response.ok) {
+        throw new Error(payload?.error || 'Unable to submit review.');
+      }
+
+      const review: Review = payload.data;
+      onSubmitted(review);
+      setSuccess('Thanks! Your review is now awaiting moderation.');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unable to submit review.');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (existingReview) {
+    return (
+      <div className="rounded-lg border border-neutral-700 bg-neutral-900 p-4 text-sm text-gray-200">
+        <div className="mb-2 flex items-center justify-between gap-2">
+          <p className="font-semibold text-white">Your review</p>
+          {statusLabel && (
+            <span
+              className={cn(
+                'rounded-full px-2 py-1 text-xs font-medium',
+                existingReview.status === 'published'
+                  ? 'bg-green-500/20 text-green-300'
+                  : existingReview.status === 'pending'
+                    ? 'bg-amber-500/20 text-amber-300'
+                    : 'bg-neutral-700 text-neutral-200'
+              )}
+            >
+              {statusLabel}
+            </span>
+          )}
+        </div>
+        <div className="mb-2 flex items-center gap-2 text-yellow-400" aria-label={`Rating ${existingReview.rating} of 5`}>
+          {ratingScale.map((value) => (
+            <span key={value}>{value <= (existingReview?.rating ?? 0) ? '★' : '☆'}</span>
+          ))}
+        </div>
+        {existingReview.title && <p className="mb-2 text-base font-semibold text-white">{existingReview.title}</p>}
+        {existingReview.body && <p className="whitespace-pre-wrap text-sm text-gray-300">{existingReview.body}</p>}
+        <dl className="mt-3 space-y-1 text-xs text-gray-400">
+          {existingReview.submitted_at && (
+            <div className="flex gap-2">
+              <dt className="min-w-[90px] font-medium text-gray-500">Submitted</dt>
+              <dd>{formatDate(existingReview.submitted_at) ?? existingReview.submitted_at}</dd>
+            </div>
+          )}
+          {existingReview.published_at && (
+            <div className="flex gap-2">
+              <dt className="min-w-[90px] font-medium text-gray-500">Published</dt>
+              <dd>{formatDate(existingReview.published_at) ?? existingReview.published_at}</dd>
+            </div>
+          )}
+        </dl>
+        {existingReview.admin_response && (
+          <div className="mt-4 rounded-md border border-neutral-700 bg-neutral-950 p-3">
+            <p className="text-xs font-semibold uppercase tracking-wide text-orange-400">Merchant response</p>
+            <p className="mt-1 text-sm text-gray-200">{existingReview.admin_response}</p>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4 rounded-lg border border-neutral-800 bg-neutral-900 p-4">
+      <div className="flex flex-col gap-2">
+        <label className="text-sm font-medium text-white" htmlFor={`rating-${productId}`}>
+          Rate your experience
+        </label>
+        <div className="flex items-center gap-1" id={`rating-${productId}`}>
+          {ratingScale.map((value) => (
+            <button
+              type="button"
+              key={value}
+              className={cn(
+                'text-2xl transition-colors',
+                value <= rating ? 'text-yellow-400' : 'text-neutral-600 hover:text-yellow-200'
+              )}
+              onClick={() => setRating(value)}
+              aria-label={`${value} star${value === 1 ? '' : 's'}`}
+              aria-pressed={value === rating}
+            >
+              {value <= rating ? '★' : '☆'}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <label className="text-sm font-medium text-white" htmlFor={`title-${productId}`}>
+          Review title <span className="text-xs text-gray-500">(optional)</span>
+        </label>
+        <input
+          id={`title-${productId}`}
+          type="text"
+          maxLength={120}
+          value={title}
+          onChange={(event) => setTitle(event.target.value)}
+          className="w-full rounded-md border border-neutral-700 bg-neutral-950 px-3 py-2 text-sm text-white focus:border-orange-500 focus:outline-none focus:ring-1 focus:ring-orange-500"
+          placeholder={`Share your thoughts on ${productName}`}
+          disabled={submitting}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <label className="text-sm font-medium text-white" htmlFor={`body-${productId}`}>
+          Your review <span className="text-xs text-gray-500">(minimum 30 characters)</span>
+        </label>
+        <textarea
+          id={`body-${productId}`}
+          value={body}
+          onChange={(event) => setBody(event.target.value)}
+          className="w-full rounded-md border border-neutral-700 bg-neutral-950 px-3 py-2 text-sm text-white focus:border-orange-500 focus:outline-none focus:ring-1 focus:ring-orange-500"
+          placeholder="Tell other shoppers about fit, quality, and performance."
+          rows={4}
+          minLength={30}
+          required
+          disabled={submitting}
+        />
+      </div>
+
+      {disabledReason && (
+        <p className="text-xs text-amber-300">{disabledReason}</p>
+      )}
+
+      {error && <p className="text-sm text-red-400">{error}</p>}
+      {success && <p className="text-sm text-green-400">{success}</p>}
+
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-xs text-gray-500">Reviews are screened for inappropriate language and links.</p>
+        <button
+          type="submit"
+          className="rounded-md bg-orange-500 px-4 py-2 text-sm font-semibold text-black transition hover:bg-orange-400 disabled:cursor-not-allowed disabled:bg-neutral-700 disabled:text-neutral-400"
+          disabled={submitting || Boolean(disabledReason)}
+        >
+          {submitting ? 'Submitting…' : 'Submit review'}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/components/reviews/StarRating.tsx
+++ b/components/reviews/StarRating.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+
+const sizeStyles: Record<'xs' | 'sm' | 'md' | 'lg', string> = {
+  xs: 'text-[10px]',
+  sm: 'text-xs',
+  md: 'text-base',
+  lg: 'text-2xl',
+};
+
+interface StarRatingProps {
+  value: number;
+  size?: 'xs' | 'sm' | 'md' | 'lg';
+  className?: string;
+  ariaLabel?: string;
+}
+
+export function StarRating({ value, size = 'sm', className, ariaLabel }: StarRatingProps) {
+  const safeValue = Number.isFinite(value) ? Math.min(5, Math.max(0, value)) : 0;
+  const width = `${(safeValue / 5) * 100}%`;
+
+  return (
+    <span
+      role="img"
+      aria-label={ariaLabel ?? `Rated ${safeValue.toFixed(1)} out of 5 stars`}
+      className={cn('relative inline-flex select-none text-neutral-600', sizeStyles[size], className)}
+    >
+      <span aria-hidden="true">★★★★★</span>
+      <span
+        aria-hidden="true"
+        className="absolute inset-0 overflow-hidden text-yellow-400"
+        style={{ width }}
+      >
+        ★★★★★
+      </span>
+    </span>
+  );
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -110,7 +110,12 @@ Mercora has evolved into a comprehensive AI-enhanced eCommerce platform featurin
 - ✅ **Production Deployment**: Live at `https://voltique.russellkmoore.me/api/mcp`
 
 ### 🌟 **Enhanced Customer Features**
-- 📋 **Reviews & Ratings**: User-generated content with moderation
+- 📋 **Reviews & Ratings**
+  - ✅ **Schema Alignment**: Product aggregates, dedicated review tables, flags, and reminder logs finalized with moderation states and audit metadata.
+  - ✅ **Submission Flow**: Authenticated order-history capture form with AI-assisted moderation and single-review enforcement for fulfilled items.
+  - ✅ **Product UI**: Star summaries on cards, detailed review highlights, filtering, verified badges, and order-history calls to action on product pages.
+  - ✅ **Moderation Strategy**: Automated AI + vector screening backed by an admin queue for publishing, suppression, flag resolution, and customer notifications.
+  - ✅ **Operations**: Review status/response emails and post-delivery reminder tooling ensure feedback loops stay active without duplicate outreach.
 - 📋 **Wishlist System**: Save products for later with sharing capabilities
 - 📋 **Social Features**: Product sharing, user-generated content integration
 

--- a/lib/ai/config.ts
+++ b/lib/ai/config.ts
@@ -74,6 +74,13 @@ export const AI_MODELS = {
     maxTokens: 800, // Reduced for faster admin UI
   },
 
+  /** For automated safety and content moderation checks */
+  MODERATION: {
+    ...TEXT_GENERATION_MODEL,
+    temperature: 0, // Deterministic moderation responses
+    maxTokens: 300, // Keep responses concise
+  },
+
   /** For greeting responses */
   GREETING: {
     ...TEXT_GENERATION_MODEL,

--- a/lib/ai/moderation.ts
+++ b/lib/ai/moderation.ts
@@ -1,0 +1,235 @@
+import { getCloudflareContext } from '@opennextjs/cloudflare';
+
+import { extractAIResponse, getCurrentEmbeddingModel, runAI } from '@/lib/ai/config';
+import type { ReviewModerationSummary } from '@/lib/types';
+
+interface AIModerationPayload {
+  title?: string;
+  body: string;
+  metadata?: Record<string, any>;
+}
+
+interface ModerationVectorPattern {
+  id: string;
+  text: string;
+  reason: string;
+  severity: 'info' | 'warn' | 'flag' | 'block';
+  example?: string;
+}
+
+const MODERATION_NAMESPACE = 'moderation';
+
+const MODERATION_PATTERNS: ModerationVectorPattern[] = [
+  {
+    id: 'moderation:external-link',
+    text: 'Check out my store at http://example.com and buy there instead',
+    reason: 'contains_external_link',
+    severity: 'block',
+    example: 'http://',
+  },
+  {
+    id: 'moderation:affiliate-promo',
+    text: 'Use my affiliate link to purchase from another retailer',
+    reason: 'third_party_promotion',
+    severity: 'flag',
+  },
+  {
+    id: 'moderation:malware',
+    text: 'Download this cracked software or malicious file',
+    reason: 'malicious_content',
+    severity: 'block',
+  },
+  {
+    id: 'moderation:hate-speech',
+    text: 'Offensive or hateful language targeting a group of people',
+    reason: 'hate_speech',
+    severity: 'block',
+  },
+  {
+    id: 'moderation:spammy-language',
+    text: 'Repeated marketing spam or advertising language for unrelated products',
+    reason: 'spammy_content',
+    severity: 'flag',
+  },
+];
+
+let moderationVectorsReady: Promise<void> | null = null;
+
+function mergeUnique(list: string[] | undefined, additions: string[] | undefined): string[] {
+  const merged = new Set<string>(list ?? []);
+  for (const item of additions ?? []) {
+    if (item) merged.add(item);
+  }
+  return Array.from(merged);
+}
+
+function sanitizeJson(text: string): any {
+  try {
+    const jsonMatch = text.match(/\{[\s\S]*\}/);
+    if (!jsonMatch) return null;
+    return JSON.parse(jsonMatch[0]);
+  } catch (error) {
+    console.warn('Failed to parse AI moderation response', error);
+    return null;
+  }
+}
+
+async function ensureModerationVectors(ai: any, vectorize: any) {
+  if (!ai || !vectorize) return;
+  if (moderationVectorsReady) {
+    return moderationVectorsReady;
+  }
+
+  moderationVectorsReady = (async () => {
+    try {
+      const vectors: any[] = [];
+      for (const pattern of MODERATION_PATTERNS) {
+        const embedding = await ai.run(getCurrentEmbeddingModel(), { text: pattern.text });
+        if (!embedding?.data?.[0]) {
+          continue;
+        }
+
+        vectors.push({
+          id: pattern.id,
+          values: embedding.data[0],
+          namespace: MODERATION_NAMESPACE,
+          metadata: {
+            type: MODERATION_NAMESPACE,
+            reason: pattern.reason,
+            severity: pattern.severity,
+            example: pattern.example ?? pattern.text,
+          },
+        });
+      }
+
+      if (vectors.length) {
+        await vectorize.upsert(vectors);
+      }
+    } catch (error) {
+      console.error('Failed to seed moderation vector patterns', error);
+    }
+  })();
+
+  return moderationVectorsReady;
+}
+
+async function evaluateWithVectorize(text: string): Promise<Partial<ReviewModerationSummary>> {
+  try {
+    const { env } = await getCloudflareContext({ async: true });
+    const ai = (env as any)?.AI;
+    const vectorize = (env as any)?.VECTORIZE;
+
+    if (!ai || !vectorize) {
+      return {};
+    }
+
+    await ensureModerationVectors(ai, vectorize);
+
+    const embedding = await ai.run(getCurrentEmbeddingModel(), { text });
+    if (!embedding?.data?.[0]) {
+      return {};
+    }
+
+    const query = await vectorize.query(embedding.data[0], {
+      namespace: MODERATION_NAMESPACE,
+      topK: 5,
+      returnMetadata: true,
+    });
+
+    if (!query?.matches?.length) {
+      return {};
+    }
+
+    const reasons: string[] = [];
+    const detected: string[] = [];
+    let flagged = false;
+    let blocked = false;
+
+    for (const match of query.matches) {
+      if (!match?.metadata?.severity || typeof match.score !== 'number') continue;
+      if (match.score < 0.72) continue;
+
+      const severity = String(match.metadata.severity);
+      const reason = String(match.metadata.reason ?? 'vector_match');
+      const example = match.metadata.example ? String(match.metadata.example) : undefined;
+
+      if (severity === 'block') {
+        blocked = true;
+      }
+      if (severity === 'block' || severity === 'flag' || severity === 'warn') {
+        flagged = true;
+      }
+
+      reasons.push(reason);
+      if (example) {
+        detected.push(example);
+      }
+    }
+
+    return {
+      flagged,
+      blocked,
+      reasons: reasons.length ? Array.from(new Set(reasons)) : undefined,
+      detectedPhrases: detected.length ? Array.from(new Set(detected)) : undefined,
+    };
+  } catch (error) {
+    console.error('Vector moderation query failed', error);
+    return {};
+  }
+}
+
+export async function analyzeReviewContent(
+  payload: AIModerationPayload
+): Promise<ReviewModerationSummary | null> {
+  try {
+    const { env } = await getCloudflareContext({ async: true });
+    const ai = (env as any)?.AI;
+
+    if (!ai) {
+      return null;
+    }
+
+    const reviewText = `Title: ${payload.title ?? '(none)'}\nBody: ${payload.body}`.trim();
+
+    const aiResponse = await runAI(ai, 'MODERATION', {
+      messages: [
+        {
+          role: 'system',
+          content:
+            'You are a strict content moderation classifier. Return JSON with fields flagged (boolean), blocked (boolean), reasons (array of strings), warnings (array of strings, optional). Flag content that links to other stores, contains ads, hate speech, malware, or policy violations. Block severe violations.',
+        },
+        {
+          role: 'user',
+          content: `${reviewText}\nRespond ONLY with JSON.`,
+        },
+      ],
+      maxTokens: 250,
+    });
+
+    const aiText = extractAIResponse(aiResponse);
+    const parsed = sanitizeJson(aiText ?? '');
+
+    const baseSummary: ReviewModerationSummary = {
+      flagged: Boolean(parsed?.flagged),
+      blocked: Boolean(parsed?.blocked),
+      reasons: Array.isArray(parsed?.reasons) ? parsed.reasons.map(String) : [],
+      warnings: Array.isArray(parsed?.warnings) ? parsed.warnings.map(String) : undefined,
+    };
+
+    const vectorSummary = await evaluateWithVectorize(`${payload.title ?? ''} ${payload.body}`.trim());
+
+    const reasons = mergeUnique(baseSummary.reasons, vectorSummary.reasons ?? []);
+    const warnings = mergeUnique(baseSummary.warnings, vectorSummary.warnings);
+
+    return {
+      flagged: baseSummary.flagged || Boolean(vectorSummary.flagged),
+      blocked: baseSummary.blocked || Boolean(vectorSummary.blocked),
+      reasons,
+      warnings: warnings.length ? warnings : undefined,
+      detectedPhrases: vectorSummary.detectedPhrases,
+    };
+  } catch (error) {
+    console.error('AI moderation check failed', error);
+    return null;
+  }
+}

--- a/lib/db/schema/index.ts
+++ b/lib/db/schema/index.ts
@@ -106,3 +106,6 @@ export * from "./pages";
 
 // MCP Server schema (application-specific)
 export * from "./mcp";
+
+// Reviews & Ratings schema (application-specific)
+export * from "./reviews";

--- a/lib/db/schema/reviews.ts
+++ b/lib/db/schema/reviews.ts
@@ -1,0 +1,109 @@
+import { sqliteTable, text, integer, index } from 'drizzle-orm/sqlite-core';
+import { sql } from 'drizzle-orm';
+import { nanoid } from 'nanoid';
+
+export const product_reviews = sqliteTable(
+  'product_reviews',
+  {
+    id: text('id')
+      .primaryKey()
+      .$defaultFn(() => `REV-${nanoid(10).toUpperCase()}`),
+    product_id: text('product_id').notNull(),
+    order_id: text('order_id').notNull(),
+    order_item_id: text('order_item_id'),
+    customer_id: text('customer_id').notNull(),
+    rating: integer('rating').notNull(),
+    title: text('title'),
+    body: text('body'),
+    status: text('status', {
+      enum: ['pending', 'needs_review', 'published', 'suppressed', 'auto_rejected']
+    })
+      .notNull()
+      .default('pending'),
+    is_verified: integer('is_verified', { mode: 'boolean' }).default(true),
+    automated_moderation: text('automated_moderation', { mode: 'json' }),
+    moderation_notes: text('moderation_notes'),
+    admin_response: text('admin_response'),
+    response_author_id: text('response_author_id'),
+    responded_at: text('responded_at'),
+    submitted_at: text('submitted_at').default(sql`CURRENT_TIMESTAMP`),
+    published_at: text('published_at'),
+    created_at: text('created_at').default(sql`CURRENT_TIMESTAMP`),
+    updated_at: text('updated_at').default(sql`CURRENT_TIMESTAMP`),
+    metadata: text('metadata', { mode: 'json' })
+  },
+  (table) => ({
+    productIdx: index('product_reviews_product_idx').on(table.product_id),
+    orderIdx: index('product_reviews_order_idx').on(table.order_id),
+    customerIdx: index('product_reviews_customer_idx').on(table.customer_id),
+    statusIdx: index('product_reviews_status_idx').on(table.status)
+  })
+);
+
+export const review_media = sqliteTable(
+  'review_media',
+  {
+    id: text('id')
+      .primaryKey()
+      .$defaultFn(() => `RMD-${nanoid(10).toUpperCase()}`),
+    review_id: text('review_id')
+      .notNull()
+      .references(() => product_reviews.id, { onDelete: 'cascade' }),
+    type: text('type', { enum: ['image', 'video'] }).default('image'),
+    url: text('url').notNull(),
+    alt_text: text('alt_text'),
+    metadata: text('metadata', { mode: 'json' }),
+    created_at: text('created_at').default(sql`CURRENT_TIMESTAMP`)
+  },
+  (table) => ({
+    reviewIdx: index('review_media_review_idx').on(table.review_id)
+  })
+);
+
+export const review_flags = sqliteTable(
+  'review_flags',
+  {
+    id: text('id')
+      .primaryKey()
+      .$defaultFn(() => `RFG-${nanoid(10).toUpperCase()}`),
+    review_id: text('review_id')
+      .notNull()
+      .references(() => product_reviews.id, { onDelete: 'cascade' }),
+    flagged_by: text('flagged_by'),
+    reason: text('reason').notNull(),
+    notes: text('notes'),
+    status: text('status', { enum: ['open', 'resolved', 'dismissed'] }).default('open'),
+    created_at: text('created_at').default(sql`CURRENT_TIMESTAMP`),
+    resolved_at: text('resolved_at')
+  },
+  (table) => ({
+    reviewFlagIdx: index('review_flags_review_idx').on(table.review_id),
+    statusIdx: index('review_flags_status_idx').on(table.status)
+  })
+);
+
+export const review_reminders = sqliteTable(
+  'review_reminders',
+  {
+    id: text('id')
+      .primaryKey()
+      .$defaultFn(() => `RRN-${nanoid(10).toUpperCase()}`),
+    order_id: text('order_id').notNull(),
+    product_id: text('product_id').notNull(),
+    customer_id: text('customer_id'),
+    status: text('status', { enum: ['sent', 'failed'] }).notNull().default('sent'),
+    error: text('error'),
+    sent_at: text('sent_at').default(sql`CURRENT_TIMESTAMP`),
+    created_at: text('created_at').default(sql`CURRENT_TIMESTAMP`),
+    updated_at: text('updated_at').default(sql`CURRENT_TIMESTAMP`)
+  },
+  (table) => ({
+    reminderOrderIdx: index('review_reminders_order_idx').on(table.order_id),
+    reminderProductIdx: index('review_reminders_product_idx').on(table.product_id)
+  })
+);
+
+export type ProductReviewRow = typeof product_reviews.$inferSelect;
+export type ReviewMediaRow = typeof review_media.$inferSelect;
+export type ReviewFlagRow = typeof review_flags.$inferSelect;
+export type ReviewReminderRow = typeof review_reminders.$inferSelect;

--- a/lib/models/index.ts
+++ b/lib/models/index.ts
@@ -10,3 +10,4 @@ export * from './cart';
 export * from './auth';
 export * from './admin';
 export * from './pages';
+export * from './reviews';

--- a/lib/models/reviews.ts
+++ b/lib/models/reviews.ts
@@ -1,0 +1,1121 @@
+import { and, eq, inArray, gte, lte, desc, sql } from 'drizzle-orm';
+import { getDbAsync } from '@/lib/db';
+import { orders } from '@/lib/db/schema/order';
+import { customers } from '@/lib/db/schema/customer';
+import {
+  product_reviews,
+  review_media,
+  review_flags,
+  review_reminders,
+  type ProductReviewRow,
+  type ReviewMediaRow,
+  type ReviewFlagRow,
+  type ReviewReminderRow
+} from '@/lib/db/schema/reviews';
+import { products } from '@/lib/db/schema/products';
+import { analyzeReviewContent } from '@/lib/ai/moderation';
+import type {
+  OrderItem,
+  Review,
+  ReviewMedia,
+  ReviewModerationSummary,
+  ReviewSubmissionPayload,
+  ReviewStatus,
+  ReviewFlagStatus,
+  ReviewQueueResult,
+  ReviewModerationMetrics,
+  ReviewReminderCandidate
+} from '@/lib/types';
+import { sendReviewReminderEmail, sendReviewStatusNotification } from '@/lib/utils/review-notifications';
+
+interface SubmitReviewInput extends ReviewSubmissionPayload {
+  customerId: string;
+}
+
+interface ReviewQueueOptions {
+  statuses?: ReviewStatus[];
+  flaggedOnly?: boolean;
+  productId?: string;
+  search?: string;
+  limit?: number;
+  offset?: number;
+}
+
+interface ReviewStatusUpdateInput {
+  reviewId: string;
+  status: ReviewStatus;
+  moderatorId: string;
+  moderationNotes?: string | null;
+  notifyCustomer?: boolean;
+}
+
+interface ReviewResponseInput {
+  reviewId: string;
+  response: string;
+  adminId: string;
+  notifyCustomer?: boolean;
+}
+
+interface ReviewFlagInput {
+  reviewId: string;
+  reason: string;
+  notes?: string;
+  flaggedBy?: string | null;
+}
+
+interface ReminderQueryOptions {
+  minDaysSinceDelivery?: number;
+  maxDaysSinceDelivery?: number;
+  limit?: number;
+}
+
+const BLOCKED_TERMS = ['porn', 'xxx', 'nazi', 'terror'];
+const PROFANITY = ['fuck', 'shit', 'bitch', 'asshole'];
+
+function parseJsonField<T>(value: any): T | undefined {
+  if (!value) return undefined;
+  if (typeof value === 'object') return value as T;
+  try {
+    return JSON.parse(String(value)) as T;
+  } catch {
+    return undefined;
+  }
+}
+
+function parseProductName(value: any): string | null {
+  if (!value) return null;
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value);
+      if (typeof parsed === 'string') return parsed;
+      if (parsed && typeof parsed === 'object') {
+        const first = Object.values(parsed as Record<string, unknown>).find((entry) => typeof entry === 'string');
+        if (typeof first === 'string') {
+          return first;
+        }
+      }
+    } catch {
+      return value;
+    }
+    return value;
+  }
+
+  if (typeof value === 'object') {
+    const first = Object.values(value as Record<string, unknown>).find((entry) => typeof entry === 'string');
+    if (typeof first === 'string') {
+      return first;
+    }
+  }
+
+  return String(value);
+}
+
+function extractCustomerContact(customer?: CustomerRow | null, order?: OrderRow | null) {
+  let email: string | null = null;
+  let name: string | null = null;
+
+  if (customer?.person) {
+    const person = parseJsonField<{ email?: string; first_name?: string; last_name?: string; full_name?: string }>(
+      customer.person
+    );
+    if (person) {
+      email = person.email ?? email;
+      name = person.full_name ?? [person.first_name, person.last_name].filter(Boolean).join(' ') || name;
+    }
+  }
+
+  if (!email && customer?.company) {
+    const company = parseJsonField<{ email?: string; name?: string }>(customer.company);
+    if (company?.email) {
+      email = company.email;
+    }
+    if (company?.name && !name) {
+      name = company.name;
+    }
+  }
+
+  if (!email && order?.extensions) {
+    const extensions = parseJsonField<Record<string, any>>(order.extensions);
+    const extEmail = typeof extensions?.email === 'string' ? extensions.email : undefined;
+    if (extEmail) {
+      email = extEmail;
+    }
+  }
+
+  if (!name && order?.shipping_address) {
+    const shipping = parseJsonField<Record<string, any>>(order.shipping_address);
+    const shippingName =
+      (typeof shipping?.recipient === 'string' && shipping.recipient) ||
+      (typeof shipping?.name === 'string' && shipping.name) ||
+      null;
+    if (shippingName) {
+      name = shippingName;
+    }
+  }
+
+  return { email, name };
+}
+
+function deserializeReview(
+  row: ProductReviewRow,
+  mediaRows: ReviewMediaRow[],
+  flagRows: ReviewFlagRow[] = []
+): Review {
+  return {
+    id: row.id!,
+    product_id: row.product_id,
+    order_id: row.order_id,
+    order_item_id: row.order_item_id ?? undefined,
+    customer_id: row.customer_id,
+    rating: row.rating,
+    title: row.title ?? undefined,
+    body: row.body ?? undefined,
+    status: row.status as ReviewStatus,
+    is_verified: Boolean(row.is_verified),
+    automated_moderation: parseJsonField<ReviewModerationSummary>(row.automated_moderation) ?? null,
+    moderation_notes: row.moderation_notes ?? null,
+    admin_response: row.admin_response ?? null,
+    response_author_id: row.response_author_id ?? null,
+    responded_at: row.responded_at ?? null,
+    submitted_at: row.submitted_at ?? null,
+    published_at: row.published_at ?? null,
+    created_at: row.created_at ?? null,
+    updated_at: row.updated_at ?? null,
+    metadata: parseJsonField<Record<string, any>>(row.metadata) ?? null,
+    media: mediaRows.map((media) => ({
+      id: media.id ?? undefined,
+      review_id: media.review_id ?? undefined,
+      type: (media.type as ReviewMedia['type']) ?? 'image',
+      url: media.url,
+      alt_text: media.alt_text ?? undefined,
+      metadata: parseJsonField<Record<string, any>>(media.metadata) ?? undefined,
+      created_at: media.created_at ?? undefined,
+    })),
+    flags: flagRows.map((flag) => ({
+      id: flag.id!,
+      review_id: flag.review_id,
+      flagged_by: flag.flagged_by ?? null,
+      reason: flag.reason,
+      notes: flag.notes ?? null,
+      status: (flag.status as ReviewFlagStatus) ?? 'open',
+      created_at: flag.created_at ?? null,
+      resolved_at: flag.resolved_at ?? null,
+    })),
+    open_flag_count: flagRows.filter((flag) => flag.status === 'open').length || undefined,
+  };
+}
+
+function dedupe(values: string[] = []): string[] | undefined {
+  if (!values.length) return undefined;
+  return Array.from(new Set(values.filter(Boolean)));
+}
+
+function buildQueueWhereClause(options: ReviewQueueOptions) {
+  const conditions: any[] = [];
+
+  if (options.productId) {
+    conditions.push(eq(product_reviews.product_id, options.productId));
+  }
+
+  if (options.statuses?.length) {
+    conditions.push(inArray(product_reviews.status, options.statuses));
+  }
+
+  if (options.flaggedOnly) {
+    conditions.push(
+      sql`(${product_reviews.status} IN ('needs_review','auto_rejected') OR EXISTS (
+        SELECT 1 FROM ${review_flags} rf
+        WHERE rf.review_id = ${product_reviews.id}
+          AND rf.status = 'open'
+      ))`
+    );
+  }
+
+  const search = options.search?.trim().toLowerCase();
+  if (search) {
+    const likeTerm = `%${search}%`;
+    conditions.push(
+      sql`(
+        LOWER(${product_reviews.body}) LIKE ${likeTerm}
+        OR LOWER(${product_reviews.title}) LIKE ${likeTerm}
+        OR LOWER(${products.name}) LIKE ${likeTerm}
+      )`
+    );
+  }
+
+  if (!conditions.length) {
+    return undefined;
+  }
+
+  if (conditions.length === 1) {
+    return conditions[0];
+  }
+
+  return and(...conditions);
+}
+
+async function runAutomatedModeration(body: string, title?: string): Promise<ReviewModerationSummary> {
+  const text = `${title ?? ''} ${body}`.toLowerCase();
+  const detectedPhrases: string[] = [];
+  const reasons: string[] = [];
+  const warnings: string[] = [];
+
+  let flagged = false;
+  let blocked = false;
+
+  for (const term of BLOCKED_TERMS) {
+    if (text.includes(term)) {
+      blocked = true;
+      detectedPhrases.push(term);
+    }
+  }
+
+  for (const term of PROFANITY) {
+    if (text.includes(term)) {
+      flagged = true;
+      detectedPhrases.push(term);
+    }
+  }
+
+  const urlPattern = /(https?:\/\/|www\.)/i;
+  if (urlPattern.test(text)) {
+    flagged = true;
+    reasons.push('contains_external_link');
+  }
+
+  if (body.length < 30) {
+    warnings.push('body_too_short');
+  }
+
+  if (blocked) {
+    reasons.push('blocked_term_detected');
+  } else if (flagged && !reasons.length) {
+    reasons.push('potential_profanity');
+  }
+
+  const summary: ReviewModerationSummary = {
+    flagged: flagged || blocked,
+    blocked,
+    reasons,
+    warnings: warnings.length ? warnings : undefined,
+    detectedPhrases: detectedPhrases.length ? detectedPhrases : undefined,
+  };
+
+  try {
+    const aiSummary = await analyzeReviewContent({ body, title });
+    if (aiSummary) {
+      summary.flagged = summary.flagged || aiSummary.flagged || aiSummary.blocked;
+      summary.blocked = summary.blocked || aiSummary.blocked;
+      summary.reasons = dedupe([...summary.reasons, ...(aiSummary.reasons ?? [])]) ?? [];
+      const mergedWarnings = dedupe([...(summary.warnings ?? []), ...(aiSummary.warnings ?? [])]);
+      summary.warnings = mergedWarnings;
+      if (aiSummary.detectedPhrases?.length) {
+        summary.detectedPhrases = dedupe([...(summary.detectedPhrases ?? []), ...aiSummary.detectedPhrases]);
+      }
+    }
+  } catch (error) {
+    console.error('AI moderation failed, falling back to heuristics', error);
+  }
+
+  summary.flagged = summary.flagged || summary.blocked || summary.reasons.length > 0;
+
+  return summary;
+}
+
+type DbClient = Awaited<ReturnType<typeof getDbAsync>>;
+type OrderRow = typeof orders.$inferSelect;
+type CustomerRow = typeof customers.$inferSelect;
+type ProductReviewInsert = typeof product_reviews.$inferInsert;
+
+async function recalcProductRating(productId: string, db?: DbClient) {
+  const database = db ?? (await getDbAsync());
+  const published = await database
+    .select({
+      id: product_reviews.id,
+      rating: product_reviews.rating,
+      publishedAt: product_reviews.published_at,
+    })
+    .from(product_reviews)
+    .where(and(eq(product_reviews.product_id, productId), eq(product_reviews.status, 'published')));
+
+  const distribution: Record<number, number> = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 };
+  let sum = 0;
+  let lastPublishedAt: string | null = null;
+
+  for (const row of published) {
+    const rating = Math.min(Math.max(row.rating ?? 0, 1), 5);
+    distribution[rating] = (distribution[rating] ?? 0) + 1;
+    sum += rating;
+    if (row.publishedAt) {
+      const current = new Date(row.publishedAt).getTime();
+      const previous = lastPublishedAt ? new Date(lastPublishedAt).getTime() : 0;
+      if (!Number.isNaN(current) && (lastPublishedAt === null || current > previous)) {
+        lastPublishedAt = row.publishedAt;
+      }
+    }
+  }
+
+  const count = published.length;
+  const average = count > 0 ? Number((sum / count).toFixed(2)) : 0;
+
+  const ratingPayload: Record<string, unknown> = {
+    average,
+    count,
+    distribution,
+  };
+
+  if (lastPublishedAt) {
+    ratingPayload.lastPublishedAt = lastPublishedAt;
+  }
+
+  await database
+    .update(products)
+    .set({ rating: JSON.stringify(ratingPayload) })
+    .where(eq(products.id, productId));
+}
+
+async function getReviewById(id: string, db?: DbClient): Promise<Review | null> {
+  const database = db ?? (await getDbAsync());
+  const rows = await database.select().from(product_reviews).where(eq(product_reviews.id, id)).limit(1);
+  if (!rows.length) {
+    return null;
+  }
+
+  const mediaRows = await database
+    .select()
+    .from(review_media)
+    .where(eq(review_media.review_id, id));
+
+  const flagRows = await database
+    .select()
+    .from(review_flags)
+    .where(eq(review_flags.review_id, id));
+
+  return deserializeReview(rows[0], mediaRows, flagRows);
+}
+
+async function loadReviewContext(reviewId: string, db?: DbClient) {
+  const database = db ?? (await getDbAsync());
+  const rows = await database
+    .select({
+      review: product_reviews,
+      order: orders,
+      productName: products.name,
+      productSlug: products.slug,
+      customer: customers,
+    })
+    .from(product_reviews)
+    .leftJoin(orders, eq(orders.id, product_reviews.order_id))
+    .leftJoin(products, eq(products.id, product_reviews.product_id))
+    .leftJoin(customers, eq(customers.id, product_reviews.customer_id))
+    .where(eq(product_reviews.id, reviewId))
+    .limit(1);
+
+  if (!rows.length) {
+    return null;
+  }
+
+  const row = rows[0];
+  const { email, name } = extractCustomerContact(row.customer, row.order);
+  const orderItems = row.order?.items ? parseJsonField<OrderItem[]>(row.order.items) ?? [] : [];
+  const matchingItem = orderItems.find((item) => {
+    if (!item) return false;
+    if (row.review.order_item_id && item.id) {
+      return item.id === row.review.order_item_id;
+    }
+    return item.product_id === row.review.product_id;
+  });
+
+  return {
+    review: row.review,
+    order: row.order,
+    productName: parseProductName(row.productName),
+    productSlug:
+      typeof row.productSlug === 'string'
+        ? row.productSlug
+        : parseProductName(row.productSlug),
+    customerEmail: email,
+    customerName: name,
+    orderItem: matchingItem,
+  } as const;
+}
+
+export async function getReviewsForOrder(orderId: string, customerId: string): Promise<Review[]> {
+  const db = await getDbAsync();
+  const rows = await db
+    .select()
+    .from(product_reviews)
+    .where(and(eq(product_reviews.order_id, orderId), eq(product_reviews.customer_id, customerId)));
+
+  if (!rows.length) {
+    return [];
+  }
+
+  const ids = rows.map((row) => row.id!).filter(Boolean);
+  const mediaRows = ids.length
+    ? await db
+        .select()
+        .from(review_media)
+        .where(inArray(review_media.review_id, ids))
+    : [];
+  const flagRows = ids.length
+    ? await db
+        .select()
+        .from(review_flags)
+        .where(inArray(review_flags.review_id, ids))
+    : [];
+
+  return rows.map((row) =>
+    deserializeReview(
+      row,
+      mediaRows.filter((media) => media.review_id === row.id),
+      flagRows.filter((flag) => flag.review_id === row.id)
+    )
+  );
+}
+
+export async function getProductReviews(options: ReviewListOptions = {}): Promise<Review[]> {
+  const db = await getDbAsync();
+  const opts = options ?? {};
+  const conditions = [] as any[];
+
+  if (opts.productId) {
+    conditions.push(eq(product_reviews.product_id, opts.productId));
+  }
+
+  if (opts.status?.length) {
+    conditions.push(inArray(product_reviews.status, opts.status));
+  }
+
+  if (typeof opts.minRating === 'number') {
+    conditions.push(gte(product_reviews.rating, Math.max(1, Math.min(5, Math.floor(opts.minRating)))));
+  }
+
+  if (typeof opts.maxRating === 'number') {
+    conditions.push(lte(product_reviews.rating, Math.max(1, Math.min(5, Math.ceil(opts.maxRating)))));
+  }
+
+  const query = db
+    .select()
+    .from(product_reviews);
+
+  if (conditions.length === 1) {
+    query.where(conditions[0]);
+  } else if (conditions.length > 1) {
+    query.where(and(...conditions));
+  }
+
+  const limit = opts.limit && opts.limit > 0 ? Math.min(opts.limit, 200) : 50;
+  query.limit(limit);
+
+  if (opts.offset && opts.offset > 0) {
+    query.offset(opts.offset);
+  }
+
+  query.orderBy(desc(product_reviews.published_at), desc(product_reviews.created_at));
+
+  const rows = await query;
+
+  if (!rows.length) {
+    return [];
+  }
+
+  const ids = rows.map((row) => row.id!).filter(Boolean);
+  const mediaRows = ids.length
+    ? await db
+        .select()
+        .from(review_media)
+        .where(inArray(review_media.review_id, ids))
+    : [];
+  const flagRows = ids.length
+    ? await db
+        .select()
+        .from(review_flags)
+        .where(inArray(review_flags.review_id, ids))
+    : [];
+
+  return rows.map((row) =>
+    deserializeReview(
+      row,
+      mediaRows.filter((media) => media.review_id === row.id),
+      flagRows.filter((flag) => flag.review_id === row.id)
+    )
+  );
+}
+
+export async function submitReviewForOrderItem(input: SubmitReviewInput): Promise<Review> {
+  if (!input.orderId) {
+    throw new Error('Order ID is required.');
+  }
+  if (!input.productId) {
+    throw new Error('Product ID is required.');
+  }
+  if (!Number.isInteger(input.rating) || input.rating < 1 || input.rating > 5) {
+    throw new Error('Rating must be an integer between 1 and 5.');
+  }
+
+  const body = input.body?.trim() ?? '';
+  if (body.length < 30) {
+    throw new Error('Review body must be at least 30 characters long.');
+  }
+
+  const title = input.title?.trim();
+
+  const db = await getDbAsync();
+  const orderRows = await db
+    .select()
+    .from(orders)
+    .where(eq(orders.id, input.orderId))
+    .limit(1);
+
+  if (!orderRows.length) {
+    throw new Error('Order not found.');
+  }
+
+  const order = orderRows[0];
+
+  if (!order.customer_id || order.customer_id !== input.customerId) {
+    throw new Error('You can only review products from your own orders.');
+  }
+
+  const isDelivered = order.status === 'delivered' || Boolean(order.delivered_at);
+  if (!isDelivered) {
+    throw new Error('You can only review items after the order has been delivered.');
+  }
+
+  const orderItems: OrderItem[] = Array.isArray(order.items)
+    ? (order.items as OrderItem[])
+    : parseJsonField<OrderItem[]>(order.items) ?? [];
+
+  const matchingItem = orderItems.find((item) => {
+    if (input.orderItemId && item.id && item.id === input.orderItemId) {
+      return true;
+    }
+    return item.product_id === input.productId;
+  });
+
+  if (!matchingItem) {
+    throw new Error('Order item could not be found for review.');
+  }
+
+  const existing = await db
+    .select({ id: product_reviews.id })
+    .from(product_reviews)
+    .where(
+      and(
+        eq(product_reviews.order_id, input.orderId),
+        eq(product_reviews.customer_id, input.customerId),
+        eq(product_reviews.product_id, input.productId)
+      )
+    )
+    .limit(1);
+
+  if (existing.length) {
+    throw new Error('You have already submitted a review for this item.');
+  }
+
+  const moderation = await runAutomatedModeration(body, title);
+  if (moderation.blocked) {
+    throw new Error('Review contains prohibited content.');
+  }
+
+  const status: ReviewStatus = moderation.flagged ? 'needs_review' : 'pending';
+  const timestamp = new Date().toISOString();
+
+  const [created] = await db
+    .insert(product_reviews)
+    .values({
+      product_id: input.productId,
+      order_id: input.orderId,
+      order_item_id: input.orderItemId ?? matchingItem.id ?? null,
+      customer_id: input.customerId,
+      rating: input.rating,
+      title: title ?? null,
+      body,
+      status,
+      is_verified: true,
+      automated_moderation: JSON.stringify(moderation),
+      submitted_at: timestamp,
+      created_at: timestamp,
+      updated_at: timestamp,
+      metadata: input.metadata ? JSON.stringify(input.metadata) : null,
+    })
+    .returning();
+
+  if (!created) {
+    throw new Error('Failed to create review.');
+  }
+
+  if (input.media?.length) {
+    const mediaInserts = input.media.map((media) => ({
+      review_id: created.id!,
+      type: media.type ?? 'image',
+      url: media.url,
+      alt_text: media.alt_text,
+      metadata: media.alt_text ? JSON.stringify({ alt_text: media.alt_text }) : null,
+    }));
+
+    await db.insert(review_media).values(mediaInserts);
+  }
+
+  await recalcProductRating(input.productId, db);
+
+  const review = await getReviewById(created.id!, db);
+  if (!review) {
+    throw new Error('Review was created but could not be retrieved.');
+  }
+
+  return review;
+}
+
+export async function getReviewQueue(options: ReviewQueueOptions = {}): Promise<ReviewQueueResult> {
+  const db = await getDbAsync();
+  const whereClause = buildQueueWhereClause(options);
+
+  const query = db
+    .select({
+      review: product_reviews,
+      productName: products.name,
+      productSlug: products.slug,
+    })
+    .from(product_reviews)
+    .leftJoin(products, eq(products.id, product_reviews.product_id));
+
+  if (whereClause) {
+    query.where(whereClause);
+  }
+
+  query.orderBy(desc(product_reviews.submitted_at), desc(product_reviews.created_at));
+
+  const limit = Math.max(1, Math.min(options.limit ?? 25, 100));
+  query.limit(limit);
+  if (options.offset) {
+    query.offset(Math.max(0, options.offset));
+  }
+
+  const rows = await query;
+  const ids = rows.map((row) => row.review.id!).filter(Boolean);
+
+  if (!ids.length) {
+    const countQuery = db
+      .select({ value: sql<number>`COUNT(*)` })
+      .from(product_reviews)
+      .leftJoin(products, eq(products.id, product_reviews.product_id));
+
+    if (whereClause) {
+      countQuery.where(whereClause);
+    }
+
+    const [countRow] = await countQuery;
+    return { items: [], total: countRow?.value ?? 0 };
+  }
+
+  const mediaRows = await db
+    .select()
+    .from(review_media)
+    .where(inArray(review_media.review_id, ids));
+
+  const flagRows = await db
+    .select()
+    .from(review_flags)
+    .where(inArray(review_flags.review_id, ids));
+
+  const items = rows.map((row) => {
+    const review = deserializeReview(
+      row.review,
+      mediaRows.filter((media) => media.review_id === row.review.id),
+      flagRows.filter((flag) => flag.review_id === row.review.id)
+    );
+    review.product_name = parseProductName(row.productName);
+    review.product_slug =
+      typeof row.productSlug === 'string' ? row.productSlug : parseProductName(row.productSlug);
+    review.open_flag_count = review.flags?.filter((flag) => flag.status === 'open').length ?? 0;
+    return review;
+  });
+
+  const countQuery = db
+    .select({ value: sql<number>`COUNT(*)` })
+    .from(product_reviews)
+    .leftJoin(products, eq(products.id, product_reviews.product_id));
+
+  if (whereClause) {
+    countQuery.where(whereClause);
+  }
+
+  const [countRow] = await countQuery;
+
+  return {
+    items,
+    total: countRow?.value ?? items.length,
+  };
+}
+
+export async function getReviewModerationMetrics(): Promise<ReviewModerationMetrics> {
+  const db = await getDbAsync();
+  const metrics: ReviewModerationMetrics = {
+    total: 0,
+    pending: 0,
+    needs_review: 0,
+    published: 0,
+    suppressed: 0,
+    auto_rejected: 0,
+    flagged: 0,
+    last_published_at: null,
+  };
+
+  const statusRows = await db
+    .select({ status: product_reviews.status, count: sql<number>`COUNT(*)` })
+    .from(product_reviews)
+    .groupBy(product_reviews.status);
+
+  for (const row of statusRows) {
+    metrics.total += row.count ?? 0;
+    switch (row.status) {
+      case 'pending':
+        metrics.pending = row.count ?? 0;
+        break;
+      case 'needs_review':
+        metrics.needs_review = row.count ?? 0;
+        break;
+      case 'published':
+        metrics.published = row.count ?? 0;
+        break;
+      case 'suppressed':
+        metrics.suppressed = row.count ?? 0;
+        break;
+      case 'auto_rejected':
+        metrics.auto_rejected = row.count ?? 0;
+        break;
+      default:
+        break;
+    }
+  }
+
+  const [flaggedRow] = await db
+    .select({
+      value: sql<number>`COUNT(*)`,
+    })
+    .from(product_reviews)
+    .where(
+      sql`(${product_reviews.status} IN ('needs_review','auto_rejected') OR EXISTS (
+        SELECT 1 FROM ${review_flags} rf
+        WHERE rf.review_id = ${product_reviews.id}
+          AND rf.status = 'open'
+      ))`
+    );
+
+  metrics.flagged = flaggedRow?.value ?? 0;
+
+  const [lastPublished] = await db
+    .select({
+      value: sql<string | null>`MAX(${product_reviews.published_at})`,
+    })
+    .from(product_reviews)
+    .where(eq(product_reviews.status, 'published'));
+
+  metrics.last_published_at = lastPublished?.value ?? null;
+
+  return metrics;
+}
+
+export async function updateReviewStatus(input: ReviewStatusUpdateInput): Promise<Review> {
+  const db = await getDbAsync();
+  const [current] = await db
+    .select()
+    .from(product_reviews)
+    .where(eq(product_reviews.id, input.reviewId))
+    .limit(1);
+
+  if (!current) {
+    throw new Error('Review not found.');
+  }
+
+  const timestamp = new Date().toISOString();
+  const updates: Partial<ProductReviewInsert> = {
+    status: input.status,
+    updated_at: timestamp,
+    moderation_notes: input.moderationNotes ?? current.moderation_notes ?? null,
+  };
+
+  if (input.status === 'published') {
+    updates.published_at = current.published_at ?? timestamp;
+  } else if (current.status === 'published' && input.status !== 'published') {
+    updates.published_at = null;
+  }
+
+  await db.update(product_reviews).set(updates).where(eq(product_reviews.id, input.reviewId));
+
+  if (current.status === 'published' || input.status === 'published') {
+    await recalcProductRating(current.product_id, db);
+  }
+
+  if (input.status === 'published' || input.status === 'suppressed' || input.status === 'auto_rejected') {
+    await db
+      .update(review_flags)
+      .set({ status: 'resolved', resolved_at: timestamp })
+      .where(and(eq(review_flags.review_id, input.reviewId), eq(review_flags.status, 'open')));
+  }
+
+  const review = await getReviewById(input.reviewId, db);
+  if (!review) {
+    throw new Error('Review not found.');
+  }
+
+  if (input.notifyCustomer) {
+    const context = await loadReviewContext(input.reviewId, db);
+    if (context?.customerEmail) {
+      try {
+        await sendReviewStatusNotification({
+          email: context.customerEmail,
+          name: context.customerName ?? undefined,
+          productName: context.productName ?? 'your purchase',
+          status: review.status,
+          reviewBody: review.body ?? undefined,
+          rating: review.rating,
+          event: 'status_change',
+        });
+      } catch (error) {
+        console.error('Failed to send review status notification', error);
+      }
+    }
+  }
+
+  return review;
+}
+
+export async function respondToReview(input: ReviewResponseInput): Promise<Review> {
+  const db = await getDbAsync();
+  const [current] = await db
+    .select()
+    .from(product_reviews)
+    .where(eq(product_reviews.id, input.reviewId))
+    .limit(1);
+
+  if (!current) {
+    throw new Error('Review not found.');
+  }
+
+  const timestamp = new Date().toISOString();
+  await db
+    .update(product_reviews)
+    .set({
+      admin_response: input.response,
+      response_author_id: input.adminId,
+      responded_at: timestamp,
+      updated_at: timestamp,
+    })
+    .where(eq(product_reviews.id, input.reviewId));
+
+  const review = await getReviewById(input.reviewId, db);
+  if (!review) {
+    throw new Error('Review not found.');
+  }
+
+  if (input.notifyCustomer) {
+    const context = await loadReviewContext(input.reviewId, db);
+    if (context?.customerEmail) {
+      try {
+        await sendReviewStatusNotification({
+          email: context.customerEmail,
+          name: context.customerName ?? undefined,
+          productName: context.productName ?? 'your purchase',
+          status: review.status,
+          adminResponse: input.response,
+          reviewBody: review.body ?? undefined,
+          rating: review.rating,
+          event: 'response',
+        });
+      } catch (error) {
+        console.error('Failed to send review response notification', error);
+      }
+    }
+  }
+
+  return review;
+}
+
+export async function recordReviewFlag(input: ReviewFlagInput): Promise<Review> {
+  const db = await getDbAsync();
+  const [existing] = await db
+    .select()
+    .from(product_reviews)
+    .where(eq(product_reviews.id, input.reviewId))
+    .limit(1);
+
+  if (!existing) {
+    throw new Error('Review not found.');
+  }
+
+  const timestamp = new Date().toISOString();
+  await db.insert(review_flags).values({
+    review_id: input.reviewId,
+    reason: input.reason,
+    notes: input.notes ?? null,
+    flagged_by: input.flaggedBy ?? null,
+    status: 'open',
+    created_at: timestamp,
+  });
+
+  return (await getReviewById(input.reviewId, db))!;
+}
+
+export async function findReviewReminderCandidates(
+  options: ReminderQueryOptions = {}
+): Promise<ReviewReminderCandidate[]> {
+  const db = await getDbAsync();
+  const minDays = Math.max(options.minDaysSinceDelivery ?? 3, 1);
+  const maxDays = Math.max(options.maxDaysSinceDelivery ?? 30, minDays);
+  const now = Date.now();
+  const minTimestamp = new Date(now - maxDays * 24 * 60 * 60 * 1000).toISOString();
+  const maxTimestamp = new Date(now - minDays * 24 * 60 * 60 * 1000).toISOString();
+
+  const ordersQuery = db
+    .select({ order: orders, customer: customers })
+    .from(orders)
+    .leftJoin(customers, eq(customers.id, orders.customer_id))
+    .where(
+      and(
+        sql`${orders.delivered_at} IS NOT NULL`,
+        gte(orders.delivered_at, minTimestamp),
+        lte(orders.delivered_at, maxTimestamp)
+      )
+    )
+    .orderBy(desc(orders.delivered_at))
+    .limit(Math.min(options.limit ?? 100, 200));
+
+  const orderRows = await ordersQuery;
+  if (!orderRows.length) {
+    return [];
+  }
+
+  const orderIds = orderRows.map((row) => row.order.id!).filter(Boolean);
+  const existingReviews = orderIds.length
+    ? await db
+        .select({ order_id: product_reviews.order_id, product_id: product_reviews.product_id })
+        .from(product_reviews)
+        .where(inArray(product_reviews.order_id, orderIds))
+    : [];
+
+  const reviewSet = new Set<string>();
+  for (const review of existingReviews) {
+    if (review.order_id && review.product_id) {
+      reviewSet.add(`${review.order_id}:${review.product_id}`);
+    }
+  }
+
+  const reminderRows = orderIds.length
+    ? await db
+        .select()
+        .from(review_reminders)
+        .where(inArray(review_reminders.order_id, orderIds))
+    : [];
+
+  const remindedSet = new Set<string>();
+  for (const reminder of reminderRows) {
+    remindedSet.add(`${reminder.order_id}:${reminder.product_id}`);
+  }
+
+  const candidates: ReviewReminderCandidate[] = [];
+  const productIds = new Set<string>();
+
+  for (const row of orderRows) {
+    const order = row.order;
+    const { email, name } = extractCustomerContact(row.customer, order);
+    const items = parseJsonField<OrderItem[]>(order.items) ?? [];
+
+    for (const item of items) {
+      if (!item?.product_id) continue;
+      const key = `${order.id}:${item.product_id}`;
+      if (reviewSet.has(key) || remindedSet.has(key)) {
+        continue;
+      }
+
+      candidates.push({
+        orderId: order.id!,
+        productId: item.product_id,
+        deliveredAt: order.delivered_at!,
+        customerId: order.customer_id ?? null,
+        customerEmail: email,
+        customerName: name,
+        orderItemId: item.id,
+        productName: null,
+      });
+      productIds.add(item.product_id);
+    }
+  }
+
+  if (!candidates.length) {
+    return [];
+  }
+
+  const productIdList = Array.from(productIds);
+  if (productIdList.length) {
+    const productRows = await db
+      .select({ id: products.id, name: products.name })
+      .from(products)
+      .where(inArray(products.id, productIdList));
+
+    const nameMap = new Map<string, string | null>();
+    for (const product of productRows) {
+      if (product.id) {
+        nameMap.set(product.id, parseProductName(product.name));
+      }
+    }
+
+    for (const candidate of candidates) {
+      candidate.productName = nameMap.get(candidate.productId) ?? null;
+    }
+  }
+
+  return candidates;
+}
+
+export async function sendReviewReminders(options: ReminderQueryOptions = {}) {
+  const db = await getDbAsync();
+  const candidates = await findReviewReminderCandidates(options);
+  if (!candidates.length) {
+    return { sent: 0, failed: [] as Array<{ candidate: ReviewReminderCandidate; error: string }> };
+  }
+
+  let sent = 0;
+  const failures: Array<{ candidate: ReviewReminderCandidate; error: string }> = [];
+
+  for (const candidate of candidates) {
+    if (!candidate.customerEmail) {
+      failures.push({ candidate, error: 'Missing customer email' });
+      continue;
+    }
+
+    try {
+      await sendReviewReminderEmail({
+        email: candidate.customerEmail,
+        name: candidate.customerName ?? undefined,
+        productName: candidate.productName ?? 'your purchase',
+        orderId: candidate.orderId,
+      });
+      await db.insert(review_reminders).values({
+        order_id: candidate.orderId,
+        product_id: candidate.productId,
+        customer_id: candidate.customerId ?? undefined,
+        status: 'sent',
+        sent_at: new Date().toISOString(),
+      });
+      sent += 1;
+    } catch (error) {
+      failures.push({
+        candidate,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+      await db.insert(review_reminders).values({
+        order_id: candidate.orderId,
+        product_id: candidate.productId,
+        customer_id: candidate.customerId ?? undefined,
+        status: 'failed',
+        error: error instanceof Error ? error.message : 'Unknown error',
+        sent_at: new Date().toISOString(),
+      });
+    }
+  }
+
+  return { sent, failed: failures };
+}

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -17,4 +17,5 @@ export * from "./cartitem";
 export * from "./money";
 export * from "./apiPermissions";
 export * from "./agent";
+export * from "./review";
 

--- a/lib/types/mach/Product.ts
+++ b/lib/types/mach/Product.ts
@@ -157,6 +157,8 @@ export interface MACHSEO {
 export interface MACHRating {
   average: number; // 0-5
   count: number; // Total number of ratings
+  distribution?: Record<number, number>; // Optional histogram keyed by star value
+  lastPublishedAt?: string; // ISO timestamp of the most recent published review
 }
 
 /**

--- a/lib/types/review.ts
+++ b/lib/types/review.ts
@@ -1,0 +1,110 @@
+export type ReviewStatus = 'pending' | 'needs_review' | 'published' | 'suppressed' | 'auto_rejected';
+export type ReviewFlagStatus = 'open' | 'resolved' | 'dismissed';
+
+export interface ReviewFlag {
+  id: string;
+  review_id: string;
+  flagged_by?: string | null;
+  reason: string;
+  notes?: string | null;
+  status: ReviewFlagStatus;
+  created_at?: string | null;
+  resolved_at?: string | null;
+}
+
+export interface ReviewModerationSummary {
+  flagged: boolean;
+  blocked: boolean;
+  reasons: string[];
+  warnings?: string[];
+  detectedPhrases?: string[];
+}
+
+export interface ReviewMedia {
+  id?: string;
+  review_id?: string;
+  type: 'image' | 'video';
+  url: string;
+  alt_text?: string;
+  metadata?: Record<string, any>;
+  created_at?: string;
+}
+
+export interface Review {
+  id: string;
+  product_id: string;
+  order_id: string;
+  order_item_id?: string | null;
+  customer_id: string;
+  rating: number;
+  title?: string | null;
+  body?: string | null;
+  status: ReviewStatus;
+  is_verified: boolean;
+  automated_moderation?: ReviewModerationSummary | null;
+  moderation_notes?: string | null;
+  admin_response?: string | null;
+  response_author_id?: string | null;
+  responded_at?: string | null;
+  submitted_at?: string | null;
+  published_at?: string | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+  metadata?: Record<string, any> | null;
+  media?: ReviewMedia[];
+  flags?: ReviewFlag[];
+  open_flag_count?: number;
+  product_name?: string | null;
+  product_slug?: string | null;
+}
+
+export interface ReviewSubmissionPayload {
+  orderId: string;
+  orderItemId?: string;
+  productId: string;
+  rating: number;
+  title?: string;
+  body: string;
+  media?: Array<{
+    url: string;
+    type?: 'image' | 'video';
+    alt_text?: string;
+  }>;
+  metadata?: Record<string, any>;
+}
+
+export interface ReviewListOptions {
+  productId?: string;
+  status?: ReviewStatus[];
+  minRating?: number;
+  maxRating?: number;
+  limit?: number;
+  offset?: number;
+}
+
+export interface ReviewQueueResult {
+  items: Review[];
+  total: number;
+}
+
+export interface ReviewModerationMetrics {
+  total: number;
+  pending: number;
+  needs_review: number;
+  published: number;
+  suppressed: number;
+  auto_rejected: number;
+  flagged: number;
+  last_published_at?: string | null;
+}
+
+export interface ReviewReminderCandidate {
+  orderId: string;
+  productId: string;
+  productName: string | null;
+  deliveredAt: string;
+  customerId: string | null;
+  customerEmail?: string | null;
+  customerName?: string | null;
+  orderItemId?: string | null;
+}

--- a/lib/utils/email.ts
+++ b/lib/utils/email.ts
@@ -2,7 +2,7 @@ import { Resend } from 'resend';
 
 let resend: Resend | null = null;
 
-function getResendClient(): Resend {
+export function getResendClient(): Resend {
   if (!resend) {
     resend = new Resend(process.env.RESEND_API_KEY);
   }

--- a/lib/utils/ratings.ts
+++ b/lib/utils/ratings.ts
@@ -1,0 +1,77 @@
+import type { Rating } from '@/lib/types';
+
+export interface NormalizedProductRating {
+  average: number;
+  count: number;
+  distribution?: Record<number, number>;
+  lastPublishedAt?: string;
+}
+
+function coerceNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const parsed = Number.parseFloat(value);
+    if (!Number.isNaN(parsed) && Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return null;
+}
+
+function parseDistribution(raw: unknown): Record<number, number> | undefined {
+  if (!raw || typeof raw !== 'object') return undefined;
+  const entries = Object.entries(raw as Record<string, unknown>);
+  if (!entries.length) return undefined;
+
+  const distribution: Record<number, number> = {};
+  for (const [key, value] of entries) {
+    const bucket = coerceNumber(key);
+    const count = coerceNumber(value);
+    if (bucket === null || count === null) continue;
+    const roundedBucket = Math.round(bucket);
+    if (roundedBucket < 1 || roundedBucket > 5) continue;
+    distribution[roundedBucket] = Math.max(0, Math.round(count));
+  }
+
+  return Object.keys(distribution).length ? distribution : undefined;
+}
+
+export function normalizeProductRating(raw?: Rating | string | null): NormalizedProductRating | null {
+  if (!raw) return null;
+
+  let value: Rating | undefined;
+  if (typeof raw === 'string') {
+    try {
+      value = JSON.parse(raw) as Rating;
+    } catch {
+      return null;
+    }
+  } else {
+    value = raw;
+  }
+
+  if (!value || typeof value !== 'object') return null;
+
+  const average = coerceNumber((value as Rating).average);
+  const count = coerceNumber((value as Rating).count);
+  const lastPublishedAt = typeof (value as Rating & { lastPublishedAt?: unknown }).lastPublishedAt === 'string'
+    ? (value as Rating & { lastPublishedAt?: string }).lastPublishedAt
+    : undefined;
+
+  if (average === null || count === null) {
+    return null;
+  }
+
+  const safeAverage = Math.min(5, Math.max(0, Number(average.toFixed(2))));
+  const safeCount = Math.max(0, Math.round(count));
+  const distribution = parseDistribution((value as Rating & { distribution?: unknown }).distribution);
+
+  return {
+    average: safeAverage,
+    count: safeCount,
+    distribution,
+    lastPublishedAt,
+  };
+}

--- a/lib/utils/review-notifications.ts
+++ b/lib/utils/review-notifications.ts
@@ -1,0 +1,125 @@
+import type { ReviewStatus } from '@/lib/types';
+import { getResendClient } from '@/lib/utils/email';
+
+interface ReviewStatusNotificationInput {
+  email: string;
+  name?: string;
+  productName: string;
+  status: ReviewStatus;
+  adminResponse?: string;
+  reviewBody?: string;
+  rating?: number;
+  event?: 'status_change' | 'response';
+}
+
+interface ReviewReminderEmailInput {
+  email: string;
+  name?: string;
+  productName: string;
+  orderId: string;
+}
+
+function formatStatus(status: ReviewStatus) {
+  switch (status) {
+    case 'published':
+      return 'approved';
+    case 'needs_review':
+      return 'awaiting moderation';
+    case 'suppressed':
+      return 'held back';
+    case 'auto_rejected':
+      return 'rejected';
+    case 'pending':
+    default:
+      return 'pending review';
+  }
+}
+
+export async function sendReviewStatusNotification(input: ReviewStatusNotificationInput): Promise<void> {
+  const resend = getResendClient();
+  const greeting = input.name ? `Hi ${input.name.split(' ')[0]},` : 'Hi there,';
+  const statusLabel = formatStatus(input.status);
+  const subjectPrefix = input.event === 'response' ? 'We replied to your review' : `Your review was ${statusLabel}`;
+  const subject = `${subjectPrefix} · ${input.productName}`;
+
+  const responseSection = input.adminResponse
+    ? `
+        <div style="margin-top: 16px; padding: 16px; background-color: #111827; border-radius: 8px;">
+          <h3 style="margin: 0 0 8px; color: #f97316; font-size: 16px; font-weight: 600;">Store response</h3>
+          <p style="margin: 0; color: #e5e7eb; line-height: 22px;">${input.adminResponse.replace(/\n/g, '<br />')}</p>
+        </div>
+      `
+    : '';
+
+  const reviewDetails = input.reviewBody
+    ? `
+        <div style="margin-top: 16px; padding: 16px; background-color: #1f2937; border-radius: 8px;">
+          <h3 style="margin: 0 0 8px; color: #f9fafb; font-size: 16px; font-weight: 600;">Your review</h3>
+          ${typeof input.rating === 'number'
+            ? `<p style="margin: 0 0 12px; color: #fbbf24; font-weight: 600;">${'★'.repeat(Math.round(input.rating))}${'☆'.repeat(5 - Math.round(input.rating))}</p>`
+            : ''}
+          <p style="margin: 0; color: #d1d5db; line-height: 22px;">${input.reviewBody.replace(/\n/g, '<br />')}</p>
+        </div>
+      `
+    : '';
+
+  const html = `
+    <div style="font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background-color: #0f172a; padding: 32px; color: #f9fafb;">
+      <div style="max-width: 520px; margin: 0 auto; background-color: #111827; border-radius: 16px; padding: 32px; box-shadow: 0 10px 30px rgba(15, 23, 42, 0.4);">
+        <h2 style="margin: 0; font-size: 22px; font-weight: 700; color: #f97316;">Voltique Reviews</h2>
+        <p style="margin: 16px 0 0; color: #e5e7eb; line-height: 24px;">${greeting}</p>
+        <p style="margin: 12px 0 0; color: #d1d5db; line-height: 24px;">
+          ${input.event === 'response'
+            ? 'Our merchandising team just replied to your feedback.'
+            : `We wanted to let you know the status of your review for <strong>${input.productName}</strong>.`}
+        </p>
+        <div style="margin-top: 16px; padding: 16px; border-radius: 12px; background: linear-gradient(135deg, #f97316, #ea580c); color: #fff;">
+          <p style="margin: 0; font-size: 18px; font-weight: 700;">${input.productName}</p>
+          <p style="margin: 4px 0 0; font-size: 14px; opacity: 0.9;">Current status: ${statusLabel}</p>
+        </div>
+        ${reviewDetails}
+        ${responseSection}
+        <p style="margin: 24px 0 0; color: #9ca3af; font-size: 14px; line-height: 22px;">
+          Thanks again for taking the time to share your experience. Your feedback helps fellow adventurers choose the right gear.
+        </p>
+        <p style="margin: 16px 0 0; color: #6b7280; font-size: 12px;">— Voltique Merchandising Team</p>
+      </div>
+    </div>
+  `;
+
+  await resend.emails.send({
+    from: 'Voltique Reviews <volt@russellkmoore.me>',
+    to: [input.email],
+    subject,
+    html,
+  });
+}
+
+export async function sendReviewReminderEmail(input: ReviewReminderEmailInput): Promise<void> {
+  const resend = getResendClient();
+  const greeting = input.name ? `Hi ${input.name.split(' ')[0]},` : 'Hi there,';
+
+  const html = `
+    <div style="font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background-color: #0f172a; padding: 32px; color: #f9fafb;">
+      <div style="max-width: 520px; margin: 0 auto; background-color: #111827; border-radius: 16px; padding: 32px; box-shadow: 0 10px 30px rgba(15, 23, 42, 0.4);">
+        <h2 style="margin: 0; font-size: 22px; font-weight: 700; color: #f97316;">How's your new gear?</h2>
+        <p style="margin: 16px 0 0; color: #e5e7eb; line-height: 24px;">${greeting}</p>
+        <p style="margin: 12px 0 0; color: #d1d5db; line-height: 24px;">
+          We hope you're putting <strong>${input.productName}</strong> to good use. When you have a moment, we'd love to hear how it's working out.
+        </p>
+        <a href="https://voltique.russellkmoore.me/account/orders/${input.orderId}" style="display: inline-block; margin-top: 20px; padding: 12px 20px; background: linear-gradient(135deg, #f97316, #ea580c); color: #fff; border-radius: 9999px; text-decoration: none; font-weight: 600;">Share your review</a>
+        <p style="margin: 24px 0 0; color: #9ca3af; font-size: 14px; line-height: 22px;">
+          Reviews help other shoppers make confident choices and give our team insight into what to improve next.
+        </p>
+        <p style="margin: 16px 0 0; color: #6b7280; font-size: 12px;">If you've already shared your thoughts, thank you! You can ignore this reminder.</p>
+      </div>
+    </div>
+  `;
+
+  await resend.emails.send({
+    from: 'Voltique Reviews <volt@russellkmoore.me>',
+    to: [input.email],
+    subject: `How's your ${input.productName}?`,
+    html,
+  });
+}

--- a/mercora-db-dump.sql
+++ b/mercora-db-dump.sql
@@ -464,7 +464,72 @@ CREATE TABLE order_webhooks (
     completed_at TEXT,
     FOREIGN KEY (order_id) REFERENCES orders(id)
 );
+CREATE TABLE product_reviews (
+    id TEXT PRIMARY KEY,
+    product_id TEXT NOT NULL,
+    order_id TEXT NOT NULL,
+    order_item_id TEXT,
+    customer_id TEXT NOT NULL,
+    rating INTEGER NOT NULL,
+    title TEXT,
+    body TEXT,
+    status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'needs_review', 'published', 'suppressed', 'auto_rejected')),
+    is_verified INTEGER DEFAULT 1 CHECK (is_verified IN (0, 1)),
+    automated_moderation TEXT,
+    moderation_notes TEXT,
+    admin_response TEXT,
+    response_author_id TEXT,
+    responded_at TEXT,
+    submitted_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    published_at TEXT,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    metadata TEXT
+);
+CREATE TABLE review_media (
+    id TEXT PRIMARY KEY,
+    review_id TEXT NOT NULL,
+    type TEXT DEFAULT 'image' CHECK (type IN ('image', 'video')),
+    url TEXT NOT NULL,
+    alt_text TEXT,
+    metadata TEXT,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (review_id) REFERENCES product_reviews(id) ON DELETE CASCADE
+);
+CREATE TABLE review_flags (
+    id TEXT PRIMARY KEY,
+    review_id TEXT NOT NULL,
+    flagged_by TEXT,
+    reason TEXT NOT NULL,
+    notes TEXT,
+    status TEXT DEFAULT 'open' CHECK (status IN ('open', 'resolved', 'dismissed')),
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    resolved_at TEXT,
+    FOREIGN KEY (review_id) REFERENCES product_reviews(id) ON DELETE CASCADE
+);
+CREATE TABLE review_reminders (
+    id TEXT PRIMARY KEY DEFAULT ('RRN-' || upper(hex(randomblob(5)))),
+    order_id TEXT NOT NULL,
+    product_id TEXT NOT NULL,
+    customer_id TEXT,
+    status TEXT NOT NULL DEFAULT 'sent' CHECK (status IN ('sent', 'failed')),
+    error TEXT,
+    sent_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+);
+
 DELETE FROM sqlite_sequence;
+CREATE INDEX product_reviews_product_idx ON product_reviews(product_id);
+CREATE INDEX product_reviews_order_idx ON product_reviews(order_id);
+CREATE INDEX product_reviews_customer_idx ON product_reviews(customer_id);
+CREATE INDEX product_reviews_status_idx ON product_reviews(status);
+CREATE INDEX review_media_review_idx ON review_media(review_id);
+CREATE INDEX review_flags_review_idx ON review_flags(review_id);
+CREATE INDEX review_flags_status_idx ON review_flags(status);
+CREATE INDEX review_reminders_order_idx ON review_reminders(order_id);
+CREATE INDEX review_reminders_product_idx ON review_reminders(product_id);
+
 CREATE INDEX idx_addresses_type ON addresses(type);
 CREATE INDEX idx_addresses_status ON addresses(status);
 CREATE INDEX idx_addresses_country ON addresses(country);

--- a/migrations/0005_add_reviews_tables.sql
+++ b/migrations/0005_add_reviews_tables.sql
@@ -1,0 +1,59 @@
+-- Reviews & Ratings Tables
+-- Customer-submitted feedback with moderation workflow support
+
+CREATE TABLE IF NOT EXISTS product_reviews (
+  id TEXT PRIMARY KEY,
+  product_id TEXT NOT NULL,
+  order_id TEXT NOT NULL,
+  order_item_id TEXT,
+  customer_id TEXT NOT NULL,
+  rating INTEGER NOT NULL,
+  title TEXT,
+  body TEXT,
+  status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'needs_review', 'published', 'suppressed', 'auto_rejected')),
+  is_verified INTEGER DEFAULT 1 CHECK (is_verified IN (0, 1)),
+  automated_moderation TEXT,
+  moderation_notes TEXT,
+  admin_response TEXT,
+  response_author_id TEXT,
+  responded_at TEXT,
+  submitted_at TEXT DEFAULT CURRENT_TIMESTAMP,
+  published_at TEXT,
+  created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+  metadata TEXT
+);
+
+CREATE INDEX IF NOT EXISTS product_reviews_product_idx ON product_reviews(product_id);
+CREATE INDEX IF NOT EXISTS product_reviews_order_idx ON product_reviews(order_id);
+CREATE INDEX IF NOT EXISTS product_reviews_customer_idx ON product_reviews(customer_id);
+CREATE INDEX IF NOT EXISTS product_reviews_status_idx ON product_reviews(status);
+
+
+CREATE TABLE IF NOT EXISTS review_media (
+  id TEXT PRIMARY KEY,
+  review_id TEXT NOT NULL,
+  type TEXT DEFAULT 'image' CHECK (type IN ('image', 'video')),
+  url TEXT NOT NULL,
+  alt_text TEXT,
+  metadata TEXT,
+  created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (review_id) REFERENCES product_reviews(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS review_media_review_idx ON review_media(review_id);
+
+CREATE TABLE IF NOT EXISTS review_flags (
+  id TEXT PRIMARY KEY,
+  review_id TEXT NOT NULL,
+  flagged_by TEXT,
+  reason TEXT NOT NULL,
+  notes TEXT,
+  status TEXT DEFAULT 'open' CHECK (status IN ('open', 'resolved', 'dismissed')),
+  created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+  resolved_at TEXT,
+  FOREIGN KEY (review_id) REFERENCES product_reviews(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS review_flags_review_idx ON review_flags(review_id);
+CREATE INDEX IF NOT EXISTS review_flags_status_idx ON review_flags(status);

--- a/migrations/0006_add_review_reminders.sql
+++ b/migrations/0006_add_review_reminders.sql
@@ -1,0 +1,15 @@
+-- Add review reminder tracking table to prevent duplicate emails
+CREATE TABLE IF NOT EXISTS review_reminders (
+  id TEXT PRIMARY KEY DEFAULT ('RRN-' || upper(hex(randomblob(5)))),
+  order_id TEXT NOT NULL,
+  product_id TEXT NOT NULL,
+  customer_id TEXT,
+  status TEXT NOT NULL DEFAULT 'sent',
+  error TEXT,
+  sent_at TEXT DEFAULT (CURRENT_TIMESTAMP),
+  created_at TEXT DEFAULT (CURRENT_TIMESTAMP),
+  updated_at TEXT DEFAULT (CURRENT_TIMESTAMP)
+);
+
+CREATE INDEX IF NOT EXISTS review_reminders_order_idx ON review_reminders (order_id);
+CREATE INDEX IF NOT EXISTS review_reminders_product_idx ON review_reminders (product_id);

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,8 @@
         "@types/react-dom": "^19",
         "autoprefixer": "^10.4.21",
         "drizzle-kit": "^0.31.4",
+        "eslint": "^9.36.0",
+        "eslint-config-next": "^15.5.4",
         "postcss": "^8.5.6",
         "tailwindcss": "^3.4.1",
         "tsx": "^4.20.3",
@@ -7885,10 +7887,33 @@
         "@noble/ciphers": "^1.0.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.5.0.tgz",
+      "integrity": "sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/runtime": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.5.tgz",
       "integrity": "sha512-++LApOtY0pEEz1zrd9vy1/zXVaVJJ/EbAF3u0fXIzPJEDtnITsBGbbK0EkM72amhl/R5b+5xx0Y/QhcVOpuulg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
+      "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -8731,6 +8756,195 @@
         "node": ">=18"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
+      "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
+      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.0.tgz",
+      "integrity": "sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.6",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.3.1.tgz",
+      "integrity": "sha512-xR93k9WhrDYpXHORXpxVL5oHj3Era7wo6k/Wd8/IsQNnZUTzkGS29lyn3nAT05v6ltUuTFVCCYDEGfy2Or/sPA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.2.tgz",
+      "integrity": "sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
+      "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.36.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.36.0.tgz",
+      "integrity": "sha512-uhCbYtYynH30iZErszX78U+nR3pJU3RHGQ57NXy5QupD4SBVwDeU8TNBy+MjMngc1UyIW9noKqsRqfjQTBU2dw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
+      "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.5.tgz",
+      "integrity": "sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.15.2",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
     "node_modules/@floating-ui/core": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
@@ -8768,6 +8982,58 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "license": "MIT"
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
     },
     "node_modules/@img/sharp-darwin-arm64": {
       "version": "0.34.3",
@@ -9331,11 +9597,64 @@
         "js-base64": "^3.7.5"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.10.0"
+      }
+    },
     "node_modules/@next/env": {
       "version": "15.3.5",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-15.3.5.tgz",
       "integrity": "sha512-7g06v8BUVtN2njAX/r8gheoVffhiKFVt4nx74Tt6G4Hqw9HCLYQVx/GkH2qHvPtAHZaUNZ0VXAa0pQP6v1wk7g==",
       "license": "MIT"
+    },
+    "node_modules/@next/eslint-plugin-next": {
+      "version": "15.5.4",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.5.4.tgz",
+      "integrity": "sha512-SR1vhXNNg16T4zffhJ4TS7Xn7eq4NfKfcOsRwea7RIAHrjRpI9ALYbamqIJqkAhowLlERffiwk0FMvTLNdnVtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-glob": "3.3.1"
+      }
+    },
+    "node_modules/@next/eslint-plugin-next/node_modules/fast-glob": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/@next/eslint-plugin-next/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/@next/swc-darwin-arm64": {
       "version": "15.3.5",
@@ -9649,6 +9968,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@nolyfill/is-core-module": {
+      "version": "1.0.39",
+      "resolved": "https://registry.npmjs.org/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz",
+      "integrity": "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.4.0"
       }
     },
     "node_modules/@opennextjs/aws": {
@@ -10921,6 +11250,20 @@
       "peerDependencies": {
         "react": "^18.0 || ^19.0 || ^19.0.0-rc"
       }
+    },
+    "node_modules/@rtsao/scc": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
+      "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rushstack/eslint-patch": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.12.0.tgz",
+      "integrity": "sha512-5EwMtOqvJMMa3HbmxLlF74e+3/HhwBTMcvt3nqVJgGCozO6hzIPOBlwm8mGVNR9SN2IJpxSnlxczyDjcn7qIyw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@selderee/plugin-htmlparser2": {
       "version": "0.11.0",
@@ -12575,6 +12918,38 @@
       "integrity": "sha512-RbwvSJQsuN9TB04AQbGULYfOGE/RnSFk/FLQ5b0NmDf5Kx2q/lABZbHQPKCO1vZ6Fiwkplu+yb9pGdLy1iGseQ==",
       "license": "MIT"
     },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "20.19.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.11.tgz",
@@ -12620,6 +12995,523 @@
       "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
       "license": "MIT"
     },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.44.1.tgz",
+      "integrity": "sha512-molgphGqOBT7t4YKCSkbasmu1tb1MgrZ2szGzHbclF7PNmOkSTQVHy+2jXOSnxvR3+Xe1yySHFZoqMpz3TfQsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.10.0",
+        "@typescript-eslint/scope-manager": "8.44.1",
+        "@typescript-eslint/type-utils": "8.44.1",
+        "@typescript-eslint/utils": "8.44.1",
+        "@typescript-eslint/visitor-keys": "8.44.1",
+        "graphemer": "^1.4.0",
+        "ignore": "^7.0.0",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.44.1",
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.44.1.tgz",
+      "integrity": "sha512-EHrrEsyhOhxYt8MTg4zTF+DJMuNBzWwgvvOYNj/zm1vnaD/IC5zCXFehZv94Piqa2cRFfXrTFxIvO95L7Qc/cw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.44.1",
+        "@typescript-eslint/types": "8.44.1",
+        "@typescript-eslint/typescript-estree": "8.44.1",
+        "@typescript-eslint/visitor-keys": "8.44.1",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.44.1.tgz",
+      "integrity": "sha512-ycSa60eGg8GWAkVsKV4E6Nz33h+HjTXbsDT4FILyL8Obk5/mx4tbvCNsLf9zret3ipSumAOG89UcCs/KRaKYrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.44.1",
+        "@typescript-eslint/types": "^8.44.1",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.44.1.tgz",
+      "integrity": "sha512-NdhWHgmynpSvyhchGLXh+w12OMT308Gm25JoRIyTZqEbApiBiQHD/8xgb6LqCWCFcxFtWwaVdFsLPQI3jvhywg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.44.1",
+        "@typescript-eslint/visitor-keys": "8.44.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.44.1.tgz",
+      "integrity": "sha512-B5OyACouEjuIvof3o86lRMvyDsFwZm+4fBOqFHccIctYgBjqR3qT39FBYGN87khcgf0ExpdCBeGKpKRhSFTjKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.44.1.tgz",
+      "integrity": "sha512-KdEerZqHWXsRNKjF9NYswNISnFzXfXNDfPxoTh7tqohU/PRIbwTmsjGK6V9/RTYWau7NZvfo52lgVk+sJh0K3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.44.1",
+        "@typescript-eslint/typescript-estree": "8.44.1",
+        "@typescript-eslint/utils": "8.44.1",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.44.1.tgz",
+      "integrity": "sha512-Lk7uj7y9uQUOEguiDIDLYLJOrYHQa7oBiURYVFqIpGxclAFQ78f6VUOM8lI2XEuNOKNB7XuvM2+2cMXAoq4ALQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.44.1.tgz",
+      "integrity": "sha512-qnQJ+mVa7szevdEyvfItbO5Vo+GfZ4/GZWWDRRLjrxYPkhM+6zYB2vRYwCsoJLzqFCdZT4mEqyJoyzkunsZ96A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.44.1",
+        "@typescript-eslint/tsconfig-utils": "8.44.1",
+        "@typescript-eslint/types": "8.44.1",
+        "@typescript-eslint/visitor-keys": "8.44.1",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.3.2",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.44.1.tgz",
+      "integrity": "sha512-DpX5Fp6edTlocMCwA+mHY8Mra+pPjRZ0TfHkXI8QFelIKcbADQz1LUPNtzOFUriBB2UYqw4Pi9+xV4w9ZczHFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.7.0",
+        "@typescript-eslint/scope-manager": "8.44.1",
+        "@typescript-eslint/types": "8.44.1",
+        "@typescript-eslint/typescript-estree": "8.44.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.44.1.tgz",
+      "integrity": "sha512-576+u0QD+Jp3tZzvfRfxon0EA2lzcDt3lhUbsC6Lgzy9x2VR4E+JUiNyGHi5T8vk0TV+fpJ5GLG1JsJuWCaKhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.44.1",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-android-arm-eabi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
+      "integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-android-arm64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
+      "integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-arm64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
+      "integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-x64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
+      "integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-freebsd-x64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
+      "integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
+      "integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
+      "integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
+      "integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
+      "integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
+      "integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
+      "integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
+      "integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
+      "integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
+      "integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
+      "integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
+      "integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^0.2.11"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
+      "integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
+      "integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
+      "integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -12657,6 +13549,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/acorn-walk": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
@@ -12677,6 +13579,30 @@
       "engines": {
         "node": ">= 8.0.0"
       }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv/node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
@@ -12745,6 +13671,13 @@
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
       "license": "MIT"
     },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
     "node_modules/aria-hidden": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
@@ -12755,6 +13688,193 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-includes": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
+      "integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.0",
+        "es-object-atoms": "^1.1.1",
+        "get-intrinsic": "^1.3.0",
+        "is-string": "^1.1.1",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.findlast": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
+      "integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.findlastindex": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.6.tgz",
+      "integrity": "sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-shim-unscopables": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flat": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
+      "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flatmap": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
+      "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.tosorted": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
+      "integrity": "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3",
+        "es-errors": "^1.3.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/arraybuffer.prototype.slice": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ast-types-flow": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
+      "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/asynckit": {
@@ -12801,11 +13921,47 @@
         "postcss": "^8.1.0"
       }
     },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/aws4fetch": {
       "version": "1.0.20",
       "resolved": "https://registry.npmjs.org/aws4fetch/-/aws4fetch-1.0.20.tgz",
       "integrity": "sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g==",
       "license": "MIT"
+    },
+    "node_modules/axe-core": {
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.3.tgz",
+      "integrity": "sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -13013,6 +14169,25 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/call-bind": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -13040,6 +14215,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/camelcase-css": {
@@ -13375,6 +14560,13 @@
         "node": ">=16"
       }
     },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/content-disposition": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
@@ -13553,6 +14745,13 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
     },
+    "node_modules/damerau-levenshtein": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
+      "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
@@ -13560,6 +14759,60 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/data-view-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/inspect-js"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/debug": {
@@ -13578,6 +14831,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/deepmerge": {
       "version": "4.3.1",
@@ -13598,6 +14858,42 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/defu": {
@@ -13659,6 +14955,19 @@
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "license": "MIT"
+    },
+    "node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -13970,6 +15279,75 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/es-abstract": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.0.tgz",
+      "integrity": "sha512-WSzPgsdLtTcQwm4CROfS5ju2Wa1QQcVeT37jFjYzdFz1r9ahadC8B8/a4qxJxM+09F18iumCdRmlr96ZYkQvEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.2",
+        "arraybuffer.prototype.slice": "^1.0.4",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-set-tostringtag": "^2.1.0",
+        "es-to-primitive": "^1.3.0",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "get-symbol-description": "^1.1.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.1.0",
+        "is-array-buffer": "^3.0.5",
+        "is-callable": "^1.2.7",
+        "is-data-view": "^1.0.2",
+        "is-negative-zero": "^2.0.3",
+        "is-regex": "^1.2.1",
+        "is-set": "^2.0.3",
+        "is-shared-array-buffer": "^1.0.4",
+        "is-string": "^1.1.1",
+        "is-typed-array": "^1.1.15",
+        "is-weakref": "^1.1.1",
+        "math-intrinsics": "^1.1.0",
+        "object-inspect": "^1.13.4",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
+        "regexp.prototype.flags": "^1.5.4",
+        "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
+        "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
+        "stop-iteration-iterator": "^1.1.0",
+        "string.prototype.trim": "^1.2.10",
+        "string.prototype.trimend": "^1.0.9",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
+        "typed-array-length": "^1.0.7",
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.19"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -13984,6 +15362,34 @@
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-iterator-helpers": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.2.1.tgz",
+      "integrity": "sha512-uDn+FE1yrDzyC0pCo961B2IHbdM8y/ACZsKD4dG6WqrjV53BADjwa7D+1aom2rsNVfLyDgU/eigvlJGJ08OQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.6",
+        "es-errors": "^1.3.0",
+        "es-set-tostringtag": "^2.0.3",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.6",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "iterator.prototype": "^1.1.4",
+        "safe-array-concat": "^1.1.3"
+      },
       "engines": {
         "node": ">= 0.4"
       }
@@ -14013,6 +15419,37 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-shim-unscopables": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
+      "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
+      "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7",
+        "is-date-object": "^1.0.5",
+        "is-symbol": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/esbuild": {
@@ -14082,6 +15519,594 @@
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.36.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.36.0.tgz",
+      "integrity": "sha512-hB4FIzXovouYzwzECDcUkJ4OcfOEkXTv2zRY6B9bkwjx/cprAq0uvm1nl7zvQ0/TsUk0zQiN4uPfJpB9m+rPMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.0",
+        "@eslint/config-helpers": "^0.3.1",
+        "@eslint/core": "^0.15.2",
+        "@eslint/eslintrc": "^3.3.1",
+        "@eslint/js": "9.36.0",
+        "@eslint/plugin-kit": "^0.3.5",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "@types/json-schema": "^7.0.15",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-next": {
+      "version": "15.5.4",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-15.5.4.tgz",
+      "integrity": "sha512-BzgVVuT3kfJes8i2GHenC1SRJ+W3BTML11lAOYFOOPzrk2xp66jBOAGEFRw+3LkYCln5UzvFsLhojrshb5Zfaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@next/eslint-plugin-next": "15.5.4",
+        "@rushstack/eslint-patch": "^1.10.3",
+        "@typescript-eslint/eslint-plugin": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
+        "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
+        "eslint-import-resolver-node": "^0.3.6",
+        "eslint-import-resolver-typescript": "^3.5.2",
+        "eslint-plugin-import": "^2.31.0",
+        "eslint-plugin-jsx-a11y": "^6.10.0",
+        "eslint-plugin-react": "^7.37.0",
+        "eslint-plugin-react-hooks": "^5.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^7.23.0 || ^8.0.0 || ^9.0.0",
+        "typescript": ">=3.3.1"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-import-resolver-node": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
+      "integrity": "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7",
+        "is-core-module": "^2.13.0",
+        "resolve": "^1.22.4"
+      }
+    },
+    "node_modules/eslint-import-resolver-node/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-import-resolver-typescript": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.10.1.tgz",
+      "integrity": "sha512-A1rHYb06zjMGAxdLSkN2fXPBwuSaQ0iO5M/hdyS0Ajj1VBaRp0sPD3dn1FhME3c/JluGFbwSxyCfqdSbtQLAHQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@nolyfill/is-core-module": "1.0.39",
+        "debug": "^4.4.0",
+        "get-tsconfig": "^4.10.0",
+        "is-bun-module": "^2.0.0",
+        "stable-hash": "^0.0.5",
+        "tinyglobby": "^0.2.13",
+        "unrs-resolver": "^1.6.2"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-import-resolver-typescript"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "eslint-plugin-import": "*",
+        "eslint-plugin-import-x": "*"
+      },
+      "peerDependenciesMeta": {
+        "eslint-plugin-import": {
+          "optional": true
+        },
+        "eslint-plugin-import-x": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-module-utils": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.1.tgz",
+      "integrity": "sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-import": {
+      "version": "2.32.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
+      "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rtsao/scc": "^1.1.0",
+        "array-includes": "^3.1.9",
+        "array.prototype.findlastindex": "^1.2.6",
+        "array.prototype.flat": "^1.3.3",
+        "array.prototype.flatmap": "^1.3.3",
+        "debug": "^3.2.7",
+        "doctrine": "^2.1.0",
+        "eslint-import-resolver-node": "^0.3.9",
+        "eslint-module-utils": "^2.12.1",
+        "hasown": "^2.0.2",
+        "is-core-module": "^2.16.1",
+        "is-glob": "^4.0.3",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "object.groupby": "^1.0.3",
+        "object.values": "^1.2.1",
+        "semver": "^6.3.1",
+        "string.prototype.trimend": "^1.0.9",
+        "tsconfig-paths": "^3.15.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y": {
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz",
+      "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aria-query": "^5.3.2",
+        "array-includes": "^3.1.8",
+        "array.prototype.flatmap": "^1.3.2",
+        "ast-types-flow": "^0.0.8",
+        "axe-core": "^4.10.0",
+        "axobject-query": "^4.1.0",
+        "damerau-levenshtein": "^1.0.8",
+        "emoji-regex": "^9.2.2",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^3.3.5",
+        "language-tags": "^1.0.9",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "safe-regex-test": "^1.0.3",
+        "string.prototype.includes": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/eslint-plugin-react": {
+      "version": "7.37.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
+      "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.8",
+        "array.prototype.findlast": "^1.2.5",
+        "array.prototype.flatmap": "^1.3.3",
+        "array.prototype.tosorted": "^1.1.4",
+        "doctrine": "^2.1.0",
+        "es-iterator-helpers": "^1.2.1",
+        "estraverse": "^5.3.0",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+        "minimatch": "^3.1.2",
+        "object.entries": "^1.1.9",
+        "object.fromentries": "^2.0.8",
+        "object.values": "^1.2.1",
+        "prop-types": "^15.8.1",
+        "resolve": "^2.0.0-next.5",
+        "semver": "^6.3.1",
+        "string.prototype.matchall": "^4.0.12",
+        "string.prototype.repeat": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz",
+      "integrity": "sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/resolve": {
+      "version": "2.0.0-next.5",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
+      "integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.13.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/eslint/node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/eslint/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/etag": {
       "version": "1.8.1",
@@ -14251,6 +16276,20 @@
         "node": ">= 6"
       }
     },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-sha256": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
@@ -14337,6 +16376,19 @@
         "node": ">= 8"
       }
     },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -14364,6 +16416,60 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/foreground-child": {
@@ -14537,6 +16643,37 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/function.prototype.name": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
+      "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "functions-have-names": "^1.2.3",
+        "hasown": "^2.0.2",
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -14616,6 +16753,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/get-symbol-description": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/get-tsconfig": {
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
@@ -14670,6 +16825,36 @@
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -14688,6 +16873,13 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
     },
+    "node_modules/graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/gzip-size": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
@@ -14703,6 +16895,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -14710,6 +16915,35 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-symbols": {
@@ -14861,11 +17095,53 @@
         "node": ">= 4"
       }
     },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -14876,11 +17152,65 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
       "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
       "license": "MIT"
+    },
+    "node_modules/is-async-function": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+      "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-function": "^1.0.0",
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -14892,6 +17222,46 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bun-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-2.0.0.tgz",
+      "integrity": "sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.7.1"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-core-module": {
@@ -14909,6 +17279,41 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-data-view": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -14918,6 +17323,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-finalizationregistry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -14925,6 +17346,25 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
+      "integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.0",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-glob": {
@@ -14951,6 +17391,32 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -14960,11 +17426,76 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
@@ -14976,6 +17507,57 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-unicode-supported": {
@@ -14990,6 +17572,59 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
@@ -14997,6 +17632,24 @@
       "license": "ISC",
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/iterator.prototype": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
+      "integrity": "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "get-proto": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/jackspeak": {
@@ -15045,6 +17698,53 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
     },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
     "node_modules/jsonfile": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
@@ -15057,6 +17757,32 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jsx-ast-utils": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
+      "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.6",
+        "array.prototype.flat": "^1.3.1",
+        "object.assign": "^4.1.4",
+        "object.values": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -15066,6 +17792,26 @@
         "node": ">=6"
       }
     },
+    "node_modules/language-subtag-registry": {
+      "version": "0.3.23",
+      "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
+      "integrity": "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/language-tags": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.9.tgz",
+      "integrity": "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "language-subtag-registry": "^0.3.20"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/leac": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/leac/-/leac-0.6.0.tgz",
@@ -15073,6 +17819,20 @@
       "license": "MIT",
       "funding": {
         "url": "https://ko-fi.com/killymxi"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/lilconfig": {
@@ -15092,6 +17852,22 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/lodash.castarray": {
       "version": "4.4.0",
@@ -15776,6 +18552,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/minipass": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
@@ -15840,6 +18626,29 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/napi-postinstall": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.3.tgz",
+      "integrity": "sha512-uTp172LLXSxuSYHv/kou+f6KW3SMppU9ivthaVTXian9sOt3XM/zHYHpRZiLgQoxeWfYUnslNWQHF1+G71xcow==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "napi-postinstall": "lib/cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/napi-postinstall"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/negotiator": {
       "version": "1.0.0",
@@ -16050,6 +18859,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/object-treeify": {
       "version": "1.1.33",
       "resolved": "https://registry.npmjs.org/object-treeify/-/object-treeify-1.1.33.tgz",
@@ -16057,6 +18876,96 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.entries": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.9.tgz",
+      "integrity": "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.fromentries": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
+      "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.groupby": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.3.tgz",
+      "integrity": "sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.values": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
+      "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/obliterator": {
@@ -16105,6 +19014,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/ora": {
@@ -16157,11 +19084,74 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/own-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.2.6",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/parseley": {
       "version": "0.12.1",
@@ -16183,6 +19173,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-key": {
@@ -16271,6 +19271,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/postcss": {
@@ -16387,6 +19397,16 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
     },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/prettier": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
@@ -16446,6 +19466,16 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/qs": {
@@ -16668,6 +19698,50 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/reflect.getprototypeof": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
+        "which-builtin-type": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/resend": {
       "version": "4.8.0",
       "resolved": "https://registry.npmjs.org/resend/-/resend-4.8.0.tgz",
@@ -16716,6 +19790,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/resolve-pkg-maps": {
@@ -16802,6 +19886,26 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-array-concat": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
+      "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "has-symbols": "^1.1.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -16821,6 +19925,41 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/safe-push-apply": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -16900,6 +20039,55 @@
       "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
       "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
       "license": "MIT"
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-proto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -17102,6 +20290,13 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/stable-hash": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
+      "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/standardwebhooks": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
@@ -17140,6 +20335,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/stoppable": {
@@ -17234,6 +20443,119 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/string.prototype.includes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
+      "integrity": "sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/string.prototype.matchall": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
+      "integrity": "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.6",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "regexp.prototype.flags": "^1.5.3",
+        "set-function-name": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.repeat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
+      "integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
+      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-data-property": "^1.1.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-object-atoms": "^1.0.0",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
+      "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -17259,6 +20581,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/strip-final-newline": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
@@ -17266,6 +20598,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/stripe": {
@@ -17590,6 +20935,23 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -17617,6 +20979,19 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
+      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -17628,6 +21003,19 @@
       "resolved": "https://registry.npmjs.org/ts-tqdm/-/ts-tqdm-0.8.6.tgz",
       "integrity": "sha512-3X3M1PZcHtgQbnwizL+xU8CAgbYbeLHrrDwL9xxcZZrV5J+e7loJm1XrXozHjSkl44J0Zg0SgA8rXbh83kCkcQ==",
       "license": "MIT"
+    },
+    "node_modules/tsconfig-paths": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
+      "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      }
     },
     "node_modules/tslib": {
       "version": "2.8.1",
@@ -17665,6 +21053,19 @@
         "url": "https://github.com/sponsors/Wombosvideo"
       }
     },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/type-is": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
@@ -17677,6 +21078,84 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typed-array-byte-length": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-byte-offset": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "reflect.getprototypeof": "^1.0.9"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-length": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
+      "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "is-typed-array": "^1.1.13",
+        "possible-typed-array-names": "^1.0.0",
+        "reflect.getprototypeof": "^1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/typescript": {
@@ -17698,6 +21177,25 @@
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
       "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
       "license": "MIT"
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/undici": {
       "version": "7.15.0",
@@ -17745,6 +21243,41 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/unrs-resolver": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
+      "integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "napi-postinstall": "^0.3.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unrs-resolver"
+      },
+      "optionalDependencies": {
+        "@unrs/resolver-binding-android-arm-eabi": "1.11.1",
+        "@unrs/resolver-binding-android-arm64": "1.11.1",
+        "@unrs/resolver-binding-darwin-arm64": "1.11.1",
+        "@unrs/resolver-binding-darwin-x64": "1.11.1",
+        "@unrs/resolver-binding-freebsd-x64": "1.11.1",
+        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1",
+        "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1",
+        "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-arm64-musl": "1.11.1",
+        "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1",
+        "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-x64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-x64-musl": "1.11.1",
+        "@unrs/resolver-binding-wasm32-wasi": "1.11.1",
+        "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
+        "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
+        "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
@@ -17774,6 +21307,16 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/urlpattern-polyfill": {
@@ -17924,6 +21467,105 @@
       },
       "engines": {
         "node": "^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "function.prototype.name": "^1.1.6",
+        "has-tostringtag": "^1.0.2",
+        "is-async-function": "^2.0.0",
+        "is-date-object": "^1.1.0",
+        "is-finalizationregistry": "^1.1.0",
+        "is-generator-function": "^1.0.10",
+        "is-regex": "^1.2.1",
+        "is-weakref": "^1.0.2",
+        "isarray": "^2.0.5",
+        "which-boxed-primitive": "^1.1.0",
+        "which-collection": "^1.0.2",
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
+      "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/workerd": {
@@ -18199,6 +21841,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/youch": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,8 @@
     "@types/react-dom": "^19",
     "autoprefixer": "^10.4.21",
     "drizzle-kit": "^0.31.4",
+    "eslint": "^9.36.0",
+    "eslint-config-next": "^15.5.4",
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.1",
     "tsx": "^4.20.3",


### PR DESCRIPTION
## Summary
- build an admin reviews dashboard with filters, moderation actions, and reminder management for unattended feedback
- expose admin review APIs plus model helpers that drive publishing, responses, notifications, and reminder logging
- extend the review schema/types with reminder tracking, email notifications, and align the roadmap/docs with the finished feature set

## Testing
- npm run lint *(fails: Next.js lint prompts for interactive configuration in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6c8f020f083218bf4ef5795deef00