### PR TITLE
fix: restore category hero background image (Tailwind v4 overlay)

### DIFF
--- a/app/category/[slug]/page.tsx
+++ b/app/category/[slug]/page.tsx
@@ -120,7 +120,7 @@ export default async function CategoryPage({ params }: any) {
             sizes="(min-width: 1024px) 100vw, 100vw"
             priority={true}
           />
-          <div className="absolute inset-0 bg-black bg-opacity-40 flex items-end">
+          <div className="absolute inset-0 bg-black/40 flex items-end">
             <div className="p-6 sm:p-8 text-white">
               <h1 className="text-3xl sm:text-4xl lg:text-5xl font-bold mb-2">
                 {typeof category.name === 'string' ? category.name : (category.name?.en || 'Category')}


### PR DESCRIPTION
## Problem

Category pages show no hero background image — just the title on a black block.

## Root cause

The hero image (`next/image`) loads fine, but it sits behind an overlay div:

```jsx
<div className="absolute inset-0 bg-black bg-opacity-40 flex items-end">
```

The Tailwind v4 upgrade codemod (#19) **did not process** `app/category/[slug]/page.tsx`, so it kept the v3-only utility `bg-opacity-40`. Tailwind v4 **removed** `*-opacity-*` utilities (replaced by the `/40` opacity modifier). In v4 `bg-opacity-40` is a no-op, so `bg-black` renders **fully opaque** and completely covers the hero image.

## Fix

`bg-black bg-opacity-40` → `bg-black/40` (v4 syntax), restoring the intended 40% overlay so the image shows through.

Verified this was the **only** remaining deprecated `*-opacity-*` utility across `app/` and `components/` (and no other v4-renamed classes like `bg-gradient-to-*` remain unconverted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)