### PR TITLE
Establish Mercora project foundation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,53 +1,39 @@
 name: CI
+
 on:
   push:
     branches: [main]
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
-  lint-boundaries:
-    name: Domain Boundary Lint
+  validate:
+    name: Lint, Typecheck, Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'npm'
-      - run: npm ci
-      - run: npm run lint:boundaries
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-  unit-parity:
-    name: Unit + Parity Tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
-      - run: npm ci
-      - run: npx vitest run --reporter=verbose --exclude 'src/eval/**'
+          node-version: "20"
+          cache: npm
 
-  playwright:
-    name: Playwright Regression
-    needs: [unit-parity]
-    runs-on: ubuntu-latest
-    env:
-      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'npm'
-      - run: npm ci
-      - run: npx playwright install --with-deps chromium
-      - run: npx playwright test
-      - uses: actions/upload-artifact@v4
-        if: ${{ !cancelled() }}
-        with:
-          name: playwright-report
-          path: test-results/
-          retention-days: 14
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Build
+        run: npm run build
+        env:
+          NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: pk_test_placeholder
+          NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: pk_test_placeholder

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+# Contributing to Mercora
+
+Thank you for helping improve Mercora. Contributions that make the platform
+safer, more reusable, easier to operate, or useful to a broader range of
+merchants are welcome.
+
+## Before You Start
+
+- Open an issue before beginning a large feature or architectural change.
+- Keep pull requests focused on one coherent capability or invariant.
+- Do not include merchant-specific content, credentials, customer data, or
+  production infrastructure identifiers.
+- Report security vulnerabilities privately as described in
+  [SECURITY.md](SECURITY.md).
+
+## Development Workflow
+
+1. Create a topic branch from the latest `main`.
+2. Install dependencies with `npm ci`.
+3. Make the smallest complete change that addresses the issue.
+4. Add or update tests when test coverage exists for the affected behavior.
+5. Update relevant documentation and database migrations.
+6. Run the available validation commands:
+
+   ```bash
+   npm run lint
+   npm run typecheck
+   npm run build
+   ```
+
+7. Open a pull request explaining what changed, why it changed, and how it was
+   verified.
+
+## Pull Request Expectations
+
+A pull request should:
+
+- Preserve Mercora's merchant-neutral configuration and default demo behavior.
+- Describe deployment, environment, or migration impact.
+- Avoid mixing unrelated refactors with functional changes.
+- Pass the repository's required CI checks.
+
+## License
+
+By contributing to Mercora, you agree that your contributions will be licensed
+under the project's [MIT License](LICENSE).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025-present Russell K. Moore and Mercora contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,28 @@
+# Security Policy
+
+## Supported Versions
+
+Mercora is under active development. Security fixes are applied to the latest
+commit on the `main` branch. Older commits and deployments may not receive
+backported fixes.
+
+## Reporting a Vulnerability
+
+Do not open a public issue for a suspected vulnerability.
+
+Use GitHub's private vulnerability reporting feature for this repository when
+it is available. If it is not available, contact the repository maintainers
+privately through their GitHub profiles and request a private reporting
+channel before sharing sensitive details.
+
+Include, when possible:
+
+- The affected route, component, or feature
+- The conditions required to reproduce the issue
+- The potential security impact
+- A minimal proof of concept or failing test
+- Any suggested remediation
+
+The maintainers will acknowledge the report, assess severity, coordinate a
+fix, and credit the reporter unless anonymity is requested. Please allow time
+for a fix to be prepared and released before public disclosure.

--- a/next.config.ts
+++ b/next.config.ts
@@ -93,4 +93,6 @@ export default nextConfig;
 
 // added by create cloudflare to enable calling `getCloudflareContext()` in `next dev`
 import { initOpenNextCloudflareForDev } from "@opennextjs/cloudflare";
-initOpenNextCloudflareForDev();
+if (process.env.NODE_ENV === "development") {
+  initOpenNextCloudflareForDev();
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "mercora",
       "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
         "@clerk/nextjs": "^6.25.5",
         "@clerk/themes": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,14 @@
 {
   "name": "mercora",
   "version": "0.1.0",
+  "license": "MIT",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "typecheck": "tsc --noEmit",
     "deploy": "rm -rf .next .open-next .wrangler/state .wrangler/public && opennextjs-cloudflare build && opennextjs-cloudflare deploy",
     "clean": "rm -rf .open-next .next .wrangler/state .wrangler/public",
     "preview": "opennextjs-cloudflare build && opennextjs-cloudflare preview",


### PR DESCRIPTION
## Summary

- replace CI jobs that referenced missing scripts, test dependencies, and test files with a working lint, typecheck, and production-build gate
- guard the OpenNext Cloudflare development initializer so non-development commands do not attempt to start the development proxy
- formalize Mercora's existing MIT license declaration in repository and package metadata
- add contribution guidelines and a private security-reporting policy

## Why

The existing workflow could not run successfully from the checked-in project because it invoked `lint:boundaries`, Vitest, and Playwright without their corresponding scripts, dependencies, configuration, or tests. The repository also declared MIT licensing in the README but did not include the referenced license file.

This establishes a green, reproducible foundation for the upcoming testing, security, and platform-extensibility contributions.

## Impact

- Pull requests and pushes to `main` are checked with the commands the repository currently supports.
- Contributors have explicit workflow, licensing, and security-reporting guidance.
- Runtime application behavior is unchanged; the OpenNext initializer still runs during local development.

## Validation

- `npm ci`
- `npm run lint`
- `npm run typecheck`
- `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_placeholder NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_placeholder npm run build`
