### PR TITLE
fix: restore image CDN (broken product/hero images)

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -67,7 +67,8 @@
    */
   "vars": {
     "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY": "pk_test_bGVhcm5pbmctbGlnZXItMTAuY2xlcmsuYWNjb3VudHMuZGV2JA",
-    "NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY": "pk_test_51Rwyc6LL7e1EcFUl2kqrcgWa8KDNzC9m4lc38wQQKiKVmekTxi3q6R6R2nohizFzRNNw9bHTeN8mripgZzgUYUDd00nlOhCWEs"
+    "NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY": "pk_test_51Rwyc6LL7e1EcFUl2kqrcgWa8KDNzC9m4lc38wQQKiKVmekTxi3q6R6R2nohizFzRNNw9bHTeN8mripgZzgUYUDd00nlOhCWEs",
+    "NEXT_PUBLIC_IMAGE_CDN": "https://voltique-images.russellkmoore.me"
   },
   /**
    * Note: Use secrets to store sensitive data.


### PR DESCRIPTION
## Problem

All product and hero images 404 on the live site (`voltique.russellkmoore.me`), rendering broken-image placeholders.

## Root cause

Commit `0bf91a8` refactored [image-loader.ts](image-loader.ts) from a **hardcoded** `https://voltique-images.russellkmoore.me` CDN to reading the `NEXT_PUBLIC_IMAGE_CDN` env var, with a `/media/<key>` fallback when it's unset. That variable was **never added to `wrangler.jsonc`**, so production emitted `/media/products/*.png` URLs — and there is no `/media/` route to serve them from the R2 `MEDIA` bucket, so they return 404.

The site kept working on its previous deployment until an unrelated merge triggered a fresh Workers Build that shipped `0bf91a8`, surfacing the latent misconfiguration.

## Fix

Add `NEXT_PUBLIC_IMAGE_CDN=https://voltique-images.russellkmoore.me` to `wrangler.jsonc` `vars`, mirroring the existing `NEXT_PUBLIC_CLERK_*` / `NEXT_PUBLIC_STRIPE_*` vars (which confirm build-time inlining works). The loader then emits:

```
https://voltique-images.russellkmoore.me/cdn-cgi/image/width=…,format=auto/<key>
```

## Verification

- `GET /media/products/vivid-mission-pack-0.png` → **404** (current, broken)
- `GET …/cdn-cgi/image/width=640,format=auto/products/vivid-mission-pack-0.png` → **200** image/jpeg (restored URL)

Takes effect on deploy (`NEXT_PUBLIC_*` inlined at build time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)