### PR TITLE
fix(admin-bi): faster Refresh — regenerate only the current range

### DIFF
--- a/app/api/admin/analytics/refresh/route.ts
+++ b/app/api/admin/analytics/refresh/route.ts
@@ -1,15 +1,15 @@
 /**
  * === Admin Analytics Refresh ===
  *
- * Manually regenerates the Admin BI dashboard payload for all time ranges and
- * upserts them into the D1 `analytics_cache` table. This runs the exact same
- * generator (`regenerateAnalytics`) that the scheduled cron handler uses, so
- * the "Refresh" button and the cron produce identical output.
+ * Manually regenerates the Admin BI dashboard payload for the requested time
+ * range and upserts it into the D1 `analytics_cache` table. This runs the same
+ * generator (`regenerateAnalytics`) the scheduled cron uses, but for a single
+ * range so the button stays responsive (one Workers AI call, not three). The
+ * 6-hour cron keeps all ranges fresh.
  *
  * POST /api/admin/analytics/refresh
- *   Body (optional): { "range": "7d" | "30d" | "90d" }
- *     - If omitted, all ranges are regenerated.
- *   Returns the fresh payload for the requested range (or "30d" by default).
+ *   Body (optional): { "range": "7d" | "30d" | "90d" }  (defaults to "30d")
+ *   Returns the fresh payload for that range.
  */
 
 import { NextRequest, NextResponse } from "next/server";
@@ -18,7 +18,6 @@ import { checkAdminPermissions } from "@/lib/auth/admin-middleware";
 import {
   regenerateAnalytics,
   isAnalyticsRange,
-  ANALYTICS_RANGES,
   type AnalyticsRange,
 } from "@/lib/analytics/generate-insights";
 
@@ -32,9 +31,10 @@ export async function POST(req: NextRequest) {
     const body = (await req.json().catch(() => ({}))) as { range?: string };
     const requested: AnalyticsRange = isAnalyticsRange(body.range) ? body.range : "30d";
 
-    // Regenerate everything so cron and manual refresh keep all ranges in sync.
+    // Regenerate only the currently-viewed range for a responsive button
+    // (one AI call, not three). The 6-hour cron keeps all ranges fresh.
     const { env } = await getCloudflareContext({ async: true });
-    const payloads = await regenerateAnalytics(env as CloudflareEnv, ANALYTICS_RANGES);
+    const payloads = await regenerateAnalytics(env as CloudflareEnv, [requested]);
     const generatedAt = new Date().toISOString();
 
     return NextResponse.json({


### PR DESCRIPTION
## Problem

The Admin BI **Refresh** button took >1 minute to update the UI. It awaited regeneration of **all three ranges** (7d/30d/90d) — three sequential Workers AI calls — before the dashboard reflected the result. (No page reload involved; the button's request was just blocking on all that work.)

## Fix

The manual refresh now regenerates **only the currently-viewed range** (one AI call, ~3× faster). The **6-hour cron** still regenerates all three ranges, so the others stay fresh in the background.

- `POST /api/admin/analytics/refresh` → `regenerateAnalytics(env, [requested])` instead of all ranges.
- No client changes needed (it already sends `{ range: timeRange }` and applies the returned payload).

Typecheck ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)