### PR TITLE
Fix runtime configuration review issues

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -92,6 +92,7 @@ export function generateMetadata(): Metadata {
       "mcp-schema": "/api/mcp/schema",
       "mcp-capabilities": config.mcp.capabilities,
       "mcp-version": "1.0.0",
+      "mcp-description": config.mcp.description,
     },
   };
 }
@@ -123,15 +124,7 @@ export default function RootLayout({
     >
       <html lang="en" suppressHydrationWarning>
         <head>
-          {/* MCP Server Discovery Meta Tags */}
-          <meta name="mcp-server" content="/api/mcp" />
-          <meta name="mcp-schema" content="/api/mcp/schema" />
-          <meta name="mcp-capabilities" content={config.mcp.capabilities} />
-          <meta name="mcp-version" content="1.0.0" />
-          <meta name="mcp-description" content={config.mcp.description} />
-          <meta name="viewport" content="width=device-width, initial-scale=1" />
-
-          {/* Additional MCP Discovery */}
+          {/* MCP discovery links complement the metadata emitted by generateMetadata. */}
           <link rel="mcp-server" href="/api/mcp" type="application/json" />
           <link rel="mcp-schema" href="/api/mcp/schema" type="application/json" />
         </head>

--- a/image-loader.ts
+++ b/image-loader.ts
@@ -90,7 +90,9 @@ export default function cloudflareLoader({
   const key = toObjectKey(src, cdn);
   if (key === null) return src;
   if (!cdn) return `/media/${key}`;
-  if (process.env.NEXT_PUBLIC_IMAGE_TRANSFORMS === "false") return `${cdn}/${key}`;
+  const transformsEnabled =
+    process.env.NEXT_PUBLIC_IMAGE_TRANSFORMS?.trim().toLowerCase() !== "false";
+  if (!transformsEnabled) return `${cdn}/${key}`;
 
   const params = [`width=${width}`, "format=auto"];
   if (quality) params.push(`quality=${quality}`);

--- a/scripts/d1-migrate.mjs
+++ b/scripts/d1-migrate.mjs
@@ -13,12 +13,12 @@ import {
   migrationArgs,
   parseWranglerConfig,
   resolveTarget,
+  valueAfter,
 } from "./lib/d1-migrate-plan.mjs";
 
 const args = process.argv.slice(2);
-const valueAfter = (flag) => args[args.indexOf(flag) + 1];
-const target = valueAfter("--target");
-const selectedEnvironment = args.includes("--env") ? valueAfter("--env") : undefined;
+const target = valueAfter(args, "--target");
+const selectedEnvironment = valueAfter(args, "--env");
 const apply = args.includes("--apply");
 
 if (!target || (args.includes("--env") && !selectedEnvironment)) {

--- a/scripts/lib/d1-migrate-plan.mjs
+++ b/scripts/lib/d1-migrate-plan.mjs
@@ -44,11 +44,43 @@ export function stripJsonComments(text) {
       output += current;
     }
   }
-  return output.replace(/,(\s*[}\]])/g, "$1");
+  let result = "";
+  inString = false;
+  escaped = false;
+
+  for (let index = 0; index < output.length; index += 1) {
+    const current = output[index];
+    if (inString) {
+      result += current;
+      if (escaped) escaped = false;
+      else if (current === "\\") escaped = true;
+      else if (current === '"') inString = false;
+      continue;
+    }
+    if (current === '"') {
+      inString = true;
+      result += current;
+      continue;
+    }
+    if (current === ",") {
+      let next = index + 1;
+      while (/\s/.test(output[next] ?? "")) next += 1;
+      if (output[next] === "}" || output[next] === "]") continue;
+    }
+    result += current;
+  }
+
+  return result;
 }
 
 export function parseWranglerConfig(text) {
   return JSON.parse(stripJsonComments(text));
+}
+
+export function valueAfter(args, flag) {
+  const index = args.indexOf(flag);
+  const value = index === -1 ? undefined : args[index + 1];
+  return value?.startsWith("--") ? undefined : value;
 }
 
 function databaseFor(config, environment) {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,7 @@
 import type { Config } from "tailwindcss";
-import { storeDefaults } from "./lib/store-config";
+
+const runtimeColor = (variable: string) =>
+  `rgb(from var(${variable}) r g b / <alpha-value>)`;
 
 const config: Config = {
   content: [
@@ -16,9 +18,9 @@ const config: Config = {
           foreground: "var(--store-foreground)",
           "muted-foreground": "var(--store-muted-foreground)",
         },
-        primary: storeDefaults.theme.primary,
-        background: "#000000",
-        foreground: "#ffffff",
+        primary: runtimeColor("--store-primary"),
+        background: runtimeColor("--store-surface"),
+        foreground: runtimeColor("--store-foreground"),
         border: "#2a2a2a",
         ring: "#333333",
       },

--- a/tests/unit/image-loader.test.ts
+++ b/tests/unit/image-loader.test.ts
@@ -23,6 +23,14 @@ describe("cloudflareLoader", () => {
     expect(cloudflareLoader(args)).toBe("https://images.example.test/products/example.png");
   });
 
+  it("normalizes the Image Transformations feature flag", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("NEXT_PUBLIC_IMAGE_CDN", "https://images.example.test");
+    vi.stubEnv("NEXT_PUBLIC_IMAGE_TRANSFORMS", " FALSE ");
+
+    expect(cloudflareLoader(args)).toBe("https://images.example.test/products/example.png");
+  });
+
   it("never rewrites an unrelated external image", () => {
     vi.stubEnv("NODE_ENV", "production");
     vi.stubEnv("NEXT_PUBLIC_IMAGE_CDN", "https://images.example.test");

--- a/tests/unit/scripts/d1-migrate-plan.test.ts
+++ b/tests/unit/scripts/d1-migrate-plan.test.ts
@@ -5,6 +5,7 @@ import {
   migrationArgs,
   parseWranglerConfig,
   resolveTarget,
+  valueAfter,
 } from "@/scripts/lib/d1-migrate-plan.mjs";
 
 const config = parseWranglerConfig(`{
@@ -13,6 +14,29 @@ const config = parseWranglerConfig(`{
 }`);
 
 describe("D1 migration plans", () => {
+  it("does not treat a positional argument as the value of a missing flag", () => {
+    expect(valueAfter(["local", "--apply"], "--target")).toBeUndefined();
+    expect(valueAfter(["--target"], "--target")).toBeUndefined();
+    expect(valueAfter(["--target", "--apply"], "--target")).toBeUndefined();
+    expect(valueAfter(["--target", "preview"], "--target")).toBe("preview");
+  });
+
+  it("preserves string contents while removing JSONC trailing commas", () => {
+    expect(
+      parseWranglerConfig(`{
+        "objectText": "keep,}",
+        "arrayText": "keep,]",
+        "nested": { "enabled": true, },
+        "items": ["one",],
+      }`),
+    ).toEqual({
+      objectText: "keep,}",
+      arrayText: "keep,]",
+      nested: { enabled: true },
+      items: ["one"],
+    });
+  });
+
   it("sends preview work to the preview database, never production", () => {
     const preview = resolveTarget(config, { target: "preview", environment: undefined });
     expect(migrationArgs(preview, "apply")).toContain("--preview");

--- a/tests/unit/tailwind-config.test.ts
+++ b/tests/unit/tailwind-config.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import config from "@/tailwind.config";
+
+describe("Tailwind runtime theme tokens", () => {
+  it("maps shared component colors to request-time store variables", () => {
+    const colors = config.theme?.extend?.colors as unknown as Record<string, string>;
+
+    expect(colors.primary).toBe("rgb(from var(--store-primary) r g b / <alpha-value>)");
+    expect(colors.background).toBe("rgb(from var(--store-surface) r g b / <alpha-value>)");
+    expect(colors.foreground).toBe("rgb(from var(--store-foreground) r g b / <alpha-value>)");
+  });
+});


### PR DESCRIPTION
## Summary

Addresses the five valid review findings that were left on PR #23 after it merged:

- normalize the image transformation feature flag before comparison
- emit MCP and viewport metadata from a single Next.js metadata source
- reject missing or valueless D1 migration CLI flags
- remove JSONC trailing commas without modifying string contents
- map shared Tailwind theme tokens to request-time store CSS variables while preserving opacity variants

## Why

PR #23 merged before its automated review comments were addressed. The original implementations could misread CLI arguments, corrupt JSONC string values in an edge case, emit duplicate metadata, ignore runtime theme overrides, and handle equivalent boolean values inconsistently.

## Impact

Runtime configuration behaves consistently, migration command validation fails closed, metadata is deduplicated, and shadcn/Tailwind components now honor request-time store colors. Regression tests cover the corrected behavior.

## Validation

- `npm test` — 9 files, 32 tests
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `git diff --check`
- verified Tailwind generation for `hover:bg-primary/90`
