### PR TITLE
Harden webhooks, inventory, and refund correctness (U09)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,5 +18,5 @@ STRIPE_WEBHOOK_SECRET=whsec_your_webhook_secret_here
 # 2. Sign up for a Stripe account at https://stripe.com
 # 3. Go to your Stripe Dashboard
 # 4. Copy your test API keys (use test keys for development)
-# 5. Set up a webhook endpoint pointing to: https://yourdomain.com/api/stripe/webhooks
+# 5. Set up a webhook endpoint pointing to: https://yourdomain.com/api/webhooks/stripe
 # 6. Copy the webhook signing secret

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Test
         run: npm test
 
+      - name: Test Workers integration
+        run: npm run test:workers
+
       - name: Build
         run: npm run build
         env:

--- a/app/admin/orders/[id]/page.tsx
+++ b/app/admin/orders/[id]/page.tsx
@@ -56,6 +56,7 @@ interface Order {
     country?: string;
   };
   items: Array<{
+    id?: string;
     product_id: string;
     variant_id?: string;
     product_name: string;
@@ -248,6 +249,15 @@ export default function OrderDetailPage() {
         alert('No items selected or invalid refund amount');
         return;
       }
+      if (
+        returnCalculation.allocationMethod === 'legacy_proportional' &&
+        !window.confirm(
+          'This legacy order has no exact per-line tax and discount snapshot. ' +
+          'The partial refund is a proportional estimate. Confirm the amount before continuing.'
+        )
+      ) {
+        return;
+      }
 
       const response = await fetch('/api/orders/refund', {
         method: 'POST',
@@ -297,6 +307,7 @@ export default function OrderDetailPage() {
       restockingFee: 0,
       baseAmount: 0,
       total: 0,
+      allocationMethod: 'legacy_proportional' as const,
       policy: {
         shippingRefunded: false,
         restockingFeeApplied: false,
@@ -306,8 +317,7 @@ export default function OrderDetailPage() {
     return calculatePartialReturnMinor(order, selectedItemIds, refundPolicy);
   };
 
-  const toggleItemSelection = (productId: string, variantId?: string) => {
-    const itemKey = `${productId}-${variantId || 'default'}`;
+  const toggleItemSelection = (itemKey: string) => {
     setSelectedItems(prev => {
       const newSet = new Set(prev);
       if (newSet.has(itemKey)) {
@@ -320,7 +330,9 @@ export default function OrderDetailPage() {
   };
 
   const selectAllItems = () => {
-    setSelectedItems(new Set(order?.items.map(item => `${item.product_id}-${item.variant_id || 'default'}`) || []));
+    setSelectedItems(new Set(order?.items.map(item =>
+      item.id ?? `${item.product_id}-${item.variant_id || 'default'}`
+    ) || []));
   };
 
   const clearItemSelection = () => {
@@ -568,8 +580,8 @@ export default function OrderDetailPage() {
       <Card className="bg-neutral-800 border-neutral-700 p-6">
         <h3 className="text-lg font-semibold text-white mb-4">Order Items</h3>
         <div className="space-y-3">
-          {order.items.map((item, index) => {
-            const itemKey = `${item.product_id}-${item.variant_id || 'default'}`;
+          {order.items.map((item) => {
+            const itemKey = item.id ?? `${item.product_id}-${item.variant_id || 'default'}`;
             return (
               <div key={itemKey} className="flex items-center justify-between bg-neutral-700 p-4 rounded">
                 {actionType === 'return' && (
@@ -577,7 +589,7 @@ export default function OrderDetailPage() {
                     type="checkbox"
                     id={`item-${itemKey}`}
                     checked={selectedItems.has(itemKey)}
-                    onChange={() => toggleItemSelection(item.product_id, item.variant_id)}
+                    onChange={() => toggleItemSelection(itemKey)}
                     className="mr-3"
                   />
                 )}
@@ -739,7 +751,7 @@ export default function OrderDetailPage() {
                 </div>
                 <p className="text-sm text-gray-300">
                   Select individual items to return or use the buttons below to select all items.
-                  Refund amounts include proportional tax and discount calculations.
+                  New orders use their exact server-recorded tax and discount allocations.
                 </p>
               </div>
 
@@ -778,12 +790,18 @@ export default function OrderDetailPage() {
                         <span className="text-white">${(calculation.subtotal / 100).toFixed(2)}</span>
                       </div>
                       <div className="flex justify-between">
-                        <span className="text-gray-400">Proportional Tax:</span>
+                        <span className="text-gray-400">
+                          {calculation.allocationMethod === 'exact_snapshot' ? 'Allocated Tax:' : 'Estimated Tax:'}
+                        </span>
                         <span className="text-white">${(calculation.tax / 100).toFixed(2)}</span>
                       </div>
                       {calculation.discount > 0 && (
                         <div className="flex justify-between">
-                          <span className="text-gray-400">Proportional Discount:</span>
+                          <span className="text-gray-400">
+                            {calculation.allocationMethod === 'exact_snapshot'
+                              ? 'Allocated Discount:'
+                              : 'Estimated Discount:'}
+                          </span>
                           <span className="text-green-400">-${(calculation.discount / 100).toFixed(2)}</span>
                         </div>
                       )}
@@ -805,8 +823,10 @@ export default function OrderDetailPage() {
                       </div>
                     </div>
                     <div className="text-xs text-gray-400 mt-2 space-y-1">
-                      {calculation.discount > 0 && (
-                        <p>* Discount prorated based on returned item value</p>
+                      {calculation.allocationMethod === 'legacy_proportional' && (
+                        <p className="text-yellow-300">
+                          * Legacy estimate: exact per-line allocations were not recorded. Confirmation is required.
+                        </p>
                       )}
                       {calculation.shipping > 0 ? (
                         <p>* Shipping refund included per refund policy</p>

--- a/app/admin/orders/[id]/page.tsx
+++ b/app/admin/orders/[id]/page.tsx
@@ -897,23 +897,37 @@ export default function OrderDetailPage() {
                     <Badge className={refund.type === 'full' ? 'bg-red-600' : 'bg-orange-600'}>
                       {refund.type === 'full' ? 'Full Refund' : 'Partial Refund'}
                     </Badge>
+                    <Badge className={
+                      refund.status === 'succeeded' ? 'bg-green-700' :
+                      refund.status === 'failed' || refund.status === 'canceled' ? 'bg-red-700' :
+                      'bg-yellow-700'
+                    }>
+                      {refund.status || 'legacy settled'}
+                    </Badge>
                     <span className="text-white font-semibold">
                       ${(refund.amount / 100).toFixed(2)}
                     </span>
                   </div>
                   <span className="text-xs text-gray-400">
-                    {new Date(refund.processed_at).toLocaleDateString()}
+                    {refund.processed_at || refund.requested_at
+                      ? new Date(refund.processed_at || refund.requested_at).toLocaleDateString()
+                      : 'Legacy record'}
                   </span>
                 </div>
                 <div className="text-sm text-gray-300 space-y-1">
-                  <p><strong>Reason:</strong> {refund.reason}</p>
+                  {refund.reason && <p><strong>Reason:</strong> {refund.reason}</p>}
                   {refund.notes && <p><strong>Notes:</strong> {refund.notes}</p>}
                   {refund.items && refund.items.length > 0 && (
                     <p><strong>Items:</strong> {refund.items.length} item(s)</p>
                   )}
-                  <p className="text-xs text-gray-400">
-                    <strong>Stripe Refund ID:</strong> {refund.stripe_refund_id}
-                  </p>
+                  {refund.source === 'stripe_dashboard' && (
+                    <p className="text-xs text-blue-300">Recorded from Stripe Dashboard</p>
+                  )}
+                  {refund.stripe_refund_id && (
+                    <p className="text-xs text-gray-400">
+                      <strong>Stripe Refund ID:</strong> {refund.stripe_refund_id}
+                    </p>
+                  )}
                 </div>
               </div>
             ))}

--- a/app/admin/settings/page.tsx
+++ b/app/admin/settings/page.tsx
@@ -95,6 +95,7 @@ interface RefundSettings {
   restocking_fee_percent: number;
   return_window_days: number;
   minimum_refund_amount: number;
+  external_full_restock_enabled: boolean;
 }
 
 interface PromotionSettings {
@@ -152,7 +153,8 @@ export default function AdminSettingsPage() {
     shipping_refunded_full: false,
     restocking_fee_percent: 0,
     return_window_days: 30,
-    minimum_refund_amount: 500
+    minimum_refund_amount: 500,
+    external_full_restock_enabled: false
   });
 
   const [promotionSettings, setPromotionSettings] = useState<PromotionSettings>({
@@ -217,6 +219,7 @@ export default function AdminSettingsPage() {
             if (setting.key === 'refund.restocking_fee_percent') setRefundSettings(prev => ({ ...prev, restocking_fee_percent: value }));
             if (setting.key === 'refund.return_window_days') setRefundSettings(prev => ({ ...prev, return_window_days: value }));
             if (setting.key === 'refund.minimum_refund_amount') setRefundSettings(prev => ({ ...prev, minimum_refund_amount: value }));
+            if (setting.key === 'refund.external_full_restock_enabled') setRefundSettings(prev => ({ ...prev, external_full_restock_enabled: value }));
           } else if (setting.category === 'promotions') {
             if (setting.key === 'promotions.site_wide_discount_percent') setPromotionSettings(prev => ({ ...prev, site_wide_discount_percent: value }));
             if (setting.key === 'promotions.banner_enabled') setPromotionSettings(prev => ({ ...prev, banner_enabled: value }));
@@ -358,6 +361,7 @@ export default function AdminSettingsPage() {
         { key: 'refund.restocking_fee_percent', value: refundSettings.restocking_fee_percent, category: 'refund' },
         { key: 'refund.return_window_days', value: refundSettings.return_window_days, category: 'refund' },
         { key: 'refund.minimum_refund_amount', value: refundSettings.minimum_refund_amount, category: 'refund' },
+        { key: 'refund.external_full_restock_enabled', value: refundSettings.external_full_restock_enabled, category: 'refund' },
         
         // Promotion settings
         { key: 'promotions.site_wide_discount_percent', value: promotionSettings.site_wide_discount_percent, category: 'promotions' },
@@ -509,7 +513,7 @@ export default function AdminSettingsPage() {
                   onCheckedChange={(checked) => setSystemSettings(prev => ({ ...prev, maintenance_mode: checked }))}
                 />
               </div>
-              
+
               {systemSettings.maintenance_mode && (
                 <div>
                   <label className="block text-sm font-medium text-gray-300 mb-2">Maintenance Message</label>
@@ -809,6 +813,19 @@ export default function AdminSettingsPage() {
                 <Switch
                   checked={refundSettings.shipping_refunded_partial}
                   onCheckedChange={(checked) => setRefundSettings(prev => ({ ...prev, shipping_refunded_partial: checked }))}
+                />
+              </div>
+
+              <div className="flex items-center justify-between border-t border-neutral-700 pt-4">
+                <div className="pr-4">
+                  <label className="text-sm font-medium text-gray-300">Restock Full Dashboard Refunds</label>
+                  <p className="text-xs text-gray-500">
+                    Restock all outstanding lines when Stripe reports a full external refund
+                  </p>
+                </div>
+                <Switch
+                  checked={refundSettings.external_full_restock_enabled}
+                  onCheckedChange={(checked) => setRefundSettings(prev => ({ ...prev, external_full_restock_enabled: checked }))}
                 />
               </div>
               

--- a/app/api/orders/refund/route.ts
+++ b/app/api/orders/refund/route.ts
@@ -1,239 +1,435 @@
-/**
- * === Order Refund API ===
- *
- * Handles Stripe refunds for order cancellations and returns.
- * Processes both full refunds (cancellations) and partial refunds (returns).
- *
- * === Features ===
- * - **Full Refunds**: Complete order cancellation with full amount refund
- * - **Partial Refunds**: Item-level returns with calculated partial amounts
- * - **Stripe Integration**: Direct Stripe refund processing
- * - **Order Updates**: Automatic order status and payment status updates
- * - **Audit Trail**: Comprehensive logging and reason tracking
- *
- * === Security ===
- * - Admin API key authentication required
- * - Payment intent validation
- * - Refund amount verification
- *
- * === Request Format ===
- * ```json
- * {
- *   "orderId": "WEB-USER-123456",
- *   "type": "full" | "partial",
- *   "reason": "requested_by_customer",
- *   "amount"?: number, // Required for partial refunds (in cents)
- *   "items"?: string[], // Required for partial refunds - product IDs
- *   "notes"?: string
- * }
- * ```
- */
-
 import { NextRequest, NextResponse } from 'next/server';
-import { getStripeClient } from '@/lib/stripe';
-import { getDbAsync } from '@/lib/db';
-import { orders } from '@/lib/db/schema/order';
-import { eq } from 'drizzle-orm';
+import type Stripe from 'stripe';
 import { authenticateRequest, PERMISSIONS } from '@/lib/auth/unified-auth';
+import { getDbAsync } from '@/lib/db';
+import { Money } from '@/lib/money';
+import { getStripeClient } from '@/lib/stripe';
+import { isBoundedArray, isBoundedString, isPlainRecord } from '@/lib/public-request-validation';
+import { normalizeRefundLineIds } from '@/lib/payments/refund-idempotency';
+import { decideRefundLedgerAction } from '@/lib/payments/refund-ledger';
+import {
+  mutateRefundLedger,
+  parseRefundExtensions,
+  type RefundLedgerContext,
+} from '@/lib/payments/refund-ledger-store';
+import {
+  classifyRefundStatus,
+  computeRefundedTotal,
+  type RefundRecord,
+} from '@/lib/utils/refund-validation';
 
 interface RefundRequest {
   orderId: string;
   type: 'full' | 'partial';
   reason: string;
-  amount?: number; // For partial refunds (in cents)
-  items?: string[]; // For partial refunds - product IDs
-  notes?: string;
+  amount?: number;
+  lineIds: string[];
+  notes: string;
+}
+
+interface Reservation {
+  idempotencyKey: string;
+  requestFingerprint: string;
+  refundAmount: number;
+  entryIndex: number;
+  stripeRefundId?: string;
+  requestedAt?: string;
+}
+
+const MAX_UNRESOLVED_CREATE_RETRY_MS = 23 * 60 * 60 * 1000;
+
+function parseRequest(value: unknown): RefundRequest | null {
+  if (!isPlainRecord(value)) return null;
+  if (!isBoundedString(value.orderId, 128) ||
+      (value.type !== 'full' && value.type !== 'partial') ||
+      !isBoundedString(value.reason, 256) ||
+      (value.notes !== undefined && !isBoundedString(value.notes, 1_000, { allowEmpty: true }))) {
+    return null;
+  }
+  const rawItems = value.items ?? [];
+  if (!isBoundedArray(rawItems, 100) ||
+      !rawItems.every((item) => isBoundedString(item, 128))) {
+    return null;
+  }
+  let lineIds: string[];
+  try {
+    lineIds = normalizeRefundLineIds(rawItems as string[]);
+  } catch {
+    return null;
+  }
+  if (value.type === 'partial') {
+    if (!Number.isSafeInteger(value.amount) || Number(value.amount) <= 0 || lineIds.length === 0) {
+      return null;
+    }
+  } else if (value.amount !== undefined || lineIds.length > 0) {
+    return null;
+  }
+  return {
+    orderId: value.orderId,
+    type: value.type,
+    reason: value.reason.trim(),
+    ...(value.type === 'partial' ? { amount: Number(value.amount) } : {}),
+    lineIds,
+    notes: typeof value.notes === 'string' ? value.notes : '',
+  };
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return parseRefundExtensions(value) ?? {};
+}
+
+function orderLineIds(context: RefundLedgerContext): string[] | null {
+  const rawItems = context.order.items;
+  const items = Array.isArray(rawItems) ? rawItems : [];
+  const ids: string[] = [];
+  for (const raw of items) {
+    if (!isPlainRecord(raw)) return null;
+    const id = typeof raw.id === 'string' && raw.id
+      ? raw.id
+      : `${String(raw.product_id ?? '')}-${String(raw.variant_id ?? 'default')}`;
+    if (!id || id.length > 128 || ids.includes(id)) return null;
+    ids.push(id);
+  }
+  return ids;
+}
+
+function responseForStoreFailure(reason: string) {
+  if (reason === 'not_found') {
+    return NextResponse.json({ error: 'Order not found' }, { status: 404 });
+  }
+  if (reason === 'invalid_ledger') {
+    return NextResponse.json({ error: 'Order refund history requires reconciliation' }, { status: 409 });
+  }
+  return NextResponse.json({ error: 'Refund reservation conflicted; retry the request' }, { status: 503 });
 }
 
 export async function POST(request: NextRequest) {
+  const authResult = await authenticateRequest(request, PERMISSIONS.ORDERS_UPDATE);
+  if (!authResult.success) return authResult.response!;
+
+  let body: unknown;
   try {
-    // Authenticate with admin permissions
-    const authResult = await authenticateRequest(request, PERMISSIONS.ORDERS_UPDATE);
-    if (!authResult.success) {
-      return authResult.response!;
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON request body' }, { status: 400 });
+  }
+  const input = parseRequest(body);
+  if (!input) return NextResponse.json({ error: 'Invalid refund request' }, { status: 400 });
+
+  const db = await getDbAsync();
+  const actor = typeof authResult.tokenInfo?.tokenName === 'string'
+    ? authResult.tokenInfo.tokenName.slice(0, 128)
+    : 'authenticated-admin';
+  const state: {
+    reservation?: Reservation;
+    completed?: {
+      refundAmount: number;
+      stripeRefundId: string;
+      providerStatus: string;
+    };
+    rejection?: { status: number; error: string };
+    bindingError?: string;
+  } = {};
+
+  const reserved = await mutateRefundLedger(db, input.orderId, async (context) => {
+    delete state.reservation;
+    delete state.completed;
+    delete state.rejection;
+    delete state.bindingError;
+    const lineIds = orderLineIds(context);
+    if (input.type === 'partial' &&
+        (!lineIds || input.lineIds.some((lineId) => !lineIds.includes(lineId)))) {
+      state.rejection = { status: 400, error: 'Refund contains an unknown or ambiguous order line' };
+      return { action: 'skip' };
+    }
+    const external = asRecord(context.order.external_references);
+    const extensionPaymentIntent = context.extensions.payment_intent_id;
+    const externalPaymentIntent = external.payment_intent_id;
+    if (typeof extensionPaymentIntent !== 'string' ||
+        typeof externalPaymentIntent !== 'string' ||
+        extensionPaymentIntent !== externalPaymentIntent) {
+      state.bindingError = 'Order PaymentIntent binding is missing or inconsistent';
+      return { action: 'skip' };
     }
 
-    const body = await request.json() as RefundRequest;
-    const { orderId, type, reason, amount, items, notes } = body;
-
-    // Validate required fields
-    if (!orderId || !type || !reason) {
-      return NextResponse.json({
-        error: 'Missing required fields: orderId, type, reason'
-      }, { status: 400 });
-    }
-
-    if (type === 'partial' && (!amount || !items || items.length === 0)) {
-      return NextResponse.json({
-        error: 'Partial refunds require amount and items'
-      }, { status: 400 });
-    }
-
-    const db = await getDbAsync();
-    
-    // Get the order
-    const [order] = await db.select().from(orders).where(eq(orders.id, orderId));
-    if (!order) {
-      return NextResponse.json({
-        error: 'Order not found'
-      }, { status: 404 });
-    }
-
-    // Parse order data
-    const extensions = order.extensions ? (typeof order.extensions === 'string' ? JSON.parse(order.extensions) : order.extensions) : {};
-    const totalAmount = order.total_amount ? (typeof order.total_amount === 'string' ? JSON.parse(order.total_amount) : order.total_amount) : { amount: 0 };
-    
-    const paymentIntentId = extensions.payment_intent_id;
-    if (!paymentIntentId) {
-      return NextResponse.json({
-        error: 'No payment intent found for this order'
-      }, { status: 400 });
-    }
-
-    // Check if order is already cancelled or refunded
-    if (order.status === 'cancelled' || order.status === 'refunded') {
-      return NextResponse.json({
-        error: 'Order is already cancelled or refunded'
-      }, { status: 400 });
-    }
-
-    // Process Stripe refund
-    const stripe = getStripeClient();
-    let refundAmount: number;
-    let newStatus: string;
-    let newPaymentStatus: string;
-
-    if (type === 'full') {
-      // Full refund
-      refundAmount = totalAmount.amount;
-      newStatus = 'cancelled';
-      newPaymentStatus = 'refunded';
-    } else {
-      // Partial refund
-      refundAmount = amount!;
-      newStatus = order.status; // Keep same status for partial refunds
-      newPaymentStatus = 'paid'; // Still considered paid since it's partial
-      
-      // Validate partial refund amount doesn't exceed total
-      if (refundAmount > totalAmount.amount) {
-        return NextResponse.json({
-          error: 'Refund amount cannot exceed order total'
-        }, { status: 400 });
-      }
-    }
-
-    // Create Stripe refund
-    let stripeRefund;
+    let totalAmount: number;
     try {
-      // Check if we're using regular Stripe SDK or Cloudflare-compatible version
-      if ('refunds' in stripe) {
-        // Using regular Stripe SDK
-        const regularStripe = stripe as any;
-        stripeRefund = await regularStripe.refunds.create({
-          payment_intent: paymentIntentId,
-          amount: refundAmount,
-          reason: 'requested_by_customer',
-          metadata: {
-            orderId,
-            refundType: type,
-            refundReason: reason,
-            ...(items && { refundedItems: items.join(',') })
-          }
-        });
-      } else {
-        // Using Cloudflare-compatible Stripe client
-        const stripeCloudflare = stripe as any;
-        stripeRefund = await stripeCloudflare.request('POST', '/refunds', {
-          payment_intent: paymentIntentId,
-          amount: refundAmount,
-          reason: 'requested_by_customer',
-          metadata: {
-            orderId,
-            refundType: type,
-            refundReason: reason,
-            ...(items && { refundedItems: items.join(',') })
-          }
-        });
-      }
-    } catch (stripeError: any) {
-      console.error('Stripe refund failed:', stripeError);
-      return NextResponse.json({
-        error: 'Failed to process refund with Stripe',
-        details: stripeError.message
-      }, { status: 500 });
+      totalAmount = Money.fromStored(
+        context.order.total_amount,
+        context.order.currency_code
+      ).toMinorUnits();
+    } catch {
+      state.rejection = { status: 409, error: 'Order total is invalid' };
+      return { action: 'skip' };
+    }
+    const hasStripeRefundedFloor = Object.prototype.hasOwnProperty.call(
+      context.extensions,
+      'stripe_amount_refunded'
+    );
+    const rawStripeRefundedFloor = context.extensions.stripe_amount_refunded;
+    if (hasStripeRefundedFloor &&
+        (typeof rawStripeRefundedFloor !== 'number' ||
+          !Number.isSafeInteger(rawStripeRefundedFloor) ||
+          rawStripeRefundedFloor < 0)) {
+      state.rejection = { status: 409, error: 'Recorded Stripe refund total is invalid' };
+      return { action: 'skip' };
     }
 
-    // Update order in database
-    const updateData: any = {
-      status: newStatus,
-      payment_status: newPaymentStatus,
-      updated_at: new Date().toISOString()
-    };
-
-    // Add refund information to extensions
-    const updatedExtensions = {
-      ...extensions,
-      refunds: [
-        ...(extensions.refunds || []),
-        {
-          id: stripeRefund.id,
-          amount: refundAmount,
-          type,
-          reason,
-          items: items || [],
-          notes: notes || '',
-          processed_at: new Date().toISOString(),
-          stripe_refund_id: stripeRefund.id
-        }
-      ]
-    };
-    updateData.extensions = JSON.stringify(updatedExtensions);
-
-    // Add cancellation reason to notes for full cancellations
-    if (type === 'full') {
-      const currentNotes = order.notes || '';
-      const cancellationNote = `CANCELLED: ${reason}${notes ? ` - ${notes}` : ''}`;
-      updateData.notes = currentNotes ? `${currentNotes}\n\n${cancellationNote}` : cancellationNote;
-    }
-
-    // Update order
-    const [updatedOrder] = await db.update(orders)
-      .set(updateData)
-      .where(eq(orders.id, orderId))
-      .returning();
-
-    // Log the refund action
-    console.log(`${type.toUpperCase()} refund processed:`, {
-      orderId,
-      stripeRefundId: stripeRefund.id,
-      amount: refundAmount,
-      reason,
-      items,
-      admin: authResult.tokenInfo?.tokenName || 'unknown'
+    const decision = await decideRefundLedgerAction(context.refunds, {
+      orderId: input.orderId,
+      type: input.type,
+      amount: input.amount,
+      lineIds: input.lineIds,
+      totalAmount,
+      stripeRefundedFloor: hasStripeRefundedFloor
+        ? rawStripeRefundedFloor as number
+        : undefined,
     });
+    if (decision.action === 'reject') {
+      state.rejection = { status: decision.status, error: decision.error };
+      return { action: 'skip' };
+    }
+    if (decision.action === 'completed') {
+      state.completed = {
+        refundAmount: decision.refundAmount,
+        stripeRefundId: decision.stripeRefundId,
+        providerStatus: decision.providerStatus,
+      };
+      return { action: 'skip' };
+    }
+    if (decision.action === 'reconcile') {
+      state.reservation = {
+        idempotencyKey: decision.idempotencyKey,
+        requestFingerprint: decision.requestFingerprint,
+        refundAmount: decision.refundAmount,
+        entryIndex: decision.entryIndex,
+        ...(decision.stripeRefundId ? { stripeRefundId: decision.stripeRefundId } : {}),
+        ...(decision.requestedAt ? { requestedAt: decision.requestedAt } : {}),
+      };
+      return { action: 'skip' };
+    }
+    if (context.order.payment_status !== 'paid') {
+      state.rejection = { status: 409, error: 'Only paid orders can be refunded' };
+      return { action: 'skip' };
+    }
 
+    const entry: RefundRecord = {
+      id: decision.idempotencyKey,
+      idempotency_key: decision.idempotencyKey,
+      request_fingerprint: decision.requestFingerprint,
+      amount: decision.refundAmount,
+      type: input.type,
+      items: input.lineIds,
+      reason: input.reason,
+      notes: input.notes,
+      status: 'pending',
+      settled_sequence: decision.settledSequence,
+      requested_at: context.nowIso,
+      requested_by: actor,
+    };
+    const refunds = [...context.refunds, entry];
+    state.reservation = {
+      idempotencyKey: decision.idempotencyKey,
+      requestFingerprint: decision.requestFingerprint,
+      refundAmount: decision.refundAmount,
+      entryIndex: refunds.length - 1,
+    };
+    return {
+      action: 'write',
+      extensions: {
+        ...context.extensions,
+        refunds,
+        refunds_version: context.nextVersion,
+      },
+    };
+  });
+
+  if (!reserved.ok) return responseForStoreFailure(reserved.reason);
+  if (state.bindingError) return NextResponse.json({ error: state.bindingError }, { status: 409 });
+  if (state.rejection) {
+    return NextResponse.json({ error: state.rejection.error }, { status: state.rejection.status });
+  }
+  if (state.completed) {
     return NextResponse.json({
       success: true,
+      duplicate: true,
       refund: {
-        id: stripeRefund.id,
-        amount: refundAmount,
-        type,
-        reason,
-        items: items || [],
-        processed_at: new Date().toISOString()
+        id: state.completed.stripeRefundId,
+        amount: state.completed.refundAmount,
+        type: input.type,
+        reason: input.reason,
+        items: input.lineIds,
+        status: 'succeeded',
+        providerStatus: state.completed.providerStatus,
       },
       order: {
-        id: updatedOrder.id,
-        status: updatedOrder.status,
-        payment_status: updatedOrder.payment_status
-      }
+        id: input.orderId,
+        status: reserved.order.status,
+        payment_status: reserved.order.payment_status,
+      },
     });
-
-  } catch (error) {
-    console.error('Refund processing error:', error);
-    return NextResponse.json({
-      error: 'Failed to process refund',
-      details: error instanceof Error ? error.message : 'Unknown error'
-    }, { status: 500 });
   }
+  const reservation = state.reservation;
+  if (!reservation) {
+    return NextResponse.json({ error: 'Refund reservation could not be established' }, { status: 503 });
+  }
+
+  const paymentIntentId = asRecord(reserved.order.external_references).payment_intent_id as string;
+  const refundParams: Stripe.RefundCreateParams = {
+    payment_intent: paymentIntentId,
+    amount: reservation.refundAmount,
+    reason: 'requested_by_customer',
+    metadata: {
+      orderId: input.orderId,
+      refundType: input.type,
+      refundReason: input.reason,
+      lineCount: String(input.lineIds.length),
+      refundRequestId: reservation.idempotencyKey,
+    },
+  };
+
+  let stripeRefund: Stripe.Refund;
+  const stripe = getStripeClient();
+  try {
+    if (reservation.stripeRefundId) {
+      stripeRefund = await stripe.refunds.retrieve(reservation.stripeRefundId);
+    } else {
+      const requestedAt = reservation.requestedAt
+        ? new Date(reservation.requestedAt).getTime()
+        : Date.now();
+      if (!Number.isFinite(requestedAt) || Date.now() - requestedAt > MAX_UNRESOLVED_CREATE_RETRY_MS) {
+        return NextResponse.json(
+          { error: 'Refund requires provider reconciliation before it can be retried' },
+          { status: 409 }
+        );
+      }
+      stripeRefund = await stripe.refunds.create(
+        refundParams,
+        { idempotencyKey: reservation.idempotencyKey }
+      );
+    }
+  } catch (error) {
+    // A transport error is ambiguous: Stripe may have accepted the request.
+    // Keep the exact reservation pending so a retry reuses the same provider key.
+    console.error(`[refund] Stripe call is unresolved for order ${input.orderId}:`, error);
+    return NextResponse.json(
+      { error: 'Refund status is unresolved; retry this same request' },
+      { status: 503, headers: { 'Retry-After': '5' } }
+    );
+  }
+
+  const providerPaymentIntent = typeof stripeRefund.payment_intent === 'string'
+    ? stripeRefund.payment_intent
+    : stripeRefund.payment_intent?.id;
+  const providerResultIsConsistent =
+    stripeRefund.id.length > 0 &&
+    (!reservation.stripeRefundId || stripeRefund.id === reservation.stripeRefundId) &&
+    providerPaymentIntent === paymentIntentId &&
+    Number.isSafeInteger(stripeRefund.amount) &&
+    stripeRefund.amount === reservation.refundAmount;
+  if (!providerResultIsConsistent) {
+    // Keep the reservation pending: an inconsistent response must be reconciled,
+    // never released or settled against the wrong order or amount.
+    console.error('[refund] Stripe returned an inconsistent refund', {
+      orderId: input.orderId,
+      expectedPaymentIntentId: paymentIntentId,
+      expectedRefundId: reservation.stripeRefundId,
+      expectedAmount: reservation.refundAmount,
+      actualPaymentIntentId: providerPaymentIntent,
+      actualRefundId: stripeRefund.id,
+      actualAmount: stripeRefund.amount,
+    });
+    return NextResponse.json(
+      { error: 'Payment provider returned an inconsistent refund' },
+      { status: 502 }
+    );
+  }
+
+  const providerStatus = stripeRefund.status ?? 'unknown';
+  const providerClass = classifyRefundStatus(providerStatus);
+  const normalizedStatus = providerClass === 'settled'
+    ? 'succeeded'
+    : providerClass === 'released'
+      ? 'failed'
+      : providerStatus === 'requires_action'
+        ? 'requires_action'
+        : 'pending';
+  let settlementConflict = false;
+  const settled = await mutateRefundLedger(db, input.orderId, (context) => {
+    settlementConflict = false;
+    const entryIndex = context.refunds.findIndex(
+      (entry) => entry.idempotency_key === reservation!.idempotencyKey
+    );
+    if (entryIndex < 0) {
+      settlementConflict = true;
+      return { action: 'skip' };
+    }
+    const current = context.refunds[entryIndex];
+    if (current.status === 'succeeded' && current.stripe_refund_id === stripeRefund.id) {
+      return { action: 'skip' };
+    }
+    const refunds = context.refunds.slice();
+    refunds[entryIndex] = {
+      ...current,
+      status: normalizedStatus,
+      provider_status: providerStatus,
+      stripe_refund_id: stripeRefund.id,
+      processed_at: context.nowIso,
+    };
+    const extensions = {
+      ...context.extensions,
+      refunds,
+      refunds_version: context.nextVersion,
+    };
+    const total = Money.fromStored(
+      context.order.total_amount,
+      context.order.currency_code
+    ).toMinorUnits();
+    const fullySettled = normalizedStatus === 'succeeded' &&
+      computeRefundedTotal({ refunds }) === total;
+    return {
+      action: 'write',
+      extensions,
+      ...(fullySettled ? {
+        columns: { status: 'cancelled' as const, payment_status: 'refunded' as const },
+      } : {}),
+    };
+  });
+  if (!settled.ok) return responseForStoreFailure(settled.reason);
+  if (settlementConflict) {
+    return NextResponse.json(
+      { error: 'Refund was accepted but ledger reconciliation is pending' },
+      { status: 503, headers: { 'Retry-After': '5' } }
+    );
+  }
+  if (normalizedStatus === 'failed') {
+    return NextResponse.json({ error: 'Stripe rejected the refund' }, { status: 502 });
+  }
+
+  console.log('[refund] refund request reconciled', {
+    orderId: input.orderId,
+    stripeRefundId: stripeRefund.id,
+    amount: reservation.refundAmount,
+    status: normalizedStatus,
+    actor,
+  });
+
+  return NextResponse.json({
+    success: true,
+    refund: {
+      id: stripeRefund.id,
+      amount: reservation.refundAmount,
+      type: input.type,
+      reason: input.reason,
+      items: input.lineIds,
+      status: normalizedStatus,
+      providerStatus,
+      processed_at: new Date().toISOString(),
+    },
+    order: {
+      id: input.orderId,
+      status: settled.order.status,
+      payment_status: settled.order.payment_status,
+    },
+  }, { status: normalizedStatus === 'succeeded' ? 200 : 202 });
 }

--- a/app/api/payment-intent/route.ts
+++ b/app/api/payment-intent/route.ts
@@ -191,6 +191,8 @@ export async function POST(request: NextRequest) {
     checkout_shipping_discount: quote.shippingDiscount,
     checkout_shipping: baseShipping.subtract(shippingDiscount).toJSON(),
     checkout_tax: quote.tax,
+    checkout_shipping_tax: quote.shippingTax,
+    checkout_line_allocations: quote.lineAllocations,
     checkout_tender: quote.tender,
     checkout_tender_state: quote.tenderState,
     checkout_total: Money.fromMinor(providerAmount, providerCurrency).toJSON(),

--- a/app/api/payment-intent/route.ts
+++ b/app/api/payment-intent/route.ts
@@ -9,6 +9,10 @@ import type { Address } from '@/lib/types';
 import { enforceRateLimit, getClientIp } from '@/lib/rate-limit';
 import { isBoundedString, isPlainRecord } from '@/lib/public-request-validation';
 import { createCustomer, getCustomer } from '@/lib/models/mach/customer';
+import {
+  assertCheckoutInventoryAvailable,
+  InventoryUnavailableError,
+} from '@/lib/services/inventory-adjustments';
 
 interface PaymentIntentRequest {
   items: CheckoutLineInput[];
@@ -106,6 +110,19 @@ export async function POST(request: NextRequest) {
       { error: 'This checkout requires a positive payment amount' },
       { status: 400 }
     );
+  }
+
+  try {
+    await assertCheckoutInventoryAvailable(quote.items);
+  } catch (error) {
+    if (error instanceof InventoryUnavailableError) {
+      return NextResponse.json(
+        { error: 'One or more items are no longer available in the requested quantity' },
+        { status: 409 }
+      );
+    }
+    console.error('[checkout] Authoritative inventory check failed:', error);
+    return NextResponse.json({ error: 'Inventory is temporarily unavailable' }, { status: 503 });
   }
 
   // Preserve the authenticated customer→order FK before creating any payment

--- a/app/api/webhooks/stripe/handlers/refund-handlers.ts
+++ b/app/api/webhooks/stripe/handlers/refund-handlers.ts
@@ -1,0 +1,389 @@
+import { getCloudflareContext } from '@opennextjs/cloudflare';
+import type Stripe from 'stripe';
+import { Money } from '@/lib/money';
+import { sendRefundSettledEmail, type RefundSettledEmailInput } from '@/lib/payments/refund-email';
+import {
+  decideRefundLifecycle,
+  type ProviderRefundSnapshot,
+  type RefundLifecycleDecision,
+} from '@/lib/payments/refund-lifecycle';
+import {
+  parseRefundExtensions,
+  readRefundsVersion,
+} from '@/lib/payments/refund-ledger-store';
+import { getStripeClient } from '@/lib/stripe';
+import { MAX_REFUND_RECORDS, type RefundRecord } from '@/lib/utils/refund-validation';
+import type { WebhookEventOutcome } from '@/lib/webhooks/processed-events';
+
+const MAX_LIFECYCLE_CAS_ATTEMPTS = 5;
+const EXTERNAL_RESTOCK_SETTING = 'refund.external_full_restock_enabled';
+
+interface RefundOrderRow {
+  id: string;
+  status: string;
+  payment_status: string | null;
+  total_amount: string;
+  currency_code: string;
+  items: string;
+  external_references: string | null;
+  extensions: string | null;
+  shipping_address: string | null;
+  updated_at: string | null;
+}
+
+interface OrderLine {
+  id: string;
+  variantId: string;
+  quantity: number;
+}
+
+export interface RefundWebhookRuntime {
+  database?: D1Database;
+  stripe?: Stripe;
+  externalRestockEnabled?: boolean;
+  sendEmail?: (input: RefundSettledEmailInput) => Promise<{ success: boolean; error?: string }>;
+  now?: () => Date;
+}
+
+async function resolveDatabase(database?: D1Database): Promise<D1Database> {
+  if (database) return database;
+  const { env } = await getCloudflareContext({ async: true });
+  return env.DB;
+}
+
+function expandableId(value: { id: string } | string | null): string | null {
+  if (typeof value === 'string') return value || null;
+  return value?.id || null;
+}
+
+function parseJson(value: string | null, name: string): unknown {
+  if (value === null) return null;
+  try {
+    return JSON.parse(value);
+  } catch {
+    throw new Error(`${name} contains malformed JSON`);
+  }
+}
+
+function parseOrderLines(value: string): OrderLine[] {
+  const raw = parseJson(value, 'Order items');
+  if (!Array.isArray(raw) || raw.length > 100) throw new Error('Order items are invalid');
+  const lines = raw.map((item): OrderLine => {
+    if (item === null || typeof item !== 'object' || Array.isArray(item)) {
+      throw new Error('Order contains an invalid line');
+    }
+    const record = item as Record<string, unknown>;
+    const id = typeof record.id === 'string' && record.id
+      ? record.id
+      : `${String(record.product_id ?? '')}-${String(record.variant_id ?? 'default')}`;
+    const variantId = record.variant_id;
+    const quantity = record.quantity;
+    if (!id || id.length > 128 || typeof variantId !== 'string' || !variantId ||
+        variantId.length > 256 || !Number.isSafeInteger(quantity) || Number(quantity) <= 0) {
+      throw new Error('Order contains an invalid refundable line');
+    }
+    return { id, variantId, quantity: Number(quantity) };
+  });
+  if (new Set(lines.map(({ id }) => id)).size !== lines.length) {
+    throw new Error('Order line ids are ambiguous');
+  }
+  return lines;
+}
+
+async function findOrderByPaymentIntent(
+  database: D1Database,
+  paymentIntentId: string
+): Promise<RefundOrderRow | null> {
+  const rows = await database.prepare(`
+SELECT id, status, payment_status, total_amount, currency_code, items,
+       external_references, extensions, shipping_address, updated_at
+FROM orders
+WHERE json_valid(COALESCE(external_references, '{}')) = 1
+  AND json_valid(COALESCE(extensions, '{}')) = 1
+  AND json_extract(external_references, '$.payment_intent_id') = ?
+  AND json_extract(extensions, '$.payment_intent_id') = ?
+LIMIT 2
+`).bind(paymentIntentId, paymentIntentId).all<RefundOrderRow>();
+  if (rows.results.length > 1) {
+    throw new Error(`PaymentIntent ${paymentIntentId} is bound to multiple orders`);
+  }
+  return rows.results[0] ?? null;
+}
+
+export async function readExternalRestockEnabled(database: D1Database): Promise<boolean> {
+  const setting = await database.prepare(
+    'SELECT value FROM admin_settings WHERE key = ?'
+  ).bind(EXTERNAL_RESTOCK_SETTING).first<{ value: string }>();
+  if (!setting) return false;
+  let value: unknown;
+  try {
+    value = JSON.parse(setting.value);
+  } catch {
+    throw new Error('External refund restock setting contains malformed JSON');
+  }
+  if (typeof value !== 'boolean') {
+    throw new Error('External refund restock setting must be boolean');
+  }
+  return value;
+}
+
+function providerSnapshot(
+  refund: Stripe.Refund,
+  paymentIntentId: string,
+  chargeId: string,
+  currency: string
+): ProviderRefundSnapshot {
+  const refundPaymentIntentId = expandableId(refund.payment_intent);
+  const refundChargeId = expandableId(refund.charge);
+  if (refundPaymentIntentId !== paymentIntentId || refundChargeId !== chargeId ||
+      refund.currency.toLowerCase() !== currency.toLowerCase() ||
+      !Number.isSafeInteger(refund.created) || refund.created < 0) {
+    throw new Error(`Stripe refund ${refund.id} conflicts with its charge binding`);
+  }
+  if (!refund.status) throw new Error(`Stripe refund ${refund.id} has no status`);
+  const requestId = refund.metadata?.refundRequestId;
+  return {
+    id: refund.id,
+    amount: refund.amount,
+    status: refund.status,
+    paymentIntentId,
+    ...(typeof requestId === 'string' && requestId ? { requestId } : {}),
+    createdAt: new Date(refund.created * 1_000).toISOString(),
+  };
+}
+
+function refundContext(row: RefundOrderRow): { email?: string; name?: string } {
+  const extensions = parseRefundExtensions(row.extensions) ?? {};
+  const address = parseJson(row.shipping_address, 'Shipping address');
+  const shipping = address !== null && typeof address === 'object' && !Array.isArray(address)
+    ? address as Record<string, unknown>
+    : {};
+  const email = typeof extensions.email === 'string'
+    ? extensions.email
+    : typeof shipping.email === 'string' ? shipping.email : undefined;
+  const name = typeof shipping.recipient === 'string'
+    ? shipping.recipient
+    : typeof shipping.company === 'string' ? shipping.company : undefined;
+  return { ...(email ? { email } : {}), ...(name ? { name } : {}) };
+}
+
+function restockInsert(
+  database: D1Database,
+  row: RefundOrderRow,
+  line: OrderLine,
+  nextVersion: number,
+  settledRefundIds: string[],
+  nowIso: string
+): D1PreparedStatement {
+  return database.prepare(`
+INSERT INTO inventory_adjustments (
+  adjustment_key, order_id, line_id, variant_id, kind, quantity,
+  status, attempt_count, claim_token, lease_expires_at, next_attempt_at,
+  result, last_error, created_at, updated_at, completed_at
+)
+SELECT ?, ?, ?, ?, 'refund_restock', ?,
+       'pending', 0, NULL, NULL, NULL, NULL, NULL, ?, ?, NULL
+WHERE EXISTS (
+  SELECT 1
+  FROM orders o, json_each(o.extensions, '$.refunds') refund
+  WHERE o.id = ?
+    AND json_extract(o.extensions, '$.refunds_version') = ?
+    AND json_extract(refund.value, '$.status') = 'succeeded'
+    AND json_extract(refund.value, '$.stripe_refund_id') IN (
+      SELECT value FROM json_each(?)
+    )
+)
+ON CONFLICT(adjustment_key) DO NOTHING
+`).bind(
+    `restock:${row.id}:${line.id}:v1`,
+    row.id,
+    line.id,
+    line.variantId,
+    line.quantity,
+    nowIso,
+    nowIso,
+    row.id,
+    nextVersion,
+    JSON.stringify(settledRefundIds)
+  );
+}
+
+export async function applyRefundLifecycleToOrder(
+  args: {
+    database: D1Database;
+    paymentIntentId: string;
+    providerCurrency: string;
+    providerRefunds: ProviderRefundSnapshot[];
+    chargeAmountRefunded: number;
+    mode: 'charge' | 'lifecycle';
+    targetRefundId?: string;
+    externalRestockEnabled: boolean;
+    now?: () => Date;
+  }
+): Promise<{ row: RefundOrderRow; decision: RefundLifecycleDecision } | null> {
+  for (let attempt = 0; attempt < MAX_LIFECYCLE_CAS_ATTEMPTS; attempt += 1) {
+    const row = await findOrderByPaymentIntent(args.database, args.paymentIntentId);
+    if (!row) return null;
+    if (!args.providerCurrency ||
+        row.currency_code.toLowerCase() !== args.providerCurrency.toLowerCase() ||
+        args.providerRefunds.some(({ paymentIntentId }) => paymentIntentId !== args.paymentIntentId)) {
+      throw new Error('Stripe refund binding conflicts with the order currency or PaymentIntent');
+    }
+    const extensions = parseRefundExtensions(row.extensions);
+    if (!extensions) throw new Error('Order extensions are invalid');
+    const rawRefunds = extensions.refunds ?? [];
+    if (!Array.isArray(rawRefunds) || rawRefunds.length > MAX_REFUND_RECORDS) {
+      throw new Error('Order refund ledger is invalid');
+    }
+    const version = readRefundsVersion(extensions);
+    if (version === null || version === Number.MAX_SAFE_INTEGER) {
+      throw new Error('Order refund version is invalid');
+    }
+    const lines = parseOrderLines(row.items);
+    const totalAmount = Money.fromStored(
+      parseJson(row.total_amount, 'Order total'),
+      row.currency_code
+    ).toMinorUnits();
+    const nowIso = (args.now?.() ?? new Date()).toISOString();
+    const decision = decideRefundLifecycle({
+      mode: args.mode,
+      refunds: rawRefunds as RefundRecord[],
+      providerRefunds: args.providerRefunds,
+      ...(args.targetRefundId ? { targetRefundId: args.targetRefundId } : {}),
+      chargeAmountRefunded: args.chargeAmountRefunded,
+      totalAmount,
+      orderLineIds: lines.map(({ id }) => id),
+      externalRestockEnabled: args.externalRestockEnabled,
+      nowIso,
+    });
+    const nextVersion = version + 1;
+    const nextExtensions = JSON.stringify({
+      ...extensions,
+      refunds: decision.refunds,
+      refunds_version: nextVersion,
+      stripe_amount_refunded: decision.stripeAmountRefunded,
+    });
+    const update = args.database.prepare(`
+UPDATE orders
+SET extensions = ?,
+    status = CASE WHEN ? = 1 THEN 'cancelled' ELSE status END,
+    payment_status = CASE WHEN ? = 1 THEN 'refunded' ELSE payment_status END,
+    updated_at = ?
+WHERE id = ?
+  AND updated_at IS ?
+  AND COALESCE(json_extract(extensions, '$.refunds_version'), 0) = ?
+`).bind(
+      nextExtensions,
+      decision.fullyRefunded ? 1 : 0,
+      decision.fullyRefunded ? 1 : 0,
+      nowIso,
+      row.id,
+      row.updated_at,
+      version
+    );
+    const settledIds = decision.settledRefunds.map(({ id }) => id);
+    const byId = new Map(lines.map((line) => [line.id, line]));
+    const inserts = decision.restockLineIds.map((lineId) => {
+      const line = byId.get(lineId);
+      if (!line) throw new Error(`Refund restock line ${lineId} is missing from the order`);
+      return restockInsert(args.database, row, line, nextVersion, settledIds, nowIso);
+    });
+    const results = await args.database.batch([update, ...inserts]);
+    if (results[0]?.meta.changes === 1) {
+      return { row: { ...row, extensions: nextExtensions, updated_at: nowIso }, decision };
+    }
+  }
+  throw new Error('Refund lifecycle CAS attempts exhausted');
+}
+
+async function sendSettlementNotifications(
+  row: RefundOrderRow,
+  decision: RefundLifecycleDecision,
+  sendEmail: NonNullable<RefundWebhookRuntime['sendEmail']>
+): Promise<void> {
+  const customer = refundContext(row);
+  for (const refund of decision.settledRefunds) {
+    const result = await sendEmail({
+      orderId: row.id,
+      refundId: refund.id,
+      amount: refund.amount,
+      currencyCode: row.currency_code,
+      ...(customer.email ? { customerEmail: customer.email } : {}),
+      ...(customer.name ? { customerName: customer.name } : {}),
+    });
+    if (!result.success) throw new Error(result.error || 'Refund notification failed');
+  }
+}
+
+export async function handleChargeRefunded(
+  eventCharge: Stripe.Charge,
+  runtime: RefundWebhookRuntime = {}
+): Promise<WebhookEventOutcome> {
+  const paymentIntentId = expandableId(eventCharge.payment_intent);
+  if (!paymentIntentId || !eventCharge.id) return 'permanent_rejection';
+  const database = await resolveDatabase(runtime.database);
+  const stripe = runtime.stripe ?? getStripeClient();
+  const listed = await stripe.refunds.list({ charge: eventCharge.id, limit: 100 });
+  if (listed.has_more || listed.data.length > 100) {
+    throw new Error('Stripe charge has more refunds than the bounded reconciler supports');
+  }
+  const providerRefunds = listed.data.map((refund) =>
+    providerSnapshot(refund, paymentIntentId, eventCharge.id, eventCharge.currency)
+  );
+  const externalRestockEnabled = runtime.externalRestockEnabled ??
+    await readExternalRestockEnabled(database);
+  const persisted = await applyRefundLifecycleToOrder({
+    database,
+    paymentIntentId,
+    providerCurrency: eventCharge.currency,
+    providerRefunds,
+    chargeAmountRefunded: eventCharge.amount_refunded,
+    mode: 'charge',
+    externalRestockEnabled,
+    now: runtime.now,
+  });
+  if (!persisted) return 'permanent_rejection';
+  await sendSettlementNotifications(
+    persisted.row,
+    persisted.decision,
+    runtime.sendEmail ?? sendRefundSettledEmail
+  );
+  return 'handled';
+}
+
+export async function handleRefundLifecycle(
+  eventRefund: Stripe.Refund,
+  runtime: RefundWebhookRuntime = {}
+): Promise<WebhookEventOutcome> {
+  const chargeId = expandableId(eventRefund.charge);
+  if (!chargeId || !eventRefund.id) return 'permanent_rejection';
+  const database = await resolveDatabase(runtime.database);
+  const stripe = runtime.stripe ?? getStripeClient();
+  const [refund, charge] = await Promise.all([
+    stripe.refunds.retrieve(eventRefund.id),
+    stripe.charges.retrieve(chargeId),
+  ]);
+  const paymentIntentId = expandableId(charge.payment_intent);
+  if (!paymentIntentId) return 'permanent_rejection';
+  const provider = providerSnapshot(refund, paymentIntentId, charge.id, charge.currency);
+  const externalRestockEnabled = runtime.externalRestockEnabled ??
+    await readExternalRestockEnabled(database);
+  const persisted = await applyRefundLifecycleToOrder({
+    database,
+    paymentIntentId,
+    providerCurrency: charge.currency,
+    providerRefunds: [provider],
+    chargeAmountRefunded: charge.amount_refunded,
+    mode: 'lifecycle',
+    targetRefundId: eventRefund.id,
+    externalRestockEnabled,
+    now: runtime.now,
+  });
+  if (!persisted) return 'permanent_rejection';
+  await sendSettlementNotifications(
+    persisted.row,
+    persisted.decision,
+    runtime.sendEmail ?? sendRefundSettledEmail
+  );
+  return persisted.decision.matchedTarget ? 'handled' : 'ignored';
+}

--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -35,6 +35,19 @@ import {
   finalizeOrderPayment,
   PaymentVerificationError,
 } from '@/lib/services/order-finalization';
+import {
+  claimWebhookEvent,
+  completeWebhookEvent,
+  failWebhookEvent,
+  type WebhookEventOutcome,
+} from '@/lib/webhooks/processed-events';
+
+function retryableResponse(message: string) {
+  return NextResponse.json(
+    { error: message },
+    { status: 503, headers: { 'Retry-After': '5' } }
+  );
+}
 
 /**
  * POST handler for Stripe webhook events
@@ -68,32 +81,81 @@ export async function POST(req: NextRequest) {
     );
   }
 
+  let claim;
   try {
+    claim = await claimWebhookEvent({
+      eventId: event.id,
+      eventType: event.type,
+    });
+  } catch (error) {
+    console.error(`Could not claim Stripe webhook ${event.id}:`, error);
+    return NextResponse.json(
+      { error: 'Webhook claim failed' },
+      { status: 500 }
+    );
+  }
+
+  if (claim.state === 'completed') {
+    return NextResponse.json({ received: true, duplicate: true });
+  }
+  if (claim.state === 'busy') {
+    return retryableResponse('Webhook is already being processed');
+  }
+
+  try {
+    let outcome: WebhookEventOutcome;
+
     // Handle different event types
     switch (event.type) {
       case 'payment_intent.succeeded':
-        await handlePaymentSucceeded(event.data.object as Stripe.PaymentIntent);
+        outcome = await handlePaymentSucceeded(event.data.object as Stripe.PaymentIntent);
         break;
 
       case 'payment_intent.payment_failed':
         await handlePaymentFailed(event.data.object as Stripe.PaymentIntent);
+        outcome = 'ignored';
         break;
 
       case 'checkout.session.completed':
         await handleCheckoutCompleted(event.data.object as Stripe.Checkout.Session);
+        outcome = 'ignored';
         break;
 
       case 'invoice.payment_succeeded':
         await handleInvoicePaymentSucceeded(event.data.object as Stripe.Invoice);
+        outcome = 'ignored';
         break;
 
       default:
         console.log(`Unhandled event type: ${event.type}`);
+        outcome = 'ignored';
+    }
+
+    const completed = await completeWebhookEvent({
+      eventId: event.id,
+      claimToken: claim.claimToken,
+      outcome,
+    });
+    if (!completed) {
+      console.error(`Lost ownership before completing Stripe webhook ${event.id}`);
+      return retryableResponse('Webhook ownership expired before completion');
     }
 
     return NextResponse.json({ received: true });
   } catch (error) {
     console.error('Error processing webhook:', error);
+    try {
+      const failed = await failWebhookEvent({
+        eventId: event.id,
+        claimToken: claim.claimToken,
+        error,
+      });
+      if (!failed) {
+        console.error(`Lost ownership before failing Stripe webhook ${event.id}`);
+      }
+    } catch (claimError) {
+      console.error(`Could not record failure for Stripe webhook ${event.id}:`, claimError);
+    }
     return NextResponse.json(
       { error: 'Webhook processing failed' },
       { status: 500 }
@@ -105,14 +167,16 @@ export async function POST(req: NextRequest) {
  * Handle successful payment intent
  * Updates order status and triggers post-payment actions
  */
-async function handlePaymentSucceeded(paymentIntent: Stripe.PaymentIntent) {
+async function handlePaymentSucceeded(
+  paymentIntent: Stripe.PaymentIntent
+): Promise<WebhookEventOutcome> {
   console.log('Payment succeeded:', paymentIntent.id);
   
   const orderId = paymentIntent.metadata.orderId;
   
   if (!orderId) {
     console.error('No orderId in payment intent metadata');
-    return;
+    return 'permanent_rejection';
   }
 
   try {
@@ -122,10 +186,11 @@ async function handlePaymentSucceeded(paymentIntent: Stripe.PaymentIntent) {
       enforceOwnership: false,
       sendEmail: true,
     });
+    return 'handled';
   } catch (error) {
     if (error instanceof PaymentVerificationError) {
       console.error(`Payment verification rejected for order ${orderId}:`, error.message);
-      return;
+      return 'permanent_rejection';
     }
     // Transient D1/Stripe failures must reach POST's 500 response so Stripe
     // retries the signed event instead of recording a false success.

--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -41,6 +41,10 @@ import {
   failWebhookEvent,
   type WebhookEventOutcome,
 } from '@/lib/webhooks/processed-events';
+import {
+  handleChargeRefunded,
+  handleRefundLifecycle,
+} from '@/app/api/webhooks/stripe/handlers/refund-handlers';
 
 function retryableResponse(message: string) {
   return NextResponse.json(
@@ -124,6 +128,16 @@ export async function POST(req: NextRequest) {
       case 'invoice.payment_succeeded':
         await handleInvoicePaymentSucceeded(event.data.object as Stripe.Invoice);
         outcome = 'ignored';
+        break;
+
+      case 'charge.refunded':
+        outcome = await handleChargeRefunded(event.data.object as Stripe.Charge);
+        break;
+
+      case 'refund.updated':
+      case 'refund.failed':
+      case 'charge.refund.updated':
+        outcome = await handleRefundLifecycle(event.data.object as Stripe.Refund);
         break;
 
       default:

--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -11,6 +11,9 @@
  * - **invoice.payment_succeeded**: Subscription/recurring payment succeeded
  * - **customer.subscription.updated**: Subscription changes
  * - **checkout.session.completed**: Checkout session completed
+ * - **charge.refunded**: Authoritative cumulative refund reconciliation
+ * - **refund.updated/refund.failed**: Delayed refund lifecycle reconciliation
+ * - **charge.refund.updated**: Legacy delayed-refund compatibility event
  *
  * === Security ===
  * - Webhook signature verification with Stripe secret
@@ -24,7 +27,7 @@
  *
  * === Usage ===
  * Configure this endpoint in your Stripe Dashboard webhook settings:
- * - URL: https://yourdomain.com/api/stripe/webhooks
+ * - URL: https://yourdomain.com/api/webhooks/stripe
  * - Events: Select the events you want to handle
  */
 

--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -29,7 +29,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { getStripe, getWebhookSecret } from '@/lib/stripe';
+import { constructWebhookEvent } from '@/lib/stripe';
 import Stripe from 'stripe';
 import {
   finalizeOrderPayment,
@@ -56,11 +56,9 @@ export async function POST(req: NextRequest) {
 
   try {
     // Verify webhook signature for security
-    const stripe = getStripe();
-    event = stripe.webhooks.constructEvent(
+    event = await constructWebhookEvent(
       body,
-      signature,
-      getWebhookSecret()
+      signature
     );
   } catch (error) {
     console.error('Webhook signature verification failed:', error);

--- a/app/category/[slug]/CategoryDisplay.tsx
+++ b/app/category/[slug]/CategoryDisplay.tsx
@@ -42,6 +42,7 @@ import ProductCard from "@/components/ProductCard";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { ArrowUp, ArrowDown } from "lucide-react";
 import type { Product } from "@/lib/types/";
+import { isVariantAvailable } from "@/lib/inventory/availability";
 
 interface CategoryDisplayProps {
   products: Product[];
@@ -69,7 +70,7 @@ export default function CategoryDisplay({ products }: CategoryDisplayProps) {
     const variants = product.variants || [];
     const defaultVariant = variants.find((v) => v.id === product.default_variant_id) || variants[0];
     const available = defaultVariant?.available_for_sale ??
-      (defaultVariant?.inventory?.quantity ?? 0) > 0;
+      (defaultVariant ? isVariantAvailable(defaultVariant) : false);
     return available ? 1 : 0;
   };
 

--- a/app/product/[slug]/ProductDisplay.tsx
+++ b/app/product/[slug]/ProductDisplay.tsx
@@ -42,6 +42,7 @@ import { Money } from "@/lib/money";
 import { normalizeProductRating } from "@/lib/utils/ratings";
 import { toast } from "sonner";
 import type { Product, Review, ProductReviewEligibility } from "@/lib/types";
+import { isVariantAvailable } from "@/lib/inventory/availability";
 import {
   Select,
   SelectContent,
@@ -118,7 +119,7 @@ export default function ProductDisplay({
 
   // Stock logic (MACH: inventory is on variant)
   const available = selectedVariant?.available_for_sale ??
-    (selectedVariant?.inventory?.quantity ?? 0) > 0;
+    (selectedVariant ? isVariantAvailable(selectedVariant) : false);
 
   const ratingSummary = useMemo(() => normalizeProductRating(product.rating), [product.rating]);
   const productDescription = useMemo(() => stringifyDescription(product.description), [product.description]);

--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -44,6 +44,7 @@ import { getDarkBlurPlaceholder } from "@/lib/utils/image-placeholders";
 import { normalizeProductRating } from "@/lib/utils/ratings";
 import { StarRating } from "@/components/reviews/StarRating";
 import { Money } from "@/lib/money";
+import { isVariantAvailable } from "@/lib/inventory/availability";
 
 /**
  * Props interface for ProductCard component
@@ -84,7 +85,7 @@ export default function ProductCard({ product, priority = false }: ProductCardPr
 
   // Availability logic
   const isAvailable = defaultVariant?.available_for_sale ??
-    (defaultVariant?.inventory?.quantity ?? 0) > 0;
+    (defaultVariant ? isVariantAvailable(defaultVariant) : false);
   const availability = isAvailable ? "available" : "coming_soon";
 
   // Name/description/slug logic

--- a/docs/DEPLOYMENT_SETUP.md
+++ b/docs/DEPLOYMENT_SETUP.md
@@ -206,6 +206,9 @@ From Stripe Dashboard > **Developers > API Keys**:
    - `payment_intent.succeeded`
    - `payment_intent.payment_failed`
    - `checkout.session.completed`
+   - `charge.refunded`
+   - `refund.updated`
+   - `refund.failed`
 5. Copy the **Signing secret** (starts with `whsec_`)
 
 ### **Step 5: Configure Environment Variables**

--- a/docs/STRIPE_INTEGRATION.md
+++ b/docs/STRIPE_INTEGRATION.md
@@ -63,6 +63,9 @@ STRIPE_SECRET_KEY=sk_test_your_actual_key_here
    - `payment_intent.succeeded`
    - `payment_intent.payment_failed`
    - `checkout.session.completed`
+   - `charge.refunded`
+   - `refund.updated`
+   - `refund.failed`
 5. Copy the **Signing secret** and add to `.env.local`:
 ```env
 STRIPE_WEBHOOK_SECRET=whsec_your_webhook_secret_here

--- a/docs/checkout-trust-boundary.md
+++ b/docs/checkout-trust-boundary.md
@@ -9,7 +9,9 @@ client-created paid order.
    shipping-method id, and optional promotion codes to `POST /api/payment-intent`.
 2. Mercora resolves the active catalog entities and recomputes canonical line
    names, SKUs, prices, discounts, taxable line bases, tax, shipping, optional
-   reserved tender, and the final cash charge with `Money`.
+   reserved tender, and the final cash charge with `Money`. It persists exact
+   discount and tax allocation by stable line id and verifies authoritative
+   variant availability before creating the PaymentIntent.
 3. Mercora creates the PaymentIntent, then persists a `pending` order containing
    the provider-reported amount and immutable PaymentIntent binding. If the D1
    insert fails, Mercora attempts to cancel the intent and never returns its
@@ -19,13 +21,12 @@ client-created paid order.
    `succeeded`, matching metadata/order ids, matching currency, an exact
    authorized amount, and an `amount_received` at or above the persisted server
    charge floor. The paid order records the actual captured receipt amount.
-5. A guarded `pending`/`pending` to `processing`/`paid` update first proves a
-   paid order. Promotion usage is then atomically audited by order on both the
-   winning call and already-paid retries, allowing transient audit failures to
-   recover without mutating coupons for cancelled or missing orders. Idempotent
-   tender settlement and subscription activation also run idempotently on the
-   winner and already-paid retries so transient failures can recover. Only the
-   transition winner runs the best-effort confirmation email.
+5. Deterministic order-effect rows are staged before a guarded
+   `pending`/`pending` to `processing`/`paid` update. They remain dormant until
+   that update proves the order paid. The winner and already-paid retries drain
+   the same durable effects for inventory, promotion audit, optional tender and
+   subscription capabilities, and confirmation email. The five-minute cron
+   recovers transient failures and expired leases.
 
 The browser cannot assert an order owner, paid status, item display data,
 prices, totals, discounts, tax, or shipping. It receives the authoritative
@@ -68,12 +69,40 @@ funds. A losing redemption writes the protected
 temporary usage overage is accepted until a later reservation/effect-ledger
 schema can prevent the race before capture.
 
+## Inventory and refund authority
+
+`product_variants.inventory` is the checkout and storefront authority. Tracked,
+non-backorderable variants must have sufficient integer quantity before Stripe
+is called. Paid decrements are keyed by order and variant in
+`inventory_adjustments`; the quantity mutation and terminal adjustment marker
+commit in one D1 batch.
+
+Refunds require the immutable PaymentIntent binding in both protected order JSON
+columns. Mercora reserves cumulative refundable balance before calling Stripe,
+uses a deterministic provider idempotency key, and reconciles delayed or
+Dashboard refunds from signed Stripe events. Exact local returned lines stage
+deterministic restocks. Dashboard partial refunds never guess line attribution,
+and full Dashboard restocking is an explicit default-off operator policy.
+
+See [Webhooks, refunds, and inventory operations](./webhooks-refunds-inventory.md)
+for event subscriptions, retries, repair queries, and migration order.
+
+## Fulfillment boundary
+
+Mercora still has no shipment command. The future atomic shipment transition
+must include `SHIPMENT_NO_UNSETTLED_REFUNDS_SQL` so a `pending` or
+`requires_action` refund reservation cannot race a transition to `shipped`.
+The accompanying real-D1 contract test covers malformed and legacy JSON shapes;
+U13 must replace that contract-only coverage with an end-to-end shipment CAS
+test.
+
 ## Scope and schema
 
-This boundary does not consume inventory, execute refunds, implement webhook
-deduplication, expose MCP operations, or start fulfillment.
+This boundary does not expose trusted MCP payment operations or start
+fulfillment. MCP checkout remains outside the paid inventory boundary until it
+performs the same PaymentIntent verification.
 
-No database migration is required. The existing `orders` columns already hold
-the durable pending state, canonical line snapshot, Money values, and guarded
-extension metadata. Promotion consumption uses an atomic JSON audit append in
-the existing `coupon_instances.extensions` column.
+The existing `orders` columns hold pending state, canonical line and Money
+snapshots, immutable provider bindings, and the versioned refund ledger. U09
+adds migrations `0008` through `0011` for webhook claims, paid effects,
+inventory adjustments, and the external full-refund restock setting.

--- a/docs/webhooks-refunds-inventory.md
+++ b/docs/webhooks-refunds-inventory.md
@@ -1,0 +1,246 @@
+# Webhooks, refunds, and inventory operations
+
+Mercora treats Stripe, order state, and variant inventory as a set of durable,
+retryable transitions. A successful HTTP request is not the recovery mechanism;
+the D1 ledgers and scheduled worker are.
+
+## Required Stripe configuration
+
+Configure one Stripe webhook endpoint at:
+
+```text
+https://<store-host>/api/webhooks/stripe
+```
+
+Subscribe it to these events:
+
+- `payment_intent.succeeded`
+- `charge.refunded`
+- `refund.updated`
+- `refund.failed`
+
+`charge.refund.updated` is also supported for compatibility with older Stripe
+event configurations. `refund.updated` is the preferred lifecycle event.
+
+Set `STRIPE_SECRET_KEY` and `STRIPE_WEBHOOK_SECRET` as Worker secrets. Do not put
+live values in `.env.example`, `wrangler.jsonc`, source files, or Git history.
+The existing `.env.example` contains placeholders for both variables.
+
+Deployment is incomplete until the endpoint shows successful deliveries for the
+required events in every Stripe environment the store uses.
+
+## Migration order
+
+Apply migrations in numeric order before deploying the corresponding code:
+
+| Migration | Durable state |
+| --- | --- |
+| `0008_add_processed_webhook_events.sql` | Webhook claims, leases, outcomes, and retry audit |
+| `0009_add_order_effects.sql` | Recoverable post-payment effects |
+| `0010_add_inventory_adjustments.sql` | Exactly-once paid decrements and refund restocks |
+| `0011_add_external_refund_restock_setting.sql` | Default-off Dashboard full-refund restock policy |
+
+Use the repository migration commands to inspect and apply them:
+
+```bash
+npm run db:migrate:status:preview
+npm run db:migrate:apply:preview
+npm run db:migrate:status:production
+npm run db:migrate:apply:production
+```
+
+The apply commands include explicit environment confirmation. Do not copy a
+preview database or migration journal into production.
+
+## Durable processing model
+
+### Webhook inbox
+
+`processed_webhook_events` has one row per Stripe event id. Processing acquires
+a claim token and five-minute lease. Only the current token can mark the event
+completed or failed.
+
+- A completed redelivery returns `200` without repeating domain work.
+- An actively leased duplicate returns `503` with `Retry-After: 5`.
+- A transient handler failure records the error and returns `500`, allowing
+  Stripe to retry.
+- An expired processing lease or failed row can be reclaimed.
+- A signed event that cannot belong to an order is recorded as a permanent
+  rejection rather than retried forever.
+
+### Paid-order effects
+
+`order_effects` stores deterministic work for inventory, coupons, optional gift
+cards/subscriptions, and confirmation email. Rows are staged before the paid
+compare-and-swap and remain dormant until the order is authoritatively `paid`.
+The five-minute cron retries failures and expired leases.
+
+### Inventory adjustments
+
+`inventory_adjustments` is the mutation ledger for variant stock:
+
+- Paid decrement key: `paid:<orderId>:inventory:<variantId>:v1`
+- Refund restock key: `restock:<orderId>:<lineId>:v1`
+
+The variant mutation and terminal adjustment status run in one D1 batch. A
+crash cannot commit the quantity change without its terminal marker. Duplicate
+events converge on the same primary key and cannot apply stock twice.
+
+The authoritative inventory value is `product_variants.inventory` JSON. Its
+`track_inventory`, `quantity`, and `allow_backorder` fields drive storefront
+availability, the pre-charge checkout check, paid decrements, and restocks. The
+separate MACH `inventory` table remains a compatibility surface and is not read
+or written by this flow.
+
+The cron in `worker.ts` drains order effects and inventory adjustments every
+five minutes. Inline handlers may attempt foreground work, but correctness must
+not depend on an isolate surviving after a response.
+
+## Refund behavior
+
+### Admin/API refunds
+
+`POST /api/orders/refund` requires `orders:update` permission and an immutable
+PaymentIntent binding in both order JSON columns.
+
+1. A bounded refund record is reserved in `orders.extensions.refunds` with a
+   compare-and-swap before Stripe is called.
+2. The Stripe SDK receives a deterministic idempotency key as request options.
+3. `pending` and `requires_action` reserve the refundable balance.
+4. `failed` and `canceled` release that reservation.
+5. `succeeded` settles it. A full refund always means the remaining refundable
+   amount, not the original order total.
+
+An ambiguous provider failure leaves the reservation pending. Retrying the
+same request reuses the same Stripe key. Do not create a replacement request to
+work around a timeout. Reservations without a known Stripe refund id stop
+automatic create retries after 23 hours and require provider reconciliation.
+
+Partial refunds use stable order-line ids. Current returns operate on whole
+lines; supporting multiple partial-quantity returns for one line requires a new
+versioned operation-id contract.
+
+### Stripe Dashboard refunds
+
+`charge.refunded` is the only event allowed to append a refund that Mercora did
+not originate. The handler lists the bounded Stripe refund collection, validates
+PaymentIntent/currency/amount bindings, and records the charge's cumulative
+`amount_refunded` as `stripe_amount_refunded`.
+
+Mercora never guesses which goods were returned for a Dashboard partial refund,
+so it does not restock one. A cumulative full Dashboard refund can restock every
+outstanding line only when the operator enables:
+
+```text
+refund.external_full_restock_enabled = true
+```
+
+The setting defaults to `false`. A malformed or unreadable setting fails closed.
+
+`refund.updated`, `refund.failed`, and legacy `charge.refund.updated` retrieve
+fresh Stripe state and may update only an existing ledger record. They never
+append an unattributed refund. The next `charge.refunded` event performs that
+authoritative reconciliation.
+
+Refund settlement and deterministic restock-row insertion share one D1 batch.
+Stock is drained separately, so a webhook can be retried without repeating a
+restock. Settlement email uses `refund/<stripeRefundId>/succeeded/v1` as its
+provider idempotency key.
+
+## Fulfillment hold contract
+
+Mercora does not yet contain the shipment command; that arrives in U13. That
+command must reject a transition while any refund has status `pending` or
+`requires_action`.
+
+The pre-read check is only for a clear `refund_pending` response. The same
+predicate must also be inside the atomic `UPDATE ... SET status = 'shipped'`
+statement, otherwise a refund reservation can land between the read and write.
+Already-shipped idempotency/conflict handling must happen before this hold,
+because a later refund cannot undo a physical shipment.
+
+Use `SHIPMENT_NO_UNSETTLED_REFUNDS_SQL` from
+`lib/utils/refund-validation.ts` in that future compare-and-swap. Its tested JSON
+guard ignores absent, malformed, scalar, and substring-only legacy values while
+blocking well-formed reserved refund objects.
+
+## Legacy orders
+
+Older orders may lack stable line ids or `checkout_line_allocations`.
+
+- A full legacy refund remains exact because it uses the remaining order total.
+- A partial legacy amount is a proportional operator estimate and the admin UI
+  must label it as such.
+- Targeted promotion and per-line provider tax attribution cannot be recreated
+  exactly after the fact.
+- Unknown or ambiguous line identity fails closed instead of restocking a
+  guessed variant.
+
+Do not backfill invented allocation data into historical orders.
+
+## Inspection and repair
+
+Start with read-only inspection:
+
+```sql
+SELECT event_id, event_type, status, outcome, attempt_count,
+       lease_expires_at, last_error, updated_at
+FROM processed_webhook_events
+WHERE status <> 'completed'
+ORDER BY updated_at;
+
+SELECT effect_key, order_id, effect_type, status, attempt_count,
+       lease_expires_at, next_attempt_at, last_error
+FROM order_effects
+WHERE status <> 'succeeded'
+ORDER BY updated_at;
+
+SELECT adjustment_key, order_id, line_id, variant_id, kind, status,
+       attempt_count, lease_expires_at, next_attempt_at, last_error, result
+FROM inventory_adjustments
+WHERE status NOT IN ('succeeded', 'skipped')
+ORDER BY updated_at;
+
+SELECT id, payment_status,
+       json_extract(extensions, '$.refunds_version') AS refunds_version,
+       json_extract(extensions, '$.stripe_amount_refunded') AS stripe_floor,
+       json_extract(extensions, '$.refunds') AS refunds
+FROM orders
+WHERE json_array_length(
+  CASE
+    WHEN json_valid(COALESCE(extensions, '{}')) = 1
+      AND json_type(extensions, '$.refunds') = 'array'
+      THEN json_extract(extensions, '$.refunds')
+    ELSE '[]'
+  END
+) > 0;
+```
+
+For provider/local disagreement:
+
+1. Inspect the PaymentIntent, charge, and refund ids in Stripe.
+2. Correct the underlying configuration or malformed local record deliberately;
+   do not delete durable claim rows to force retries.
+3. Redeliver the original Stripe event from the Dashboard. Use
+   `charge.refunded` when Dashboard-created refunds need attribution.
+4. Let the cron drain any staged adjustment. Review `needs_review` rows manually;
+   they are terminal because automatic mutation would be unsafe.
+
+Avoid direct quantity edits while a related adjustment is retryable. If a
+manual repair is unavoidable, record the reason and reconcile the adjustment
+row and order ledger together.
+
+## Verification
+
+Run both suites under the project's Node 24 standard:
+
+```bash
+npm test
+npm run test:workers
+npm run typecheck
+npm run lint
+```
+
+The Workers suite is a required correctness gate because it verifies D1 batch
+rollback, JSON predicates, leases, CAS races, and exactly-once adjustment keys
+against real D1 behavior rather than an in-memory mock.

--- a/lib/admin/order-return-calculation.ts
+++ b/lib/admin/order-return-calculation.ts
@@ -1,6 +1,7 @@
 import { Money } from '@/lib/money';
 
 interface ReturnItem {
+  id?: string;
   product_id: string;
   variant_id?: string;
   quantity: number;
@@ -29,6 +30,7 @@ export interface ReturnCalculation {
   restockingFee: number;
   baseAmount: number;
   total: number;
+  allocationMethod: 'exact_snapshot' | 'legacy_proportional' | 'legacy_full_order';
   policy: {
     shippingRefunded: boolean;
     restockingFeeApplied: boolean;
@@ -46,6 +48,94 @@ function storedMinor(value: unknown, currency: string): number {
   return value === undefined || value === null
     ? 0
     : Money.fromStored(value, currency).toMinorUnits();
+}
+
+interface ParsedLineAllocation {
+  lineId: string;
+  productId: string;
+  variantId: string;
+  quantity: number;
+  catalogSubtotal: number;
+  merchandiseDiscount: number;
+  netMerchandise: number;
+  tax: number;
+}
+
+function lineSelectionKey(item: ReturnItem): string {
+  return item.id ?? `${item.product_id}-${item.variant_id || 'default'}`;
+}
+
+function exactAllocations(order: ReturnOrder): ParsedLineAllocation[] | null {
+  const raw = order.extensions?.checkout_line_allocations;
+  if (raw === undefined) return null;
+  if (!Array.isArray(raw) || raw.length !== order.items.length) {
+    throw new Error('Stored checkout line allocations are corrupt');
+  }
+
+  const seen = new Set<string>();
+  const parsed = raw.map((value) => {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      throw new Error('Stored checkout line allocations are corrupt');
+    }
+    const entry = value as Record<string, unknown>;
+    if (
+      typeof entry.lineId !== 'string' || !entry.lineId || seen.has(entry.lineId) ||
+      typeof entry.productId !== 'string' || !entry.productId ||
+      typeof entry.variantId !== 'string' || !entry.variantId ||
+      !Number.isSafeInteger(entry.quantity) || Number(entry.quantity) <= 0
+    ) {
+      throw new Error('Stored checkout line allocations are corrupt');
+    }
+    seen.add(entry.lineId);
+    const catalogSubtotal = storedMinor(entry.catalogSubtotal, order.currency_code);
+    const merchandiseDiscount = storedMinor(entry.merchandiseDiscount, order.currency_code);
+    const netMerchandise = storedMinor(entry.netMerchandise, order.currency_code);
+    const tax = storedMinor(entry.tax, order.currency_code);
+    if (
+      catalogSubtotal < 0 || merchandiseDiscount < 0 || tax < 0 ||
+      merchandiseDiscount > catalogSubtotal ||
+      netMerchandise !== catalogSubtotal - merchandiseDiscount ||
+      tax > netMerchandise
+    ) {
+      throw new Error('Stored checkout line allocations are corrupt');
+    }
+    return {
+      lineId: entry.lineId,
+      productId: entry.productId,
+      variantId: entry.variantId,
+      quantity: Number(entry.quantity),
+      catalogSubtotal,
+      merchandiseDiscount,
+      netMerchandise,
+      tax,
+    };
+  });
+
+  const byId = new Map(parsed.map((allocation) => [allocation.lineId, allocation]));
+  for (const item of order.items) {
+    if (!item.id) throw new Error('Stored checkout line allocations do not match order lines');
+    const allocation = byId.get(item.id);
+    if (
+      !allocation || allocation.productId !== item.product_id ||
+      allocation.variantId !== item.variant_id || allocation.quantity !== item.quantity
+    ) {
+      throw new Error('Stored checkout line allocations do not match order lines');
+    }
+  }
+
+  const extensions = order.extensions ?? {};
+  const snapshotSubtotal = storedMinor(extensions.checkout_catalog_subtotal, order.currency_code);
+  const snapshotDiscount = storedMinor(extensions.checkout_merchandise_discount, order.currency_code);
+  const snapshotTax = storedMinor(extensions.checkout_tax, order.currency_code);
+  const shippingTax = storedMinor(extensions.checkout_shipping_tax, order.currency_code);
+  if (
+    parsed.reduce((sum, line) => sum + line.catalogSubtotal, 0) !== snapshotSubtotal ||
+    parsed.reduce((sum, line) => sum + line.merchandiseDiscount, 0) !== snapshotDiscount ||
+    parsed.reduce((sum, line) => sum + line.tax, 0) + shippingTax !== snapshotTax
+  ) {
+    throw new Error('Stored checkout allocation totals are corrupt');
+  }
+  return parsed;
 }
 
 /** Calculate a partial return entirely in integer minor units. */
@@ -94,20 +184,41 @@ export function calculatePartialReturnMinor(
   }
 
   const selected = new Set(selectedItemIds);
-  const returnItemsSubtotal = order.items
-    .filter((item) => selected.has(`${item.product_id}-${item.variant_id || 'default'}`))
-    .reduce(
-      (total, item) => total + wireMajorToMinor(item.unit_price, order.currency_code) * item.quantity,
-      0
-    );
-  const subtotalRatio = orderSubtotal > 0 ? returnItemsSubtotal / orderSubtotal : 0;
-  const returnTax = Math.round(orderTax * subtotalRatio);
-  const returnDiscount = Math.round(orderDiscount * subtotalRatio);
-  const isFullReturn = selectedItemIds.length === order.items.length;
+  const isFullReturn = order.items.length > 0 &&
+    order.items.every((item) => selected.has(lineSelectionKey(item)));
   const returnShipping = (
     (isFullReturn && policy.refundShippingOnFullReturn) ||
     (!isFullReturn && policy.refundShipping)
   ) ? orderShipping : 0;
+  const allocations = exactAllocations(order);
+  let returnItemsSubtotal: number;
+  let returnTax: number;
+  let returnDiscount: number;
+  let allocationMethod: ReturnCalculation['allocationMethod'];
+  if (allocations) {
+    const selectedAllocations = allocations.filter((line) => selected.has(line.lineId));
+    returnItemsSubtotal = selectedAllocations.reduce((sum, line) => sum + line.catalogSubtotal, 0);
+    returnDiscount = selectedAllocations.reduce(
+      (sum, line) => sum + line.merchandiseDiscount,
+      0
+    );
+    returnTax = selectedAllocations.reduce((sum, line) => sum + line.tax, 0) +
+      (returnShipping > 0
+        ? storedMinor(extensions.checkout_shipping_tax, order.currency_code)
+        : 0);
+    allocationMethod = 'exact_snapshot';
+  } else {
+    returnItemsSubtotal = order.items
+      .filter((item) => selected.has(lineSelectionKey(item)))
+      .reduce(
+        (total, item) => total + wireMajorToMinor(item.unit_price, order.currency_code) * item.quantity,
+        0
+      );
+    const subtotalRatio = orderSubtotal > 0 ? returnItemsSubtotal / orderSubtotal : 0;
+    returnTax = isFullReturn ? orderTax : Math.round(orderTax * subtotalRatio);
+    returnDiscount = isFullReturn ? orderDiscount : Math.round(orderDiscount * subtotalRatio);
+    allocationMethod = isFullReturn ? 'legacy_full_order' : 'legacy_proportional';
+  }
   const baseAmount = returnItemsSubtotal + returnTax - returnDiscount + returnShipping;
   const restockingFee = (
     (isFullReturn || policy.applyRestockingFeeOnPartialReturn) &&
@@ -122,6 +233,7 @@ export function calculatePartialReturnMinor(
     restockingFee,
     baseAmount,
     total: Math.max(0, baseAmount - restockingFee),
+    allocationMethod,
     policy: {
       shippingRefunded: returnShipping > 0,
       restockingFeeApplied: restockingFee > 0,

--- a/lib/db/schema/index.ts
+++ b/lib/db/schema/index.ts
@@ -118,3 +118,6 @@ export * from "./webhook-events";
 
 // Durable post-payment recovery state (application-specific)
 export * from "./order-effects";
+
+// Durable authoritative variant-inventory mutations (application-specific)
+export * from "./inventory-adjustments";

--- a/lib/db/schema/index.ts
+++ b/lib/db/schema/index.ts
@@ -112,3 +112,6 @@ export * from "./reviews";
 
 // Analytics cache schema (Admin BI dashboard, application-specific)
 export * from "./analytics";
+
+// Durable Stripe webhook claim state (application-specific)
+export * from "./webhook-events";

--- a/lib/db/schema/index.ts
+++ b/lib/db/schema/index.ts
@@ -115,3 +115,6 @@ export * from "./analytics";
 
 // Durable Stripe webhook claim state (application-specific)
 export * from "./webhook-events";
+
+// Durable post-payment recovery state (application-specific)
+export * from "./order-effects";

--- a/lib/db/schema/inventory-adjustments.ts
+++ b/lib/db/schema/inventory-adjustments.ts
@@ -1,0 +1,33 @@
+import { index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+import { orders } from './order';
+
+export const inventory_adjustments = sqliteTable(
+  'inventory_adjustments',
+  {
+    adjustment_key: text('adjustment_key').primaryKey(),
+    order_id: text('order_id').notNull().references(() => orders.id),
+    line_id: text('line_id'),
+    variant_id: text('variant_id').notNull(),
+    kind: text('kind', { enum: ['paid_decrement', 'refund_restock'] }).notNull(),
+    quantity: integer('quantity').notNull(),
+    status: text('status', {
+      enum: ['pending', 'processing', 'succeeded', 'skipped', 'needs_review', 'failed'],
+    }).notNull(),
+    attempt_count: integer('attempt_count').notNull().default(0),
+    claim_token: text('claim_token'),
+    lease_expires_at: text('lease_expires_at'),
+    next_attempt_at: text('next_attempt_at'),
+    result: text('result'),
+    last_error: text('last_error'),
+    created_at: text('created_at').notNull(),
+    updated_at: text('updated_at').notNull(),
+    completed_at: text('completed_at'),
+  },
+  (table) => ({
+    retryIdx: index('idx_inventory_adjustments_retry')
+      .on(table.status, table.next_attempt_at, table.lease_expires_at),
+    orderIdx: index('idx_inventory_adjustments_order').on(table.order_id, table.kind),
+  })
+);
+
+export type InventoryAdjustmentRow = typeof inventory_adjustments.$inferSelect;

--- a/lib/db/schema/order-effects.ts
+++ b/lib/db/schema/order-effects.ts
@@ -1,0 +1,32 @@
+import { index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+import { orders } from './order';
+
+export const order_effects = sqliteTable(
+  'order_effects',
+  {
+    effect_key: text('effect_key').primaryKey(),
+    order_id: text('order_id').notNull().references(() => orders.id),
+    effect_type: text('effect_type', {
+      enum: ['inventory', 'coupon', 'gift_card', 'subscription', 'confirmation_email'],
+    }).notNull(),
+    status: text('status', {
+      enum: ['pending', 'processing', 'succeeded', 'failed'],
+    }).notNull(),
+    attempt_count: integer('attempt_count').notNull().default(0),
+    claim_token: text('claim_token'),
+    lease_expires_at: text('lease_expires_at'),
+    next_attempt_at: text('next_attempt_at'),
+    last_error: text('last_error'),
+    result: text('result'),
+    created_at: text('created_at').notNull(),
+    updated_at: text('updated_at').notNull(),
+    completed_at: text('completed_at'),
+  },
+  (table) => ({
+    retryIdx: index('idx_order_effects_retry')
+      .on(table.status, table.next_attempt_at, table.lease_expires_at),
+    orderIdx: index('idx_order_effects_order').on(table.order_id),
+  })
+);
+
+export type OrderEffectRow = typeof order_effects.$inferSelect;

--- a/lib/db/schema/products.ts
+++ b/lib/db/schema/products.ts
@@ -17,6 +17,7 @@ import type {
   Rating,
   ProductInventory
 } from '@/lib/types';
+import { isVariantAvailable as hasAvailableInventory } from '@/lib/inventory/availability';
 
 // Main products table
 export const products = sqliteTable('products', {
@@ -216,12 +217,7 @@ export function getAvailableOptionValues(
 }
 
 export function isVariantAvailable(variant: ProductVariant): boolean {
-  return (
-    variant.status === 'active' &&
-    (!variant.inventory?.track_inventory || 
-     (variant.inventory.quantity && variant.inventory.quantity > 0) ||
-     Boolean(variant.inventory.allow_backorder))
-  );
+  return hasAvailableInventory(variant);
 }
 
 export function getVariantInventoryLevel(variant: ProductVariant): number {

--- a/lib/db/schema/settings.ts
+++ b/lib/db/schema/settings.ts
@@ -122,6 +122,13 @@ export const defaultSettings = [
     description: 'Minimum refund amount in cents ($5.00)',
     data_type: 'number'
   },
+  {
+    key: 'refund.external_full_restock_enabled',
+    value: JSON.stringify(false),
+    category: 'refund',
+    description: 'Restock every outstanding line after a full Stripe Dashboard refund',
+    data_type: 'boolean'
+  },
   
   // Promotions & Banners
   {

--- a/lib/db/schema/webhook-events.ts
+++ b/lib/db/schema/webhook-events.ts
@@ -1,0 +1,27 @@
+import { index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+
+export const processed_webhook_events = sqliteTable(
+  'processed_webhook_events',
+  {
+    event_id: text('event_id').primaryKey(),
+    event_type: text('event_type').notNull(),
+    status: text('status', { enum: ['processing', 'completed', 'failed'] }).notNull(),
+    attempt_count: integer('attempt_count').notNull().default(0),
+    claim_token: text('claim_token'),
+    claimed_at: text('claimed_at'),
+    lease_expires_at: text('lease_expires_at'),
+    completed_at: text('completed_at'),
+    last_error: text('last_error'),
+    outcome: text('outcome'),
+    created_at: text('created_at').notNull(),
+    updated_at: text('updated_at').notNull(),
+  },
+  (table) => ({
+    statusLeaseIdx: index('idx_processed_webhook_events_status_lease')
+      .on(table.status, table.lease_expires_at),
+    completedAtIdx: index('idx_processed_webhook_events_completed_at')
+      .on(table.completed_at),
+  })
+);
+
+export type ProcessedWebhookEventRow = typeof processed_webhook_events.$inferSelect;

--- a/lib/inventory/availability.ts
+++ b/lib/inventory/availability.ts
@@ -1,0 +1,25 @@
+import type { ProductInventory, ProductVariant } from '@/lib/types';
+
+export function isInventoryAvailable(inventory: ProductInventory | null | undefined): boolean {
+  if (!inventory?.track_inventory) return true;
+  const quantity = inventory.quantity ?? 0;
+  if (!Number.isSafeInteger(quantity)) return false;
+  if (inventory.allow_backorder) return true;
+  return quantity > 0;
+}
+
+export function canFulfillInventory(
+  inventory: ProductInventory | null | undefined,
+  requestedQuantity: number
+): boolean {
+  if (!Number.isSafeInteger(requestedQuantity) || requestedQuantity <= 0) return false;
+  if (!inventory?.track_inventory) return true;
+  const quantity = inventory.quantity ?? 0;
+  if (!Number.isSafeInteger(quantity)) return false;
+  return inventory.allow_backorder || quantity >= requestedQuantity;
+}
+
+export function isVariantAvailable(variant: Pick<ProductVariant, 'status' | 'inventory'>): boolean {
+  return (variant.status == null || variant.status === 'active') &&
+    isInventoryAvailable(variant.inventory);
+}

--- a/lib/models/mach/product-serializer.ts
+++ b/lib/models/mach/product-serializer.ts
@@ -1,5 +1,6 @@
 import type { Product, ProductVariant } from '@/lib/types';
 import { Money, toWireMoney, type MachMoney } from '@/lib/money';
+import { isVariantAvailable } from '@/lib/inventory/availability';
 
 export type WireVariant = Omit<ProductVariant, 'price' | 'compare_at_price' | 'cost'> & {
   price: MachMoney;
@@ -38,7 +39,7 @@ function toPublicVariant(variant: ProductVariant): ProductVariant {
 
   return {
     ...publicVariant,
-    available_for_sale: (variant.inventory?.quantity ?? 0) > 0,
+    available_for_sale: isVariantAvailable(variant),
     ...(publicVariant.media
       ? { media: publicVariant.media.map(toPublicMedia) }
       : {}),

--- a/lib/payments/refund-email.ts
+++ b/lib/payments/refund-email.ts
@@ -1,0 +1,48 @@
+import { Money } from '@/lib/money';
+import { getStoreConfig } from '@/lib/store-config';
+import { getResendClient, type EmailResult } from '@/lib/utils/email';
+import { escapeHtmlText } from '@/lib/utils/maintenance-html';
+
+export interface RefundSettledEmailInput {
+  orderId: string;
+  refundId: string;
+  amount: number;
+  currencyCode: string;
+  customerEmail?: string;
+  customerName?: string;
+}
+
+/** Send one provider-idempotent notification for a settled Stripe refund. */
+export async function sendRefundSettledEmail(
+  input: RefundSettledEmailInput
+): Promise<EmailResult> {
+  if (!input.customerEmail) return { success: true };
+  const store = getStoreConfig();
+  const amount = Money.fromMinor(input.amount, input.currencyCode).format();
+  const customerName = input.customerName || 'Customer';
+  const html = `<!doctype html>
+<html><body style="font-family:Arial,sans-serif;color:#1e293b">
+  <h1>${escapeHtmlText(store.identity.name)}</h1>
+  <p>Hi ${escapeHtmlText(customerName)},</p>
+  <p>We processed a refund of <strong>${escapeHtmlText(amount)}</strong> for order
+    <strong>#${escapeHtmlText(input.orderId)}</strong>.</p>
+  <p>Your bank may take several business days to show the credit.</p>
+  <p>Questions? Contact ${escapeHtmlText(store.contact.supportEmail)}.</p>
+</body></html>`;
+
+  try {
+    const { data, error } = await getResendClient().emails.send({
+      from: store.contact.senderEmail,
+      to: [input.customerEmail],
+      subject: `Refund processed for order #${input.orderId} - ${store.identity.name}`,
+      html,
+    }, { idempotencyKey: `refund/${input.refundId}/succeeded/v1` });
+    if (error) return { success: false, error: error.message || 'Refund email failed' };
+    return { success: true, id: data?.id };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Refund email failed',
+    };
+  }
+}

--- a/lib/payments/refund-idempotency.ts
+++ b/lib/payments/refund-idempotency.ts
@@ -1,0 +1,94 @@
+import { sha256Hex } from '@/lib/auth/crypto';
+import {
+  MAX_REFUND_LINE_IDS,
+  MAX_REFUND_TEXT_LENGTH,
+  isPositiveSafeInteger,
+} from '@/lib/utils/refund-validation';
+
+export interface RefundIdempotencyInput {
+  orderId: string;
+  type: 'full' | 'partial';
+  refundAmount: number;
+  /** Monotonic sequence derived from the settled (non-reserved) ledger. */
+  settledSequence: number;
+  /** Stable order-line ids. Product or variant ids are not sufficient. */
+  lineIds?: string[] | null;
+}
+
+export type RefundRequestFingerprintInput = Omit<RefundIdempotencyInput, 'settledSequence'>;
+
+function assertBoundedText(value: unknown, name: string): asserts value is string {
+  if (typeof value !== 'string' || value.trim().length === 0 || value.length > MAX_REFUND_TEXT_LENGTH) {
+    throw new TypeError(`${name} must be a non-empty string of at most ${MAX_REFUND_TEXT_LENGTH} characters`);
+  }
+}
+
+/** Sort and validate exact stable line ids without changing their spelling. */
+export function normalizeRefundLineIds(lineIds: string[] | null | undefined): string[] {
+  if (lineIds == null) return [];
+  if (!Array.isArray(lineIds) || lineIds.length > MAX_REFUND_LINE_IDS) {
+    throw new TypeError(`lineIds must contain at most ${MAX_REFUND_LINE_IDS} entries`);
+  }
+  const normalized = lineIds.slice();
+  for (const lineId of normalized) assertBoundedText(lineId, 'lineId');
+  if (new Set(normalized).size !== normalized.length) {
+    throw new TypeError('lineIds must not contain duplicates');
+  }
+  normalized.sort();
+  return normalized;
+}
+
+/** Compatibility helper for callers that need the canonical serialized set. */
+export function normalizeRefundItemKeys(lineIds: string[] | null | undefined): string {
+  return JSON.stringify(normalizeRefundLineIds(lineIds));
+}
+
+/** Derive a bounded deterministic Stripe idempotency key. */
+export async function deriveRefundIdempotencyKey(input: RefundIdempotencyInput): Promise<string> {
+  assertBoundedText(input.orderId, 'orderId');
+  if (input.type !== 'full' && input.type !== 'partial') {
+    throw new TypeError('type must be full or partial');
+  }
+  if (!isPositiveSafeInteger(input.refundAmount)) {
+    throw new TypeError('refundAmount must be a positive safe integer');
+  }
+  if (!Number.isSafeInteger(input.settledSequence) || input.settledSequence < 0) {
+    throw new TypeError('settledSequence must be a non-negative safe integer');
+  }
+
+  const canonical = JSON.stringify({
+    orderId: input.orderId,
+    type: input.type,
+    amount: input.refundAmount,
+    settledSequence: input.settledSequence,
+    lineIds: normalizeRefundLineIds(input.lineIds),
+  });
+  return `refund:${await sha256Hex(canonical)}`;
+}
+
+/**
+ * Stable operation fingerprint used to recognize retries after settlement.
+ *
+ * The current refund contract returns whole order lines, so a given line set,
+ * type, and amount is one operation for the lifetime of the order. Supporting
+ * multiple partial-quantity returns for the same lines would require a distinct
+ * client operation id and a versioned fingerprint contract.
+ */
+export async function deriveRefundRequestFingerprint(
+  input: RefundRequestFingerprintInput
+): Promise<string> {
+  assertBoundedText(input.orderId, 'orderId');
+  if (input.type !== 'full' && input.type !== 'partial') {
+    throw new TypeError('type must be full or partial');
+  }
+  if (!isPositiveSafeInteger(input.refundAmount)) {
+    throw new TypeError('refundAmount must be a positive safe integer');
+  }
+  const canonical = JSON.stringify({
+    orderId: input.orderId,
+    type: input.type,
+    amount: input.refundAmount,
+    lineIds: normalizeRefundLineIds(input.lineIds),
+  });
+  return `refund-request:${await sha256Hex(canonical)}`;
+}

--- a/lib/payments/refund-ledger-store.ts
+++ b/lib/payments/refund-ledger-store.ts
@@ -1,0 +1,122 @@
+import { and, eq, isNull, sql } from 'drizzle-orm';
+import type { getDbAsync } from '@/lib/db';
+import { orders } from '@/lib/db/schema/order';
+import {
+  MAX_REFUND_RECORDS,
+  type RefundRecord,
+} from '@/lib/utils/refund-validation';
+
+type Db = Awaited<ReturnType<typeof getDbAsync>>;
+export type RefundOrderRow = typeof orders.$inferSelect;
+export const MAX_REFUND_CAS_ATTEMPTS = 5;
+
+export interface RefundLedgerContext {
+  order: RefundOrderRow;
+  extensions: Record<string, unknown>;
+  refunds: RefundRecord[];
+  version: number;
+  nextVersion: number;
+  nowIso: string;
+}
+
+export type RefundLedgerMutation =
+  | { action: 'skip' }
+  | {
+      action: 'write';
+      extensions: Record<string, unknown>;
+      columns?: Partial<Pick<RefundOrderRow, 'status' | 'payment_status' | 'notes'>>;
+    };
+
+export type RefundLedgerMutationResult =
+  | { ok: true; skipped: boolean; order: RefundOrderRow }
+  | { ok: false; reason: 'not_found' | 'invalid_ledger' | 'cas_exhausted' };
+
+export function parseRefundExtensions(value: unknown): Record<string, unknown> | null {
+  let parsed = value;
+  if (typeof value === 'string') {
+    try {
+      parsed = JSON.parse(value);
+    } catch {
+      return null;
+    }
+  }
+  if (parsed == null) return {};
+  return typeof parsed === 'object' && !Array.isArray(parsed)
+    ? parsed as Record<string, unknown>
+    : null;
+}
+
+export function readRefundsVersion(extensions: Record<string, unknown>): number | null {
+  const value = extensions.refunds_version ?? 0;
+  return Number.isSafeInteger(value) && (value as number) >= 0
+    ? value as number
+    : null;
+}
+
+function updatedAtGuard(value: string | null) {
+  return value === null ? isNull(orders.updated_at) : eq(orders.updated_at, value);
+}
+
+function refundsVersionGuard(version: number) {
+  return sql`COALESCE(json_extract(${orders.extensions}, '$.refunds_version'), 0) = ${version}`;
+}
+
+/**
+ * Run a bounded optimistic-concurrency update over the JSON refund ledger.
+ * The callback may be retried and therefore must remain side-effect free.
+ */
+export async function mutateRefundLedger(
+  db: Db,
+  orderId: string,
+  mutate: (context: RefundLedgerContext) => RefundLedgerMutation | Promise<RefundLedgerMutation>,
+  options: { now?: () => Date; maxAttempts?: number } = {}
+): Promise<RefundLedgerMutationResult> {
+  const attempts = options.maxAttempts ?? MAX_REFUND_CAS_ATTEMPTS;
+  if (!Number.isSafeInteger(attempts) || attempts < 1 || attempts > 10) {
+    throw new Error('Refund ledger CAS attempts must be between 1 and 10');
+  }
+
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    const [order] = await db.select().from(orders).where(eq(orders.id, orderId)).limit(1);
+    if (!order) return { ok: false, reason: 'not_found' };
+
+    const extensions = parseRefundExtensions(order.extensions);
+    if (!extensions) return { ok: false, reason: 'invalid_ledger' };
+    const rawRefunds = extensions.refunds ?? [];
+    if (!Array.isArray(rawRefunds) || rawRefunds.length > MAX_REFUND_RECORDS) {
+      return { ok: false, reason: 'invalid_ledger' };
+    }
+    const version = readRefundsVersion(extensions);
+    if (version === null || version === Number.MAX_SAFE_INTEGER) {
+      return { ok: false, reason: 'invalid_ledger' };
+    }
+    const nowIso = (options.now?.() ?? new Date()).toISOString();
+    const decision = await mutate({
+      order,
+      extensions,
+      refunds: rawRefunds as RefundRecord[],
+      version,
+      nextVersion: version + 1,
+      nowIso,
+    });
+    if (decision.action === 'skip') {
+      return { ok: true, skipped: true, order };
+    }
+    if (decision.extensions.refunds_version !== version + 1) {
+      throw new Error('Refund ledger mutation must increment refunds_version exactly once');
+    }
+
+    const [updated] = await db.update(orders).set({
+      ...(decision.columns ?? {}),
+      extensions: decision.extensions,
+      updated_at: nowIso,
+    }).where(and(
+      eq(orders.id, orderId),
+      updatedAtGuard(order.updated_at ?? null),
+      refundsVersionGuard(version)
+    )).returning();
+    if (updated) return { ok: true, skipped: false, order: updated };
+  }
+
+  return { ok: false, reason: 'cas_exhausted' };
+}

--- a/lib/payments/refund-ledger.ts
+++ b/lib/payments/refund-ledger.ts
@@ -1,0 +1,244 @@
+import {
+  deriveRefundIdempotencyKey,
+  deriveRefundRequestFingerprint,
+  normalizeRefundLineIds,
+} from '@/lib/payments/refund-idempotency';
+import {
+  MAX_REFUND_RECORDS,
+  assertRefundWithinRemaining,
+  classifyRefundStatus,
+  computeRefundedTotal,
+  isPositiveSafeInteger,
+  resolveFullRefundAmount,
+  type RefundRecord,
+} from '@/lib/utils/refund-validation';
+
+export interface RefundLedgerRequest {
+  orderId: string;
+  type: 'full' | 'partial';
+  amount?: number;
+  lineIds?: string[];
+  totalAmount: number;
+  /** Provider-observed cumulative truth. Reject-only; never a hash input. */
+  stripeRefundedFloor?: number;
+}
+
+export type RefundLedgerDecision =
+  | {
+      action: 'completed';
+      entryIndex: number;
+      idempotencyKey: string;
+      requestFingerprint: string;
+      refundAmount: number;
+      stripeRefundId: string;
+      providerStatus: string;
+    }
+  | {
+      action: 'reconcile';
+      entryIndex: number;
+      idempotencyKey: string;
+      requestFingerprint: string;
+      refundAmount: number;
+      stripeRefundId?: string;
+      requestedAt?: string;
+    }
+  | {
+      action: 'reserve';
+      idempotencyKey: string;
+      requestFingerprint: string;
+      refundAmount: number;
+      settledSequence: number;
+    }
+  | {
+      action: 'reject';
+      status: 400 | 409;
+      error: string;
+    };
+
+function isReserved(record: RefundRecord): boolean {
+  return classifyRefundStatus(record.status) === 'reserved';
+}
+
+function reject(error: string, status: 400 | 409 = 400): RefundLedgerDecision {
+  return { action: 'reject', status, error };
+}
+
+/**
+ * Reconcile an exact pending reservation or decide a new atomic reservation.
+ * Pure apart from Workers-compatible Web Crypto used for the deterministic key.
+ */
+export async function decideRefundLedgerAction(
+  refunds: RefundRecord[],
+  request: RefundLedgerRequest
+): Promise<RefundLedgerDecision> {
+  if (!Array.isArray(refunds) || refunds.length > MAX_REFUND_RECORDS) {
+    return reject('Refund ledger is invalid or exceeds its supported size', 409);
+  }
+  if (!isPositiveSafeInteger(request.totalAmount)) {
+    return reject('Order total must be a positive safe integer');
+  }
+
+  // Failed/canceled entries remain part of the monotonic sequence even though
+  // they release money. Only currently reserved entries are omitted so a retry
+  // reproduces the key stored by its own pending reservation.
+  const settledBaseline = refunds.filter((entry) => !isReserved(entry));
+  const settledSequence = settledBaseline.length;
+  const allRefunded = computeRefundedTotal({ refunds });
+  if (!Number.isSafeInteger(allRefunded)) {
+    return reject('Refund ledger arithmetic is invalid', 409);
+  }
+
+  // Re-derive each pending entry's key from its stored immutable sequence and
+  // exact request fields. This remains stable if an unrelated pending refund
+  // settles between the original attempt and its retry.
+  let requestLines: string[];
+  try {
+    requestLines = normalizeRefundLineIds(request.lineIds);
+  } catch (error) {
+    return reject(error instanceof Error ? error.message : 'Invalid refund request');
+  }
+  const matching: Array<{
+    entryIndex: number;
+    key: string;
+    fingerprint: string;
+    amount: number;
+    status: 'reserved' | 'settled';
+    stripeRefundId?: string;
+    providerStatus?: string;
+    requestedAt?: string;
+  }> = [];
+  for (const [entryIndex, entry] of refunds.entries()) {
+    const status = classifyRefundStatus(entry.status);
+    if ((status !== 'reserved' && status !== 'settled') ||
+        entry.type !== request.type || !isPositiveSafeInteger(entry.amount)) {
+      continue;
+    }
+    if (request.type === 'partial' && entry.amount !== request.amount) continue;
+    let entryLines: string[];
+    try {
+      entryLines = normalizeRefundLineIds(entry.items);
+    } catch {
+      return reject('Pending refund reservation has invalid line ids', 409);
+    }
+    if (JSON.stringify(entryLines) !== JSON.stringify(requestLines)) continue;
+    if (typeof entry.request_fingerprint !== 'string' ||
+        typeof entry.idempotency_key !== 'string') {
+      return reject('Refund entry has invalid retry identity', 409);
+    }
+    const fingerprint = await deriveRefundRequestFingerprint({
+      orderId: request.orderId,
+      type: request.type,
+      refundAmount: entry.amount,
+      lineIds: entryLines,
+    });
+    if (fingerprint !== entry.request_fingerprint) {
+      return reject('Refund entry fingerprint is inconsistent', 409);
+    }
+    if (!Number.isSafeInteger(entry.settled_sequence) || Number(entry.settled_sequence) < 0) {
+      return reject('Refund entry has invalid idempotency sequence', 409);
+    }
+    const key = await deriveRefundIdempotencyKey({
+      orderId: request.orderId,
+      type: request.type,
+      refundAmount: entry.amount,
+      settledSequence: Number(entry.settled_sequence),
+      lineIds: entryLines,
+    });
+    if (key !== entry.idempotency_key) {
+      return reject('Refund entry idempotency key is inconsistent', 409);
+    }
+    matching.push({
+      entryIndex,
+      key,
+      fingerprint,
+      amount: entry.amount,
+      status,
+      ...(typeof entry.stripe_refund_id === 'string'
+        ? { stripeRefundId: entry.stripe_refund_id }
+        : {}),
+      ...(typeof entry.provider_status === 'string'
+        ? { providerStatus: entry.provider_status }
+        : {}),
+      ...(typeof entry.requested_at === 'string' ? { requestedAt: entry.requested_at } : {}),
+    });
+  }
+  if (matching.length > 1) {
+    return reject('Multiple ledger entries match this refund request', 409);
+  }
+  if (matching.length === 1) {
+    const match = matching[0];
+    if (match.status === 'settled') {
+      if (!match.stripeRefundId) return reject('Settled refund is missing its Stripe id', 409);
+      return {
+        action: 'completed',
+        entryIndex: match.entryIndex,
+        idempotencyKey: match.key,
+        requestFingerprint: match.fingerprint,
+        refundAmount: match.amount,
+        stripeRefundId: match.stripeRefundId,
+        providerStatus: match.providerStatus ?? 'succeeded',
+      };
+    }
+    return {
+      action: 'reconcile',
+      entryIndex: match.entryIndex,
+      idempotencyKey: match.key,
+      requestFingerprint: match.fingerprint,
+      refundAmount: match.amount,
+      ...(match.stripeRefundId ? { stripeRefundId: match.stripeRefundId } : {}),
+      ...(match.requestedAt ? { requestedAt: match.requestedAt } : {}),
+    };
+  }
+
+  if (refunds.length >= MAX_REFUND_RECORDS) {
+    return reject('Refund ledger has reached its supported size', 409);
+  }
+
+  let refundAmount: number;
+  if (request.type === 'full') {
+    const result = resolveFullRefundAmount(request.totalAmount, allRefunded);
+    if (!result.ok) return reject(result.error);
+    refundAmount = result.amount;
+  } else {
+    if (request.amount === undefined) return reject('Partial refunds require an amount');
+    const result = assertRefundWithinRemaining(request.totalAmount, allRefunded, request.amount);
+    if (!result.ok) return reject(result.error);
+    refundAmount = request.amount;
+  }
+
+  // Fail closed when Stripe knows about more money than the local ledger. This
+  // is deliberately after amount resolution and never changes amount/sequence.
+  const floor = request.stripeRefundedFloor;
+  if (floor !== undefined) {
+    if (!Number.isSafeInteger(floor) || floor < 0) {
+      return reject('Stripe refunded amount is invalid', 409);
+    }
+    if (floor > allRefunded) {
+      return reject(
+        'Stripe reports more refunded than the local ledger; reconcile before refunding again',
+        409
+      );
+    }
+  }
+
+  try {
+    const idempotencyKey = await deriveRefundIdempotencyKey({
+      orderId: request.orderId,
+      type: request.type,
+      refundAmount,
+      settledSequence,
+      lineIds: request.lineIds,
+    });
+    const requestFingerprint = await deriveRefundRequestFingerprint({
+      orderId: request.orderId,
+      type: request.type,
+      refundAmount,
+      lineIds: request.lineIds,
+    });
+    return {
+      action: 'reserve', idempotencyKey, requestFingerprint, refundAmount, settledSequence,
+    };
+  } catch (error) {
+    return reject(error instanceof Error ? error.message : 'Invalid refund request');
+  }
+}

--- a/lib/payments/refund-lifecycle.ts
+++ b/lib/payments/refund-lifecycle.ts
@@ -1,0 +1,198 @@
+import {
+  MAX_REFUND_RECORDS,
+  classifyRefundStatus,
+  computeRefundedTotal,
+  isPositiveSafeInteger,
+  type RefundRecord,
+} from '@/lib/utils/refund-validation';
+
+export interface ProviderRefundSnapshot {
+  id: string;
+  amount: number;
+  status: string;
+  paymentIntentId: string;
+  requestId?: string;
+  createdAt?: string;
+}
+
+export interface RefundLifecycleInput {
+  mode: 'charge' | 'lifecycle';
+  refunds: RefundRecord[];
+  providerRefunds: ProviderRefundSnapshot[];
+  targetRefundId?: string;
+  chargeAmountRefunded: number;
+  totalAmount: number;
+  orderLineIds: string[];
+  externalRestockEnabled: boolean;
+  nowIso: string;
+}
+
+export interface RefundLifecycleDecision {
+  refunds: RefundRecord[];
+  stripeAmountRefunded: number;
+  fullyRefunded: boolean;
+  restockLineIds: string[];
+  settledRefunds: Array<{ id: string; amount: number }>;
+  matchedTarget: boolean;
+}
+
+function normalizeProviderStatus(status: string): 'pending' | 'requires_action' | 'succeeded' | 'failed' | 'canceled' {
+  const classification = classifyRefundStatus(status);
+  if (classification === 'settled') return 'succeeded';
+  if (classification === 'released') return status === 'canceled' ? 'canceled' : 'failed';
+  if (classification === 'reserved') return status === 'requires_action' ? 'requires_action' : 'pending';
+  throw new Error(`Unsupported Stripe refund status: ${status}`);
+}
+
+function validateLineIds(lineIds: string[], name: string): void {
+  if (lineIds.length > 100 || new Set(lineIds).size !== lineIds.length ||
+      lineIds.some((lineId) => typeof lineId !== 'string' || !lineId || lineId.length > 128)) {
+    throw new Error(`${name} contains invalid line ids`);
+  }
+}
+
+function findLocalEntry(
+  refunds: RefundRecord[],
+  provider: ProviderRefundSnapshot
+): number {
+  const matches = refunds.flatMap((entry, index) => {
+    const stripeMatch = entry.stripe_refund_id === provider.id;
+    const requestMatch = provider.requestId !== undefined &&
+      entry.idempotency_key === provider.requestId;
+    return stripeMatch || requestMatch ? [index] : [];
+  });
+  if (matches.length > 1) {
+    throw new Error(`Refund ${provider.id} matches multiple local ledger entries`);
+  }
+  return matches[0] ?? -1;
+}
+
+/**
+ * Reconcile signed provider truth into the local ledger without performing I/O.
+ * Only charge.refunded may append Dashboard-created refunds; lifecycle events
+ * may update an existing entry and advance the provider floor, but never append.
+ */
+export function decideRefundLifecycle(input: RefundLifecycleInput): RefundLifecycleDecision {
+  if (!Array.isArray(input.refunds) || input.refunds.length > MAX_REFUND_RECORDS) {
+    throw new Error('Refund ledger is invalid or exceeds its supported size');
+  }
+  if (!isPositiveSafeInteger(input.totalAmount) ||
+      !Number.isSafeInteger(input.chargeAmountRefunded) ||
+      input.chargeAmountRefunded < 0 ||
+      input.chargeAmountRefunded > input.totalAmount) {
+    throw new Error('Stripe refund total is invalid for this order');
+  }
+  validateLineIds(input.orderLineIds, 'Order');
+  if (input.mode === 'lifecycle' &&
+      (!input.targetRefundId || input.providerRefunds.length !== 1 ||
+        input.providerRefunds[0]?.id !== input.targetRefundId)) {
+    throw new Error('Lifecycle reconciliation requires exactly its target refund');
+  }
+
+  const providerIds = new Set<string>();
+  let providerSettledTotal = 0;
+  for (const provider of input.providerRefunds) {
+    if (!provider.id || provider.id.length > 256 || providerIds.has(provider.id) ||
+        !isPositiveSafeInteger(provider.amount) || !provider.paymentIntentId) {
+      throw new Error('Stripe returned an invalid or duplicate refund');
+    }
+    providerIds.add(provider.id);
+    if (normalizeProviderStatus(provider.status) === 'succeeded') {
+      if (providerSettledTotal > Number.MAX_SAFE_INTEGER - provider.amount) {
+        throw new Error('Stripe refund arithmetic overflowed');
+      }
+      providerSettledTotal += provider.amount;
+    }
+  }
+  if (input.mode === 'charge' && providerSettledTotal !== input.chargeAmountRefunded) {
+    throw new Error('Stripe refund list does not match the charge refund total');
+  }
+
+  const refunds = input.refunds.map((entry) => {
+    if (entry === null || typeof entry !== 'object' || Array.isArray(entry)) {
+      throw new Error('Refund ledger contains an invalid entry');
+    }
+    return { ...entry };
+  });
+  let matchedTarget = input.mode === 'charge';
+  const settledRefunds: Array<{ id: string; amount: number }> = [];
+  const restockCandidates: Array<{ provider: ProviderRefundSnapshot; entry: RefundRecord }> = [];
+
+  for (const provider of input.providerRefunds) {
+    const status = normalizeProviderStatus(provider.status);
+    let entryIndex = findLocalEntry(refunds, provider);
+    if (entryIndex < 0) {
+      if (input.mode === 'lifecycle') continue;
+      if (refunds.length >= MAX_REFUND_RECORDS) {
+        throw new Error('Refund ledger has reached its supported size');
+      }
+      refunds.push({
+        id: `stripe:${provider.id}`,
+        stripe_refund_id: provider.id,
+        amount: provider.amount,
+        type: 'partial',
+        items: [],
+        status,
+        provider_status: provider.status,
+        source: 'stripe_dashboard',
+        requested_at: provider.createdAt ?? input.nowIso,
+        processed_at: input.nowIso,
+      });
+      entryIndex = refunds.length - 1;
+    } else {
+      const current = refunds[entryIndex];
+      if (!isPositiveSafeInteger(current.amount) || current.amount !== provider.amount) {
+        throw new Error(`Stripe refund ${provider.id} amount conflicts with the local ledger`);
+      }
+      refunds[entryIndex] = {
+        ...current,
+        stripe_refund_id: provider.id,
+        status,
+        provider_status: provider.status,
+        processed_at: input.nowIso,
+      };
+    }
+
+    if (provider.id === input.targetRefundId) matchedTarget = true;
+    if (status === 'succeeded') {
+      settledRefunds.push({ id: provider.id, amount: provider.amount });
+      restockCandidates.push({ provider, entry: refunds[entryIndex] });
+    }
+  }
+
+  const localTotal = computeRefundedTotal({ refunds });
+  if (!Number.isSafeInteger(localTotal) || localTotal > input.totalAmount) {
+    throw new Error('Reconciled refund ledger exceeds the order total');
+  }
+  const unsettled = refunds.some((entry) => classifyRefundStatus(entry.status) === 'reserved');
+  const fullyRefunded = input.chargeAmountRefunded === input.totalAmount &&
+    localTotal === input.totalAmount && !unsettled;
+
+  const knownLines = new Set(input.orderLineIds);
+  const restockLineIds = new Set<string>();
+  for (const { entry } of restockCandidates) {
+    if (entry.source === 'stripe_dashboard') {
+      if (input.externalRestockEnabled && fullyRefunded) {
+        input.orderLineIds.forEach((lineId) => restockLineIds.add(lineId));
+      }
+      continue;
+    }
+    const lineIds = entry.type === 'full' ? input.orderLineIds : entry.items ?? [];
+    validateLineIds(lineIds, 'Refund');
+    for (const lineId of lineIds) {
+      if (!knownLines.has(lineId)) {
+        throw new Error('Refund ledger references an unknown order line');
+      }
+      restockLineIds.add(lineId);
+    }
+  }
+
+  return {
+    refunds,
+    stripeAmountRefunded: input.chargeAmountRefunded,
+    fullyRefunded,
+    restockLineIds: [...restockLineIds].sort(),
+    settledRefunds,
+    matchedTarget,
+  };
+}

--- a/lib/services/checkout-pricing.ts
+++ b/lib/services/checkout-pricing.ts
@@ -8,7 +8,7 @@ import {
   noOpCommerceCapabilities,
   type CommerceCapabilities,
 } from '@/lib/commerce/capabilities';
-import type { Address, OrderItem, Promotion } from '@/lib/types';
+import type { Address, CheckoutLineAllocation, OrderItem, Promotion } from '@/lib/types';
 import {
   allowedShippingCountries,
   enabledShippingMethods,
@@ -43,6 +43,8 @@ export interface CheckoutQuote {
   shippingDiscount: StoredMoney;
   shipping: StoredMoney;
   tax: StoredMoney;
+  shippingTax: StoredMoney;
+  lineAllocations: CheckoutLineAllocation[];
   tender: StoredMoney;
   total: StoredMoney;
   discountCodes: string[];
@@ -59,6 +61,19 @@ interface PricingDependencies {
   getPromotionById: typeof getPromotionById;
   getSettings: typeof getSettings;
   calculateTax: typeof calculateTax;
+}
+
+type TaxCalculation = Awaited<ReturnType<typeof calculateTax>>;
+
+interface ExpectedTaxLine {
+  lineId: string;
+  amount: number;
+}
+
+export interface TaxAllocationResult {
+  lineTaxById: Map<string, number>;
+  shippingTax: number;
+  totalTax: number;
 }
 
 const defaultDependencies: PricingDependencies = {
@@ -256,7 +271,13 @@ async function resolveDiscounts(
   catalog: PricedCatalogLine[],
   context: EligibilityContext,
   deps: PricingDependencies
-): Promise<{ merchandise: Money; shipping: Money; perLine: Money[]; appliedCodes: string[] }> {
+): Promise<{
+  merchandise: Money;
+  shipping: Money;
+  perLine: Money[];
+  promotionCodesByLine: string[][];
+  appliedCodes: string[];
+}> {
   const promotionIds = new Set<string>();
   const candidates: Array<{ code: string; promotion: Promotion; eligible: number[] }> = [];
   for (const code of codes) {
@@ -292,6 +313,7 @@ async function resolveDiscounts(
     : candidates;
 
   const perLine = catalog.map(() => Money.zero(subtotal.currency));
+  const promotionCodesByLine = catalog.map(() => [] as string[]);
   let shippingDiscount = Money.zero(subtotal.currency);
   const appliedCodes: string[] = [];
   for (const { code, promotion, eligible } of selected) {
@@ -309,12 +331,18 @@ async function resolveDiscounts(
       Money.zero(subtotal.currency)
     );
     const before = perLine.reduce((sum, amount) => sum.add(amount), Money.zero(subtotal.currency));
+    const lineBefore = perLine.map((amount) => amount.toMinorUnits());
     allocateDiscount(
       actionDiscount(promotion, currentEligibleTotal),
       eligible,
       catalog.map(({ lineTotal }) => lineTotal),
       perLine
     );
+    perLine.forEach((amount, index) => {
+      if (amount.toMinorUnits() > lineBefore[index]) {
+        promotionCodesByLine[index].push(code);
+      }
+    });
     const after = perLine.reduce((sum, amount) => sum.add(amount), Money.zero(subtotal.currency));
     if (after.gt(before)) appliedCodes.push(code);
   }
@@ -327,6 +355,7 @@ async function resolveDiscounts(
     merchandise,
     shipping: shippingDiscount,
     perLine,
+    promotionCodesByLine,
     appliedCodes,
   };
 }
@@ -336,6 +365,103 @@ function configuredRate(value: unknown): number | null {
   return Number.isFinite(percentage) && percentage >= 0 && percentage <= 100
     ? percentage / 100
     : null;
+}
+
+/** Validate Stripe's expanded response before accepting any per-line tax data. */
+export function mapProviderTaxAllocations(
+  calculation: TaxCalculation,
+  expectedLines: ExpectedTaxLine[],
+  expectedShippingAmount: number
+): TaxAllocationResult {
+  const providerLines = calculation.line_items;
+  if (!providerLines || providerLines.has_more || providerLines.data.length !== expectedLines.length) {
+    throw new Error('Tax provider returned an incomplete line allocation');
+  }
+
+  const expectedByReference = new Map<string, ExpectedTaxLine>(
+    expectedLines.map((line) => [`line:${line.lineId}`, line] as const)
+  );
+  if (expectedByReference.size !== expectedLines.length) {
+    throw new Error('Checkout contains duplicate line identifiers');
+  }
+
+  const lineTaxById = new Map<string, number>();
+  let allocatedTax = 0;
+  for (const providerLine of providerLines.data) {
+    const expected = expectedByReference.get(providerLine.reference);
+    if (!expected || lineTaxById.has(expected.lineId)) {
+      throw new Error('Tax provider returned an unknown or duplicate line reference');
+    }
+    if (
+      !Number.isSafeInteger(providerLine.amount) ||
+      providerLine.amount !== expected.amount ||
+      !Number.isSafeInteger(providerLine.amount_tax) ||
+      providerLine.amount_tax < 0 ||
+      providerLine.amount_tax > expected.amount
+    ) {
+      throw new Error('Tax provider returned an invalid line allocation');
+    }
+    lineTaxById.set(expected.lineId, providerLine.amount_tax);
+    allocatedTax += providerLine.amount_tax;
+  }
+
+  const shipping = calculation.shipping_cost;
+  let shippingTax = 0;
+  if (expectedShippingAmount > 0) {
+    if (
+      !shipping ||
+      shipping.amount !== expectedShippingAmount ||
+      !Number.isSafeInteger(shipping.amount_tax) ||
+      shipping.amount_tax < 0 ||
+      shipping.amount_tax > expectedShippingAmount
+    ) {
+      throw new Error('Tax provider returned an invalid shipping allocation');
+    }
+    shippingTax = shipping.amount_tax;
+  } else if (shipping && (shipping.amount !== 0 || shipping.amount_tax !== 0)) {
+    throw new Error('Tax provider returned unexpected shipping tax');
+  }
+
+  const totalTax = calculation.tax_amount_exclusive;
+  if (
+    !Number.isSafeInteger(totalTax) ||
+    totalTax < 0 ||
+    allocatedTax + shippingTax !== totalTax
+  ) {
+    throw new Error('Tax provider allocations do not match its aggregate tax');
+  }
+  return { lineTaxById, shippingTax, totalTax };
+}
+
+function allocateLargestRemainder(total: number, weights: number[]): number[] {
+  if (!Number.isSafeInteger(total) || total < 0 || weights.some((weight) =>
+    !Number.isSafeInteger(weight) || weight < 0
+  )) {
+    throw new Error('Tax fallback allocation requires nonnegative integer minor units');
+  }
+  const weightTotal = weights.reduce((sum, weight) => sum + weight, 0);
+  if (weightTotal === 0) {
+    if (total !== 0) throw new Error('Cannot allocate tax across zero-value lines');
+    return weights.map(() => 0);
+  }
+
+  const denominator = BigInt(weightTotal);
+  const shares = weights.map((weight, index) => {
+    const numerator = BigInt(total) * BigInt(weight);
+    return {
+      index,
+      amount: Number(numerator / denominator),
+      remainder: numerator % denominator,
+    };
+  });
+  let remaining = total - shares.reduce((sum, share) => sum + share.amount, 0);
+  const ranked = [...shares].sort((a, b) =>
+    a.remainder === b.remainder ? a.index - b.index : (a.remainder > b.remainder ? -1 : 1)
+  );
+  for (let index = 0; index < remaining; index += 1) {
+    ranked[index].amount += 1;
+  }
+  return shares.sort((a, b) => a.index - b.index).map((share) => share.amount);
 }
 
 export async function priceCheckout(
@@ -388,6 +514,7 @@ export async function priceCheckout(
     const totalPrice = unitPrice.times(line.quantity);
     subtotal = subtotal.add(totalPrice);
     return {
+      id: `line_${crypto.randomUUID()}`,
       product_id: product.id,
       variant_id: variant.id,
       sku: variant.sku,
@@ -474,15 +601,22 @@ export async function priceCheckout(
   });
 
   let tax: Money;
+  let shippingTax: Money;
+  let lineTaxes: Money[];
   let taxSource: CheckoutQuote['taxSource'] = 'provider';
   try {
+    const expectedTaxLines = orderItems.map((item, index) => ({
+      lineId: item.id!,
+      amount: pricedCatalog[index].lineTotal.subtract(discounts.perLine[index]).toMinorUnits(),
+    }));
     const calculation = await deps.calculateTax({
       currency: currency.toLowerCase(),
-      line_items: pricedCatalog.map(({ lineTotal }, index) => ({
-        amount: lineTotal.subtract(discounts.perLine[index]).toMinorUnits(),
-        reference: `checkout_line_${index}`,
+      line_items: expectedTaxLines.map((line, index) => ({
+        amount: line.amount,
+        reference: `line:${line.lineId}`,
         tax_code: taxCodes[index],
       })),
+      expand: ['line_items'],
       customer_details: {
         address: {
           line1: String(input.shippingAddress.line1),
@@ -497,22 +631,47 @@ export async function priceCheckout(
         shipping_cost: { amount: chargedShipping.toMinorUnits(), tax_code: 'txcd_92010001' },
       }),
     });
-    const amount = Number((calculation as { tax_amount_exclusive?: unknown }).tax_amount_exclusive);
-    if (!Number.isSafeInteger(amount) || amount < 0) throw new Error('Invalid tax provider response');
-    tax = Money.fromMinor(amount, currency);
+    const allocation = mapProviderTaxAllocations(
+      calculation,
+      expectedTaxLines,
+      chargedShipping.toMinorUnits()
+    );
+    lineTaxes = orderItems.map((item) =>
+      Money.fromMinor(allocation.lineTaxById.get(item.id!)!, currency)
+    );
+    shippingTax = Money.fromMinor(allocation.shippingTax, currency);
+    tax = Money.fromMinor(allocation.totalTax, currency);
   } catch {
     taxSource = 'configured_fallback';
     const fallbackRate = configuredRate(storeSettings['store.tax_rate']);
     if (fallbackRate === null) {
       throw new Error('Tax provider failed and store.tax_rate is not a valid configured fallback');
     }
-    const taxableShipping = storeSettings['store.tax_shipping'] === true
-      ? chargedShipping
+    const netLineMinor = pricedCatalog.map(({ lineTotal }, index) =>
+      lineTotal.subtract(discounts.perLine[index]).toMinorUnits()
+    );
+    const merchandiseTax = discountedMerchandise.applyRate(fallbackRate);
+    lineTaxes = allocateLargestRemainder(
+      merchandiseTax.toMinorUnits(),
+      netLineMinor
+    ).map((amount) => Money.fromMinor(amount, currency));
+    shippingTax = storeSettings['store.tax_shipping'] === true
+      ? chargedShipping.applyRate(fallbackRate)
       : Money.zero(currency);
-    tax = discountedMerchandise
-      .add(taxableShipping)
-      .applyRate(fallbackRate);
+    tax = merchandiseTax.add(shippingTax);
   }
+
+  const lineAllocations: CheckoutLineAllocation[] = orderItems.map((item, index) => ({
+    lineId: item.id!,
+    productId: item.product_id,
+    variantId: item.variant_id!,
+    quantity: item.quantity,
+    catalogSubtotal: pricedCatalog[index].lineTotal.toJSON(),
+    merchandiseDiscount: discounts.perLine[index].toJSON(),
+    netMerchandise: pricedCatalog[index].lineTotal.subtract(discounts.perLine[index]).toJSON(),
+    tax: lineTaxes[index].toJSON(),
+    promotionCodes: discounts.promotionCodesByLine[index],
+  }));
 
   const beforeTender = discountedMerchandise.add(chargedShipping).add(tax);
   const tenderResolution = await capabilities.giftCards.resolveTender({
@@ -543,6 +702,8 @@ export async function priceCheckout(
     shippingDiscount: discounts.shipping.toJSON(),
     shipping: shipping.toJSON(),
     tax: tax.toJSON(),
+    shippingTax: shippingTax.toJSON(),
+    lineAllocations,
     tender: tender.toJSON(),
     total: total.toJSON(),
     discountCodes: discounts.appliedCodes,

--- a/lib/services/inventory-adjustments.ts
+++ b/lib/services/inventory-adjustments.ts
@@ -1,0 +1,455 @@
+import { getCloudflareContext } from '@opennextjs/cloudflare';
+import type { Order, OrderItem } from '@/lib/types/order';
+import type { ProductInventory } from '@/lib/types';
+import { canFulfillInventory } from '@/lib/inventory/availability';
+
+const ADJUSTMENT_LEASE_MS = 5 * 60 * 1000;
+const MAX_ADJUSTMENT_ERROR = 2_000;
+
+export type InventoryAdjustmentKind = 'paid_decrement' | 'refund_restock';
+export type InventoryAdjustmentStatus =
+  | 'pending'
+  | 'processing'
+  | 'succeeded'
+  | 'skipped'
+  | 'needs_review'
+  | 'failed';
+
+export interface InventoryAdjustmentInput {
+  adjustmentKey: string;
+  orderId: string;
+  lineId?: string;
+  variantId: string;
+  kind: InventoryAdjustmentKind;
+  quantity: number;
+}
+
+export interface ClaimedInventoryAdjustment {
+  adjustment_key: string;
+  order_id: string;
+  line_id: string | null;
+  variant_id: string;
+  kind: InventoryAdjustmentKind;
+  quantity: number;
+  attempt_count: number;
+  claim_token: string;
+}
+
+export interface InventoryAdjustmentDrainResult {
+  claimed: number;
+  succeeded: number;
+  skipped: number;
+  needsReview: number;
+  failed: number;
+  ownershipLost: number;
+}
+
+export class InventoryUnavailableError extends Error {
+  constructor(public readonly variantIds: string[]) {
+    super('One or more requested variants do not have enough inventory');
+    this.name = 'InventoryUnavailableError';
+  }
+}
+
+async function resolveDatabase(database?: D1Database): Promise<D1Database> {
+  if (database) return database;
+  const { env } = await getCloudflareContext({ async: true });
+  return env.DB;
+}
+
+function validateAdjustment(input: InventoryAdjustmentInput): void {
+  if (!input.adjustmentKey || input.adjustmentKey.length > 512) {
+    throw new Error('Inventory adjustment key is invalid');
+  }
+  if (!input.orderId || input.orderId.length > 256) {
+    throw new Error('Inventory adjustment order id is invalid');
+  }
+  if (!input.variantId || input.variantId.length > 256) {
+    throw new Error('Inventory adjustment variant id is invalid');
+  }
+  if (input.lineId && input.lineId.length > 256) {
+    throw new Error('Inventory adjustment line id is invalid');
+  }
+  if (!Number.isSafeInteger(input.quantity) || input.quantity <= 0) {
+    throw new Error('Inventory adjustment quantity must be a positive integer');
+  }
+  if (input.kind === 'paid_decrement') {
+    if (input.lineId != null || input.adjustmentKey !==
+      `paid:${input.orderId}:inventory:${input.variantId}:v1`) {
+      throw new Error('Paid inventory adjustment identity is invalid');
+    }
+    return;
+  }
+  if (input.kind === 'refund_restock') {
+    if (!input.lineId || input.adjustmentKey !==
+      `restock:${input.orderId}:${input.lineId}:v1`) {
+      throw new Error('Refund restock adjustment identity is invalid');
+    }
+    return;
+  }
+  throw new Error('Inventory adjustment kind is invalid');
+}
+
+function aggregateOrderDemand(items: OrderItem[]): Map<string, number> {
+  const demand = new Map<string, number>();
+  for (const item of items) {
+    if (!item.variant_id || item.variant_id.length > 256) {
+      throw new Error('Paid order item has no valid variant id');
+    }
+    if (!Number.isSafeInteger(item.quantity) || item.quantity <= 0) {
+      throw new Error('Paid order item has an invalid quantity');
+    }
+    const quantity = (demand.get(item.variant_id) ?? 0) + item.quantity;
+    if (!Number.isSafeInteger(quantity)) {
+      throw new Error('Paid order variant quantity is too large');
+    }
+    demand.set(item.variant_id, quantity);
+  }
+  return demand;
+}
+
+export async function stageInventoryAdjustments(
+  inputs: InventoryAdjustmentInput[],
+  options: { database?: D1Database; now?: Date } = {}
+): Promise<void> {
+  if (inputs.length === 0) return;
+  if (inputs.length > 100) throw new Error('Too many inventory adjustments');
+  inputs.forEach(validateAdjustment);
+  const database = await resolveDatabase(options.database);
+  const now = (options.now ?? new Date()).toISOString();
+  await database.batch(inputs.map((input) => database.prepare(`
+INSERT INTO inventory_adjustments (
+  adjustment_key, order_id, line_id, variant_id, kind, quantity,
+  status, attempt_count, claim_token, lease_expires_at, next_attempt_at,
+  result, last_error, created_at, updated_at, completed_at
+) VALUES (?, ?, ?, ?, ?, ?, 'pending', 0, NULL, NULL, NULL, NULL, NULL, ?, ?, NULL)
+ON CONFLICT(adjustment_key) DO NOTHING
+`).bind(
+    input.adjustmentKey,
+    input.orderId,
+    input.lineId ?? null,
+    input.variantId,
+    input.kind,
+    input.quantity,
+    now,
+    now
+  )));
+}
+
+export async function stagePaidInventoryAdjustments(
+  order: Order,
+  options: { database?: D1Database; now?: Date } = {}
+): Promise<void> {
+  if (!order.id) throw new Error('Cannot stage inventory for an order without an id');
+  const inputs = [...aggregateOrderDemand(order.items)].map(([variantId, quantity]) => ({
+    adjustmentKey: `paid:${order.id}:inventory:${variantId}:v1`,
+    orderId: order.id!,
+    variantId,
+    kind: 'paid_decrement' as const,
+    quantity,
+  }));
+  await stageInventoryAdjustments(inputs, options);
+}
+
+export async function assertCheckoutInventoryAvailable(
+  items: OrderItem[],
+  options: { database?: D1Database } = {}
+): Promise<void> {
+  const demand = aggregateOrderDemand(items);
+  if (demand.size === 0) return;
+  const database = await resolveDatabase(options.database);
+  const rows = await database.batch([...demand].map(([variantId]) =>
+    database.prepare('SELECT status, inventory FROM product_variants WHERE id = ?')
+      .bind(variantId)
+  ));
+  const unavailable: string[] = [];
+  [...demand].forEach(([variantId, quantity], index) => {
+    const row = rows[index]?.results?.[0] as { status?: string; inventory?: string | ProductInventory } | undefined;
+    if (!row || (row.status != null && row.status !== 'active')) {
+      unavailable.push(variantId);
+      return;
+    }
+    let inventory: ProductInventory | undefined;
+    try {
+      inventory = typeof row.inventory === 'string'
+        ? JSON.parse(row.inventory) as ProductInventory
+        : row.inventory;
+    } catch {
+      unavailable.push(variantId);
+      return;
+    }
+    if (!canFulfillInventory(inventory, quantity)) unavailable.push(variantId);
+  });
+  if (unavailable.length > 0) throw new InventoryUnavailableError(unavailable.sort());
+}
+
+const CLAIM_SQL = `
+UPDATE inventory_adjustments
+SET status = 'processing',
+    attempt_count = attempt_count + 1,
+    claim_token = ?,
+    lease_expires_at = ?,
+    next_attempt_at = NULL,
+    last_error = NULL,
+    updated_at = ?
+WHERE adjustment_key = (
+  SELECT ia.adjustment_key
+  FROM inventory_adjustments ia
+  JOIN orders o ON o.id = ia.order_id
+  WHERE (? IS NULL OR ia.order_id = ?)
+    AND (? IS NULL OR ia.kind = ?)
+    AND (
+      (ia.kind = 'paid_decrement' AND o.payment_status = 'paid')
+      OR (ia.kind = 'refund_restock' AND o.payment_status IN ('paid', 'refunded'))
+    )
+    AND (
+      ia.status = 'pending'
+      OR (ia.status = 'failed' AND (ia.next_attempt_at IS NULL OR ia.next_attempt_at <= ?))
+      OR (ia.status = 'processing' AND ia.lease_expires_at <= ?)
+    )
+  ORDER BY ia.created_at, ia.adjustment_key
+  LIMIT 1
+)
+RETURNING adjustment_key, order_id, line_id, variant_id, kind, quantity,
+          attempt_count, claim_token
+`;
+
+export async function claimNextInventoryAdjustment(
+  database: D1Database,
+  options: {
+    orderId?: string;
+    kind?: InventoryAdjustmentKind;
+    now?: Date;
+    claimToken?: string;
+    leaseDurationMs?: number;
+  } = {}
+): Promise<ClaimedInventoryAdjustment | null> {
+  const now = options.now ?? new Date();
+  const leaseDurationMs = options.leaseDurationMs ?? ADJUSTMENT_LEASE_MS;
+  if (!Number.isSafeInteger(leaseDurationMs) || leaseDurationMs <= 0) {
+    throw new Error('Inventory adjustment lease duration must be a positive integer');
+  }
+  const nowIso = now.toISOString();
+  return database.prepare(CLAIM_SQL).bind(
+    options.claimToken ?? crypto.randomUUID(),
+    new Date(now.getTime() + leaseDurationMs).toISOString(),
+    nowIso,
+    options.orderId ?? null,
+    options.orderId ?? null,
+    options.kind ?? null,
+    options.kind ?? null,
+    nowIso,
+    nowIso
+  ).first<ClaimedInventoryAdjustment>();
+}
+
+const TERMINAL_SQL = `
+UPDATE inventory_adjustments
+SET status = CASE
+      WHEN changes() = 1 THEN 'succeeded'
+      WHEN EXISTS (SELECT 1 FROM product_variants WHERE id = ?) AND
+           (SELECT json_valid(COALESCE(inventory, '{}'))
+            FROM product_variants WHERE id = ?) = 1 AND
+           COALESCE((SELECT CASE WHEN json_valid(COALESCE(inventory, '{}')) = 1
+                                THEN json_extract(inventory, '$.track_inventory') END
+                     FROM product_variants WHERE id = ?), 0) <> 1 THEN 'skipped'
+      ELSE 'needs_review'
+    END,
+    claim_token = NULL,
+    lease_expires_at = NULL,
+    next_attempt_at = NULL,
+    last_error = NULL,
+    result = json_object(
+      'outcome', CASE
+        WHEN changes() = 1 THEN 'applied'
+        WHEN EXISTS (SELECT 1 FROM product_variants WHERE id = ?) AND
+             (SELECT json_valid(COALESCE(inventory, '{}'))
+              FROM product_variants WHERE id = ?) = 1 AND
+             COALESCE((SELECT CASE WHEN json_valid(COALESCE(inventory, '{}')) = 1
+                                  THEN json_extract(inventory, '$.track_inventory') END
+                       FROM product_variants WHERE id = ?), 0) <> 1 THEN 'untracked'
+        ELSE 'needs_review'
+      END,
+      'variantId', ?,
+      'quantity', ?
+    ),
+    completed_at = ?,
+    updated_at = ?
+WHERE adjustment_key = ?
+  AND status = 'processing'
+  AND claim_token = ?
+`;
+
+export async function applyClaimedInventoryAdjustment(
+  database: D1Database,
+  adjustment: ClaimedInventoryAdjustment,
+  now: Date = new Date()
+): Promise<InventoryAdjustmentStatus | null> {
+  const validInventory = "json_valid(COALESCE(inventory, '{}')) = 1";
+  const quantityValue = `CASE WHEN ${validInventory}
+    THEN COALESCE(json_extract(inventory, '$.quantity'), 0) END`;
+  const quantityType = `CASE WHEN ${validInventory}
+    THEN json_type(inventory, '$.quantity') END`;
+  const tracked = `CASE WHEN ${validInventory}
+    THEN json_extract(inventory, '$.track_inventory') END`;
+  const allowsBackorder = `CASE WHEN ${validInventory}
+    THEN json_extract(inventory, '$.allow_backorder') END`;
+  const quantityExpression = adjustment.kind === 'paid_decrement'
+    ? `${quantityValue} - ?`
+    : `${quantityValue} + ?`;
+  const stockGuard = adjustment.kind === 'paid_decrement'
+    ? `AND (${allowsBackorder} = 1 OR ${quantityValue} >= ?)`
+    : '';
+  const mutation = database.prepare(`
+UPDATE product_variants
+SET inventory = json_set(COALESCE(inventory, '{}'), '$.quantity', ${quantityExpression}),
+    updated_at = ?
+WHERE id = ?
+  AND ${validInventory}
+  AND ${tracked} = 1
+  AND (${quantityType} IS NULL OR ${quantityType} = 'integer')
+  AND ${quantityValue} BETWEEN -9007199254740991 AND 9007199254740991
+  AND (${quantityExpression}) BETWEEN -9007199254740991 AND 9007199254740991
+  ${stockGuard}
+  AND EXISTS (
+    SELECT 1 FROM inventory_adjustments ia
+    WHERE ia.adjustment_key = ?
+      AND ia.status = 'processing'
+      AND ia.claim_token = ?
+  )
+`).bind(
+    adjustment.quantity,
+    now.toISOString(),
+    adjustment.variant_id,
+    adjustment.quantity,
+    ...(adjustment.kind === 'paid_decrement' ? [adjustment.quantity] : []),
+    adjustment.adjustment_key,
+    adjustment.claim_token
+  );
+  const terminal = database.prepare(TERMINAL_SQL).bind(
+    adjustment.variant_id,
+    adjustment.variant_id,
+    adjustment.variant_id,
+    adjustment.variant_id,
+    adjustment.variant_id,
+    adjustment.variant_id,
+    adjustment.variant_id,
+    adjustment.quantity,
+    now.toISOString(),
+    now.toISOString(),
+    adjustment.adjustment_key,
+    adjustment.claim_token
+  );
+  const results = await database.batch([mutation, terminal]);
+  if (results[1]?.meta.changes !== 1) return null;
+  const row = await database.prepare(
+    'SELECT status FROM inventory_adjustments WHERE adjustment_key = ?'
+  ).bind(adjustment.adjustment_key).first<{ status: InventoryAdjustmentStatus }>();
+  return row?.status ?? null;
+}
+
+export async function failInventoryAdjustment(
+  database: D1Database,
+  adjustment: ClaimedInventoryAdjustment,
+  error: unknown,
+  now: Date = new Date()
+): Promise<boolean> {
+  const delayMs = Math.min(
+    6 * 60 * 60 * 1000,
+    5 * 60 * 1000 * 2 ** Math.min(adjustment.attempt_count - 1, 10)
+  );
+  const message = (error instanceof Error ? error.message : String(error))
+    .slice(0, MAX_ADJUSTMENT_ERROR);
+  const response = await database.prepare(`
+UPDATE inventory_adjustments
+SET status = 'failed', claim_token = NULL, lease_expires_at = NULL,
+    next_attempt_at = ?, last_error = ?, updated_at = ?
+WHERE adjustment_key = ? AND status = 'processing' AND claim_token = ?
+`).bind(
+    new Date(now.getTime() + delayMs).toISOString(),
+    message,
+    now.toISOString(),
+    adjustment.adjustment_key,
+    adjustment.claim_token
+  ).run();
+  return response.meta.changes === 1;
+}
+
+export async function drainInventoryAdjustments(
+  options: {
+    database?: D1Database;
+    orderId?: string;
+    kind?: InventoryAdjustmentKind;
+    limit?: number;
+    now?: () => Date;
+  } = {}
+): Promise<InventoryAdjustmentDrainResult> {
+  const database = await resolveDatabase(options.database);
+  const limit = options.limit ?? 25;
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > 100) {
+    throw new Error('Inventory adjustment drain limit must be between 1 and 100');
+  }
+  const result: InventoryAdjustmentDrainResult = {
+    claimed: 0, succeeded: 0, skipped: 0, needsReview: 0, failed: 0, ownershipLost: 0,
+  };
+  for (let index = 0; index < limit; index += 1) {
+    const adjustment = await claimNextInventoryAdjustment(database, {
+      orderId: options.orderId,
+      kind: options.kind,
+      now: options.now?.() ?? new Date(),
+    });
+    if (!adjustment) break;
+    result.claimed += 1;
+    try {
+      const status = await applyClaimedInventoryAdjustment(
+        database,
+        adjustment,
+        options.now?.() ?? new Date()
+      );
+      if (status === 'succeeded') result.succeeded += 1;
+      else if (status === 'skipped') result.skipped += 1;
+      else if (status === 'needs_review') result.needsReview += 1;
+      else result.ownershipLost += 1;
+    } catch (error) {
+      await failInventoryAdjustment(
+        database,
+        adjustment,
+        error,
+        options.now?.() ?? new Date()
+      );
+      result.failed += 1;
+    }
+  }
+  return result;
+}
+
+export async function runPaidOrderInventoryEffect(
+  order: Order,
+  options: { database?: D1Database; now?: () => Date } = {}
+): Promise<InventoryAdjustmentDrainResult> {
+  if (!order.id || order.payment_status !== 'paid') {
+    throw new Error('Inventory decrement requires an authoritatively paid order');
+  }
+  const database = await resolveDatabase(options.database);
+  await stagePaidInventoryAdjustments(order, {
+    database,
+    now: options.now?.() ?? new Date(),
+  });
+  const result = await drainInventoryAdjustments({
+    database,
+    orderId: order.id,
+    kind: 'paid_decrement',
+    limit: 100,
+    now: options.now,
+  });
+  const remaining = await database.prepare(`
+SELECT COUNT(*) AS count
+FROM inventory_adjustments
+WHERE order_id = ? AND kind = 'paid_decrement'
+  AND status NOT IN ('succeeded', 'skipped', 'needs_review')
+`).bind(order.id).first<{ count: number }>();
+  if ((remaining?.count ?? 0) > 0) {
+    throw new Error('Paid inventory adjustments remain retryable');
+  }
+  return result;
+}

--- a/lib/services/order-confirmation.ts
+++ b/lib/services/order-confirmation.ts
@@ -1,0 +1,56 @@
+import { Money } from '@/lib/money';
+import type { Order } from '@/lib/types/order';
+import { sendOrderConfirmationEmail, type EmailResult } from '@/lib/utils/email';
+
+function localizedText(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (value && typeof value === 'object') {
+    const values = value as Record<string, unknown>;
+    const localized = values.en ?? Object.values(values)[0];
+    if (typeof localized === 'string') return localized;
+  }
+  return '';
+}
+
+export async function sendOrderConfirmation(
+  order: Order,
+  idempotencyKey: string
+): Promise<EmailResult> {
+  const address = order.shipping_address;
+  const extensions = order.extensions ?? {};
+  const email = typeof extensions.email === 'string'
+    ? extensions.email
+    : address?.email;
+  if (!email || !address || !order.id) return { success: true };
+
+  return sendOrderConfirmationEmail({
+    orderNumber: order.id,
+    customerName: address.recipient || address.company || 'Customer',
+    customerEmail: email,
+    items: order.items.map((item) => ({
+      productId: item.product_id,
+      name: item.product_name,
+      price: Money.fromStored(item.unit_price, order.currency_code).toJSON(),
+      quantity: item.quantity,
+    })),
+    subtotal: Money.fromStored(
+      extensions.checkout_catalog_subtotal ?? extensions.checkout_subtotal ?? 0,
+      order.currency_code
+    ).toJSON(),
+    shipping: Money.fromStored(
+      extensions.checkout_shipping_before_discount ?? extensions.checkout_shipping ?? 0,
+      order.currency_code
+    ).toJSON(),
+    tax: Money.fromStored(extensions.checkout_tax ?? 0, order.currency_code).toJSON(),
+    discount: Money.fromStored(extensions.checkout_discount ?? 0, order.currency_code).toJSON(),
+    tender: Money.fromStored(extensions.checkout_tender ?? 0, order.currency_code).toJSON(),
+    total: Money.fromStored(order.total_amount, order.currency_code).toJSON(),
+    shippingAddress: {
+      street: [localizedText(address.line1), localizedText(address.line2)].filter(Boolean).join(', '),
+      city: localizedText(address.city),
+      state: address.region || '',
+      zipCode: address.postal_code || '',
+      country: address.country,
+    },
+  }, { idempotencyKey });
+}

--- a/lib/services/order-effects.ts
+++ b/lib/services/order-effects.ts
@@ -12,6 +12,7 @@ import {
 } from '@/lib/commerce/capabilities';
 import type { Order } from '@/lib/types/order';
 import { sendOrderConfirmation } from '@/lib/services/order-confirmation';
+import { runPaidOrderInventoryEffect } from '@/lib/services/inventory-adjustments';
 
 const EFFECT_LEASE_MS = 5 * 60 * 1000;
 const MAX_EFFECT_ERROR = 2_000;
@@ -195,10 +196,12 @@ async function executeEffect(
   const extensions = order.extensions ?? {};
   switch (effect.effect_type) {
     case 'inventory':
-      if (!runtime.runInventory) {
-        throw new Error('Inventory effect handler is not configured');
-      }
-      return runtime.runInventory(order, effect);
+      return runtime.runInventory
+        ? runtime.runInventory(order, effect)
+        : runPaidOrderInventoryEffect(order, {
+            database: runtime.database,
+            now: runtime.now,
+          });
     case 'coupon': {
       const code = findCoupon(order, effect.effect_key);
       const codes = normalizedCodes(order);

--- a/lib/services/order-effects.ts
+++ b/lib/services/order-effects.ts
@@ -1,0 +1,353 @@
+import { getCloudflareContext } from '@opennextjs/cloudflare';
+import { Money } from '@/lib/money';
+import { redeemCoupon } from '@/lib/models/mach/couponInstance';
+import {
+  hydrateOrder,
+  recordCouponReconciliation,
+} from '@/lib/models/mach/orders';
+import { orders } from '@/lib/db/schema/order';
+import {
+  noOpCommerceCapabilities,
+  type CommerceCapabilities,
+} from '@/lib/commerce/capabilities';
+import type { Order } from '@/lib/types/order';
+import { sendOrderConfirmation } from '@/lib/services/order-confirmation';
+
+const EFFECT_LEASE_MS = 5 * 60 * 1000;
+const MAX_EFFECT_ERROR = 2_000;
+
+export type OrderEffectType =
+  | 'inventory'
+  | 'coupon'
+  | 'gift_card'
+  | 'subscription'
+  | 'confirmation_email';
+
+export interface ClaimedOrderEffect {
+  effect_key: string;
+  order_id: string;
+  effect_type: OrderEffectType;
+  attempt_count: number;
+  claim_token: string;
+}
+
+interface EffectDefinition {
+  key: string;
+  type: OrderEffectType;
+}
+
+export interface OrderEffectRuntime {
+  database?: D1Database;
+  capabilities?: CommerceCapabilities;
+  getOrder?: (orderId: string) => Promise<Order | null>;
+  redeem?: typeof redeemCoupon;
+  recordCouponReconciliation?: typeof recordCouponReconciliation;
+  sendConfirmation?: typeof sendOrderConfirmation;
+  runInventory?: (order: Order, effect: ClaimedOrderEffect) => Promise<unknown>;
+  now?: () => Date;
+}
+
+export interface OrderEffectDrainResult {
+  claimed: number;
+  succeeded: number;
+  failed: number;
+}
+
+async function resolveDatabase(database?: D1Database): Promise<D1Database> {
+  if (database) return database;
+  const { env } = await getCloudflareContext({ async: true });
+  return env.DB;
+}
+
+function normalizedCodes(order: Order): string[] {
+  const codes = order.extensions?.discount_codes;
+  if (!Array.isArray(codes)) return [];
+  if (codes.length > 25) throw new Error('Paid order contains too many discount codes');
+  const normalized = codes.map((code) => {
+    if (typeof code !== 'string' || !code.trim() || code.length > 128) {
+      throw new Error('Paid order contains an invalid discount code');
+    }
+    return code.trim().toUpperCase();
+  });
+  return [...new Set(normalized)].sort();
+}
+
+function couponEffectKey(orderId: string, code: string): string {
+  return `paid:${orderId}:coupon:${code}:v1`;
+}
+
+function effectDefinitions(
+  order: Order,
+  includeEmail: boolean
+): EffectDefinition[] {
+  if (!order.id) throw new Error('Cannot stage effects for an order without an id');
+  const definitions: EffectDefinition[] = [
+    { key: `paid:${order.id}:inventory:v1`, type: 'inventory' },
+    ...normalizedCodes(order).map((code) => ({
+      key: couponEffectKey(order.id!, code),
+      type: 'coupon' as const,
+    })),
+    { key: `paid:${order.id}:gift-card:v1`, type: 'gift_card' },
+    { key: `paid:${order.id}:subscription:v1`, type: 'subscription' },
+  ];
+  if (includeEmail) {
+    definitions.push({
+      key: `paid:${order.id}:confirmation-email:v1`,
+      type: 'confirmation_email',
+    });
+  }
+  return definitions;
+}
+
+/**
+ * Stage deterministic dormant recovery rows before the paid CAS. Effect
+ * runners only claim rows whose order is authoritatively paid.
+ */
+export async function stagePaidOrderEffects(
+  order: Order,
+  options: { includeEmail?: boolean; database?: D1Database; now?: Date } = {}
+): Promise<void> {
+  if (!order.id) throw new Error('Cannot stage effects for an order without an id');
+  const database = await resolveDatabase(options.database);
+  const now = (options.now ?? new Date()).toISOString();
+  const statements = effectDefinitions(order, options.includeEmail !== false).map(({ key, type }) =>
+    database.prepare(`
+INSERT INTO order_effects (
+  effect_key, order_id, effect_type, status, attempt_count,
+  claim_token, lease_expires_at, next_attempt_at, last_error, result,
+  created_at, updated_at, completed_at
+) VALUES (?, ?, ?, 'pending', 0, NULL, NULL, NULL, NULL, NULL, ?, ?, NULL)
+ON CONFLICT(effect_key) DO NOTHING
+`).bind(key, order.id!, type, now, now)
+  );
+  await database.batch(statements);
+}
+
+const CLAIM_SQL = `
+UPDATE order_effects
+SET status = 'processing',
+    attempt_count = attempt_count + 1,
+    claim_token = ?,
+    lease_expires_at = ?,
+    next_attempt_at = NULL,
+    last_error = NULL,
+    updated_at = ?
+WHERE effect_key = (
+  SELECT oe.effect_key
+  FROM order_effects oe
+  JOIN orders o ON o.id = oe.order_id
+  WHERE o.payment_status = 'paid'
+    AND (? IS NULL OR oe.order_id = ?)
+    AND (
+      oe.status = 'pending'
+      OR (oe.status = 'failed' AND (oe.next_attempt_at IS NULL OR oe.next_attempt_at <= ?))
+      OR (oe.status = 'processing' AND oe.lease_expires_at <= ?)
+    )
+  ORDER BY oe.created_at, oe.effect_key
+  LIMIT 1
+)
+RETURNING effect_key, order_id, effect_type, attempt_count, claim_token
+`;
+
+export async function claimNextOrderEffect(
+  database: D1Database,
+  options: {
+    orderId?: string;
+    now?: Date;
+    claimToken?: string;
+    leaseDurationMs?: number;
+  } = {}
+): Promise<ClaimedOrderEffect | null> {
+  const now = options.now ?? new Date();
+  const leaseDurationMs = options.leaseDurationMs ?? EFFECT_LEASE_MS;
+  if (!Number.isSafeInteger(leaseDurationMs) || leaseDurationMs <= 0) {
+    throw new Error('Order effect lease duration must be a positive integer');
+  }
+  const claimToken = options.claimToken ?? crypto.randomUUID();
+  const nowIso = now.toISOString();
+  const leaseExpiresAt = new Date(now.getTime() + leaseDurationMs).toISOString();
+  return database.prepare(CLAIM_SQL).bind(
+    claimToken,
+    leaseExpiresAt,
+    nowIso,
+    options.orderId ?? null,
+    options.orderId ?? null,
+    nowIso,
+    nowIso
+  ).first<ClaimedOrderEffect>();
+}
+
+function findCoupon(order: Order, effectKey: string): string {
+  if (!order.id) throw new Error('Coupon effect order has no id');
+  const code = normalizedCodes(order).find(
+    (candidate) => couponEffectKey(order.id!, candidate) === effectKey
+  );
+  if (!code) throw new Error('Coupon effect no longer matches the paid order');
+  return code;
+}
+
+async function executeEffect(
+  effect: ClaimedOrderEffect,
+  order: Order,
+  runtime: OrderEffectRuntime
+): Promise<unknown> {
+  const capabilities = runtime.capabilities ?? noOpCommerceCapabilities;
+  const extensions = order.extensions ?? {};
+  switch (effect.effect_type) {
+    case 'inventory':
+      if (!runtime.runInventory) {
+        throw new Error('Inventory effect handler is not configured');
+      }
+      return runtime.runInventory(order, effect);
+    case 'coupon': {
+      const code = findCoupon(order, effect.effect_key);
+      const codes = normalizedCodes(order);
+      const redeem = runtime.redeem ?? redeemCoupon;
+      const redemption = await redeem(code, {
+        orderId: order.id!,
+        customerId: order.customer_id,
+        channel: 'web',
+        discountAmount: codes.length === 1
+          ? Money.fromStored(extensions.checkout_discount ?? 0, order.currency_code).toMach()
+          : undefined,
+      });
+      if (!redemption.redeemed && !redemption.alreadyRedeemed) {
+        const reconcile = runtime.recordCouponReconciliation ?? recordCouponReconciliation;
+        await reconcile({ orderId: order.id!, code });
+        return { reconciliationRequired: true, code };
+      }
+      return { code, alreadyRedeemed: redemption.alreadyRedeemed === true };
+    }
+    case 'gift_card':
+      await capabilities.giftCards.applyTender({
+        order,
+        state: extensions.checkout_tender_state,
+      });
+      return { applied: true };
+    case 'subscription':
+      await capabilities.subscriptions.orderPaid(order);
+      return { applied: true };
+    case 'confirmation_email': {
+      const send = runtime.sendConfirmation ?? sendOrderConfirmation;
+      const result = await send(order, `order-confirmation/${order.id}/v1`);
+      if (!result.success) throw new Error(result.error || 'Confirmation email failed');
+      return { providerId: result.id ?? null };
+    }
+  }
+}
+
+function serializeEffectResult(result: unknown): string {
+  try {
+    const serialized = JSON.stringify(result ?? null);
+    return serialized.length <= 8_192
+      ? serialized
+      : JSON.stringify({ truncated: true, originalLength: serialized.length });
+  } catch {
+    return JSON.stringify({ unserializable: true });
+  }
+}
+
+export async function completeOrderEffect(
+  database: D1Database,
+  effect: ClaimedOrderEffect,
+  result: unknown,
+  now: Date
+): Promise<boolean> {
+  const serialized = serializeEffectResult(result);
+  const response = await database.prepare(`
+UPDATE order_effects
+SET status = 'succeeded',
+    claim_token = NULL,
+    lease_expires_at = NULL,
+    next_attempt_at = NULL,
+    last_error = NULL,
+    result = ?,
+    completed_at = ?,
+    updated_at = ?
+WHERE effect_key = ?
+  AND status = 'processing'
+  AND claim_token = ?
+`).bind(
+    serialized,
+    now.toISOString(),
+    now.toISOString(),
+    effect.effect_key,
+    effect.claim_token
+  ).run();
+  return response.meta.changes === 1;
+}
+
+export async function failOrderEffect(
+  database: D1Database,
+  effect: ClaimedOrderEffect,
+  error: unknown,
+  now: Date
+): Promise<boolean> {
+  const delayMs = Math.min(
+    6 * 60 * 60 * 1000,
+    5 * 60 * 1000 * 2 ** Math.min(effect.attempt_count - 1, 10)
+  );
+  const nextAttemptAt = new Date(now.getTime() + delayMs).toISOString();
+  const message = (error instanceof Error ? error.message : String(error)).slice(0, MAX_EFFECT_ERROR);
+  const response = await database.prepare(`
+UPDATE order_effects
+SET status = 'failed',
+    claim_token = NULL,
+    lease_expires_at = NULL,
+    next_attempt_at = ?,
+    last_error = ?,
+    updated_at = ?
+WHERE effect_key = ?
+  AND status = 'processing'
+  AND claim_token = ?
+`).bind(
+    nextAttemptAt,
+    message,
+    now.toISOString(),
+    effect.effect_key,
+    effect.claim_token
+  ).run();
+  return response.meta.changes === 1;
+}
+
+export async function drainOrderEffects(
+  options: OrderEffectRuntime & { orderId?: string; limit?: number } = {}
+): Promise<OrderEffectDrainResult> {
+  const database = await resolveDatabase(options.database);
+  const getOrder = options.getOrder ?? (async (orderId: string) => {
+    const record = await database.prepare('SELECT * FROM orders WHERE id = ?')
+      .bind(orderId)
+      .first<typeof orders.$inferSelect>();
+    return record ? hydrateOrder(record) : null;
+  });
+  const limit = options.limit ?? 25;
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > 100) {
+    throw new Error('Order effect drain limit must be between 1 and 100');
+  }
+  const result: OrderEffectDrainResult = { claimed: 0, succeeded: 0, failed: 0 };
+
+  for (let index = 0; index < limit; index += 1) {
+    const now = options.now?.() ?? new Date();
+    const effect = await claimNextOrderEffect(database, {
+      orderId: options.orderId,
+      now,
+    });
+    if (!effect) break;
+    result.claimed += 1;
+    try {
+      const order = await getOrder(effect.order_id);
+      if (!order || order.payment_status !== 'paid') {
+        throw new Error('Order effect lost its paid order');
+      }
+      const effectResult = await executeEffect(effect, order, options);
+      if (!await completeOrderEffect(database, effect, effectResult, options.now?.() ?? new Date())) {
+        throw new Error('Order effect ownership expired before completion');
+      }
+      result.succeeded += 1;
+    } catch (error) {
+      await failOrderEffect(database, effect, error, options.now?.() ?? new Date());
+      result.failed += 1;
+    }
+  }
+  return result;
+}

--- a/lib/services/order-finalization.ts
+++ b/lib/services/order-finalization.ts
@@ -5,16 +5,17 @@ import { Money } from '@/lib/money';
 import {
   hydrateOrder,
   promoteOrderToPaid,
-  recordCouponReconciliation,
 } from '@/lib/models/mach/orders';
-import { redeemCoupon } from '@/lib/models/mach/couponInstance';
 import { retrievePaymentIntent } from '@/lib/stripe';
-import { sendOrderConfirmationEmail } from '@/lib/utils/email';
 import {
   noOpCommerceCapabilities,
   type CommerceCapabilities,
 } from '@/lib/commerce/capabilities';
 import type { Order } from '@/lib/types/order';
+import {
+  drainOrderEffects,
+  stagePaidOrderEffects,
+} from '@/lib/services/order-effects';
 
 export class PaymentVerificationError extends Error {}
 
@@ -26,56 +27,6 @@ function asObject(value: unknown): Record<string, unknown> {
   return typeof value === 'object' && !Array.isArray(value)
     ? value as Record<string, unknown>
     : {};
-}
-
-function text(value: unknown): string {
-  if (typeof value === 'string') return value;
-  if (value && typeof value === 'object') {
-    const values = value as Record<string, unknown>;
-    const localized = values.en ?? Object.values(values)[0];
-    if (typeof localized === 'string') return localized;
-  }
-  return '';
-}
-
-async function sendConfirmation(order: Order): Promise<void> {
-  const address = order.shipping_address;
-  const extensions = order.extensions ?? {};
-  const email = typeof extensions.email === 'string'
-    ? extensions.email
-    : address?.email;
-  if (!email || !address) return;
-
-  await sendOrderConfirmationEmail({
-    orderNumber: order.id!,
-    customerName: address.recipient || address.company || 'Customer',
-    customerEmail: email,
-    items: order.items.map((item) => ({
-      productId: item.product_id,
-      name: item.product_name,
-      price: Money.fromStored(item.unit_price, order.currency_code).toJSON(),
-      quantity: item.quantity,
-    })),
-    subtotal: Money.fromStored(
-      extensions.checkout_catalog_subtotal ?? extensions.checkout_subtotal ?? 0,
-      order.currency_code
-    ).toJSON(),
-    shipping: Money.fromStored(
-      extensions.checkout_shipping_before_discount ?? extensions.checkout_shipping ?? 0,
-      order.currency_code
-    ).toJSON(),
-    tax: Money.fromStored(extensions.checkout_tax ?? 0, order.currency_code).toJSON(),
-    discount: Money.fromStored(extensions.checkout_discount ?? 0, order.currency_code).toJSON(),
-    tender: Money.fromStored(extensions.checkout_tender ?? 0, order.currency_code).toJSON(),
-    total: Money.fromStored(order.total_amount, order.currency_code).toJSON(),
-    shippingAddress: {
-      street: [text(address.line1), text(address.line2)].filter(Boolean).join(', '),
-      city: text(address.city),
-      state: address.region || '',
-      zipCode: address.postal_code || '',
-      country: address.country,
-    },
-  });
 }
 
 export interface FinalizeOrderResult {
@@ -156,58 +107,34 @@ export async function finalizeOrderPayment(args: {
     });
   }
 
+  // Stage deterministic, dormant effect rows before the paid CAS. A crash
+  // after promotion can then be recovered by another request or the scheduler.
+  await stagePaidOrderEffects(order, { includeEmail: args.sendEmail !== false });
+
   const amountReceived = Money.fromMinor(paymentIntent.amount_received, receivedCurrency);
   const promotion = await promoteOrderToPaid({ orderId: args.orderId, amountReceived });
   if (!promotion.order || promotion.order.payment_status !== 'paid') {
     throw new Error('Order payment promotion lost without a paid winner');
   }
 
-  // Coupon usage is a paid-order effect, but is independently order-idempotent.
-  // Run it for both the CAS winner and already-paid convergence so a transient
-  // failure can be recovered by the next signed webhook/finalization retry.
   const paidOrder = promotion.order;
-  const paidExtensions = paidOrder.extensions ?? {};
-  const discountCodes = Array.isArray(paidExtensions.discount_codes)
-    ? paidExtensions.discount_codes.filter((value): value is string => typeof value === 'string')
-    : [];
-  for (const code of discountCodes) {
-    const redemption = await redeemCoupon(code, {
+  // Ensure repairs legacy/already-paid convergence. Inline draining is an
+  // optimization; every failure remains durable for scheduled retry.
+  await stagePaidOrderEffects(paidOrder, { includeEmail: args.sendEmail !== false });
+  try {
+    const effects = await drainOrderEffects({
       orderId: paidOrder.id!,
-      customerId: paidOrder.customer_id,
-      channel: 'web',
-      discountAmount: discountCodes.length === 1
-        ? Money.fromStored(paidExtensions.checkout_discount ?? 0, paidOrder.currency_code).toMach()
-        : undefined,
+      capabilities,
+      limit: 25,
     });
-    if (!redemption.redeemed && !redemption.alreadyRedeemed) {
-      // Captured money is already durably paid. A last-use race needs
-      // reconciliation, but cannot roll back or strand the paid order.
-      await recordCouponReconciliation({ orderId: paidOrder.id!, code });
-      console.error(`[checkout] Applied coupon ${code} needs reconciliation for order ${paidOrder.id}`);
+    if (effects.failed > 0) {
+      console.error(`[checkout] ${effects.failed} paid effect(s) queued for retry on order ${paidOrder.id}`);
     }
-  }
-
-  // Tender settlement is keyed by order and must be idempotent. Run it on both
-  // the CAS winner and already-paid convergence; transient failures propagate
-  // to the webhook so a later delivery can recover settlement.
-  await capabilities.giftCards.applyTender({
-    order: paidOrder,
-    state: paidExtensions.checkout_tender_state,
-  });
-  // Subscription activation follows the same order-idempotent recovery
-  // contract and must surface transient failures for webhook retry.
-  await capabilities.subscriptions.orderPaid(paidOrder);
-
-  if (promotion.promoted) {
-    if (args.sendEmail !== false) {
-      try {
-        await sendConfirmation(paidOrder);
-      } catch (error) {
-        // Paid is already durable. Email is a best-effort post-paid effect until
-        // a later webhook/effect-ledger phase can provide retry and dedup state.
-        console.error(`[checkout] Confirmation email failed for order ${paidOrder.id}:`, error);
-      }
-    }
+  } catch (error) {
+    // Paid state and deterministic effect rows are already durable. The
+    // scheduled runner owns recovery even if this opportunistic drain cannot
+    // reach D1 after the payment transition.
+    console.error(`[checkout] Paid effects queued for retry on order ${paidOrder.id}:`, error);
   }
 
   return { paid: true, promoted: promotion.promoted, order: promotion.order };

--- a/lib/stripe.ts
+++ b/lib/stripe.ts
@@ -63,244 +63,67 @@ export const loadStripe = (): Promise<Stripe | null> => {
   return stripePromise;
 };
 
-/**
- * Server-side Stripe instance
- * Configured with secret key for server operations
- */
-export const stripe = secretKey 
-  ? new StripeServer(secretKey, {
-      apiVersion: '2026-07-29.dahlia',
-      typescript: true,
-    })
-  : null;
+let stripeClient: StripeServer | null = null;
 
 /**
  * Get Stripe instance with proper error handling
  * Throws an error if Stripe is not properly configured
  */
 export const getStripe = (): StripeServer => {
-  if (!stripe) {
+  if (!secretKey) {
     throw new Error('Stripe is not properly configured - missing secret key');
   }
-  return stripe;
-};
-
-/**
- * Cloudflare Workers-compatible Stripe API client
- * Uses fetch instead of Node.js https module
- */
-export class CloudflareStripe {
-  private apiKey: string;
-  private apiVersion = '2020-08-27';
-
-  constructor(apiKey: string) {
-    this.apiKey = apiKey;
-  }
-
-  private async request(
-    method: 'GET' | 'POST',
-    endpoint: string,
-    data?: Record<string, any>
-  ) {
-    const url = `https://api.stripe.com/v1${endpoint}`;
-    const headers: Record<string, string> = {
-      'Authorization': `Bearer ${this.apiKey}`,
-      'Stripe-Version': this.apiVersion,
-    };
-
-    let body: string | undefined;
-    if (data && method === 'POST') {
-      // Convert to URL-encoded string for Stripe API
-      headers['Content-Type'] = 'application/x-www-form-urlencoded';
-      
-      const encodeValue = (obj: any, prefix = ''): string[] => {
-        const params: string[] = [];
-        
-        for (const key in obj) {
-          if (obj[key] !== null && obj[key] !== undefined) {
-            const value = obj[key];
-            const fieldName = prefix ? `${prefix}[${key}]` : key;
-            
-            if (typeof value === 'object' && !Array.isArray(value)) {
-              params.push(...encodeValue(value, fieldName));
-            } else if (Array.isArray(value)) {
-              value.forEach((item, index) => {
-                if (typeof item === 'object') {
-                  params.push(...encodeValue(item, `${fieldName}[${index}]`));
-                } else {
-                  params.push(`${encodeURIComponent(`${fieldName}[${index}]`)}=${encodeURIComponent(String(item))}`);
-                }
-              });
-            } else {
-              params.push(`${encodeURIComponent(fieldName)}=${encodeURIComponent(String(value))}`);
-            }
-          }
-        }
-        
-        return params;
-      };
-      
-      body = encodeValue(data).join('&');
-    }
-
-    const response = await fetch(url, {
-      method,
-      headers,
-      body,
+  if (!stripeClient) {
+    stripeClient = new StripeServer(secretKey, {
+      apiVersion: '2026-07-29.dahlia',
+      typescript: true,
+      httpClient: StripeServer.createFetchHttpClient(),
     });
-
-    if (!response.ok) {
-      const errorData = await response.json() as any;
-      throw new Error(`Stripe API Error: ${errorData.error?.message || response.statusText}`);
-    }
-
-    return await response.json();
   }
-
-  async createPaymentIntent(params: {
-    amount: number;
-    currency: string;
-    automatic_payment_methods?: { enabled: boolean };
-    metadata?: Record<string, string>;
-    shipping?: any;
-    description?: string;
-  }) {
-    return await this.request('POST', '/payment_intents', params);
-  }
-
-  async retrievePaymentIntent(id: string) {
-    return await this.request('GET', `/payment_intents/${encodeURIComponent(id)}`);
-  }
-
-  async cancelPaymentIntent(id: string) {
-    return await this.request('POST', `/payment_intents/${encodeURIComponent(id)}/cancel`);
-  }
-
-  async calculateTax(params: {
-    currency: string;
-    line_items: Array<{
-      amount: number;
-      reference: string;
-      tax_behavior?: string;
-      tax_code?: string;
-    }>;
-    customer_details: {
-      address: {
-        line1: string;
-        city: string;
-        state: string;
-        postal_code: string;
-        country: string;
-      };
-      address_source: string;
-    };
-  }) {
-    return await this.request('POST', '/tax/calculations', params);
-  }
-
-  webhooks = {
-    constructEvent: (payload: string, signature: string, secret: string) => {
-      // Basic webhook verification - in production, you'd want more robust verification
-      // For now, just parse the payload
-      try {
-        return JSON.parse(payload);
-      } catch (error) {
-        throw new Error('Invalid webhook payload');
-      }
-    }
-  };
-}
-
-/**
- * Get Cloudflare Workers-compatible Stripe client
- */
-export const getCloudflareStripe = (): CloudflareStripe => {
-  if (!secretKey) {
-    throw new Error('Stripe secret key not configured for Cloudflare Workers');
-  }
-  return new CloudflareStripe(secretKey);
+  return stripeClient;
 };
 
-/**
- * Get the appropriate Stripe client based on the runtime environment
- */
-export const getStripeClient = (): StripeServer | CloudflareStripe => {
-  // Detect if we're running in Cloudflare Workers
-  const isCloudflareWorkers = typeof globalThis !== 'undefined' && 
-    globalThis.navigator?.userAgent?.includes('Cloudflare-Workers');
-  
-  // Also check for specific Cloudflare Workers globals
-  const hasWorkersGlobals = typeof caches !== 'undefined' && 
-    typeof Request !== 'undefined' && 
-    typeof Response !== 'undefined' && 
-    typeof globalThis.fetch === 'function';
-
-  if (isCloudflareWorkers || hasWorkersGlobals || process.env.NODE_ENV === 'production') {
-    return getCloudflareStripe();
-  } else {
-    return getStripe();
-  }
-};
+/** One SDK client is used in Node.js and Cloudflare Workers. */
+export const getStripeClient = getStripe;
 
 /**
  * Create a payment intent using the appropriate Stripe client
  */
-export const createPaymentIntent = async (params: {
-  amount: number;
-  currency: string;
-  automatic_payment_methods?: { enabled: boolean };
-  metadata?: Record<string, string>;
-  shipping?: any;
-  description?: string;
-}): Promise<{ id: string; client_secret: string | null; [key: string]: any }> => {
-  const client = getStripeClient();
-  
-  if (client instanceof CloudflareStripe) {
-    return await client.createPaymentIntent(params) as { id: string; client_secret: string | null; [key: string]: any };
-  } else {
-    // Use the regular Stripe SDK
-    return await client.paymentIntents.create(params) as { id: string; client_secret: string | null; [key: string]: any };
-  }
-};
+export const createPaymentIntent = async (
+  params: StripeServer.PaymentIntentCreateParams
+): Promise<StripeServer.PaymentIntent> => getStripe().paymentIntents.create(params);
 
-export const retrievePaymentIntent = async (id: string): Promise<{
-  id: string;
-  status: string;
-  amount: number;
-  amount_received: number;
-  currency: string;
-  metadata: Record<string, string>;
-}> => {
-  const client = getStripeClient();
-  if (client instanceof CloudflareStripe) {
-    return await client.retrievePaymentIntent(id) as any;
-  }
-  return await client.paymentIntents.retrieve(id) as any;
-};
+export const retrievePaymentIntent = async (
+  id: string
+): Promise<StripeServer.PaymentIntent> => getStripe().paymentIntents.retrieve(id);
 
 /** Best-effort cleanup when durable pending-order persistence fails. */
 export const cancelPaymentIntent = async (id: string): Promise<void> => {
-  const client = getStripeClient();
-  if (client instanceof CloudflareStripe) {
-    await client.cancelPaymentIntent(id);
-    return;
-  }
-  await client.paymentIntents.cancel(id);
+  await getStripe().paymentIntents.cancel(id);
 };
 
 /**
  * Calculate tax using the appropriate Stripe client
  */
-export const calculateTax = async (params: any): Promise<any> => {
-  const client = getStripeClient();
-  
-  if (client instanceof CloudflareStripe) {
-    return await client.calculateTax(params);
-  } else {
-    // Use the regular Stripe SDK
-    return await client.tax.calculations.create(params);
-  }
-};
+export const calculateTax = async (
+  params: StripeServer.Tax.CalculationCreateParams
+): Promise<StripeServer.Tax.Calculation> => getStripe().tax.calculations.create(params);
+
+/**
+ * Verify a Stripe webhook with Web Crypto so signature checking works in
+ * Cloudflare Workers as well as Node.js.
+ */
+export const constructWebhookEvent = async (
+  payload: string | Uint8Array,
+  signature: string,
+  secret = getWebhookSecret()
+): Promise<StripeServer.Event> => getStripe().webhooks.constructEventAsync(
+  payload,
+  signature,
+  secret,
+  undefined,
+  StripeServer.createSubtleCryptoProvider()
+);
 
 /**
  * Stripe Tax configuration

--- a/lib/types/order.ts
+++ b/lib/types/order.ts
@@ -22,6 +22,22 @@ export interface OrderItem {
   created_at?: string;
 }
 
+/**
+ * Immutable server-authored money attribution for one checkout line. These
+ * snapshots are the refund authority for orders created by the web checkout.
+ */
+export interface CheckoutLineAllocation {
+  lineId: string;
+  productId: string;
+  variantId: string;
+  quantity: number;
+  catalogSubtotal: Money;
+  merchandiseDiscount: Money;
+  netMerchandise: Money;
+  tax: Money;
+  promotionCodes: string[];
+}
+
 // Order status enumeration
 export type OrderStatus = "pending" | "processing" | "shipped" | "delivered" | "cancelled" | "refunded";
 

--- a/lib/utils/email.ts
+++ b/lib/utils/email.ts
@@ -1,6 +1,7 @@
 import { Resend } from 'resend';
 import { Money, type StoredMoney } from '@/lib/money';
 import { escapeHtmlText } from '@/lib/utils/maintenance-html';
+import { getStoreConfig } from '@/lib/store-config';
 
 let resend: Resend | null = null;
 
@@ -70,17 +71,21 @@ export interface OrderStatusUpdateData {
   };
 }
 
-export async function sendOrderConfirmationEmail(orderData: OrderData): Promise<EmailResult> {
+export async function sendOrderConfirmationEmail(
+  orderData: OrderData,
+  options: { idempotencyKey?: string } = {}
+): Promise<EmailResult> {
   try {
     const emailHtml = generateOrderConfirmationHTML(orderData);
     const resendClient = getResendClient();
+    const store = getStoreConfig();
     
     const { data, error } = await resendClient.emails.send({
-      from: 'Volt at Voltique<volt@russellkmoore.me>',
+      from: store.contact.senderEmail,
       to: [orderData.customerEmail],
-      subject: `Order Confirmation #${orderData.orderNumber} - Voltique`,
+      subject: `Order Confirmation #${orderData.orderNumber} - ${store.identity.name}`,
       html: emailHtml,
-    });
+    }, options.idempotencyKey ? { idempotencyKey: options.idempotencyKey } : undefined);
 
     if (error) {
       console.error('Email sending error:', error);
@@ -96,6 +101,10 @@ export async function sendOrderConfirmationEmail(orderData: OrderData): Promise<
 }
 
 export function generateOrderConfirmationHTML(orderData: OrderData): string {
+  const store = getStoreConfig();
+  const safeStoreName = escapeHtmlText(store.identity.name);
+  const safeTagline = escapeHtmlText(store.identity.tagline);
+
   // Helper function to ensure absolute URLs for images using Cloudflare Image service
   const getAbsoluteImageUrl = (imageUrl: string | undefined): string | undefined => {
     if (!imageUrl) return undefined;
@@ -110,14 +119,15 @@ export function generateOrderConfirmationHTML(orderData: OrderData): string {
       }
     }
     
-    // Resolve relative catalog paths under the trusted image service. URL
-    // serialization percent-encodes quotes/spaces before HTML attribute escaping.
+    // Resolve relative catalog paths under the configured store/image origin.
+    // URL serialization percent-encodes quotes/spaces before HTML escaping.
     try {
       const normalizedPath = imageUrl.startsWith('/') ? imageUrl.slice(1) : imageUrl;
-      return new URL(
-        `/cdn-cgi/image/width=100,quality=80,format=auto/${normalizedPath}`,
-        'https://voltique-images.russellkmoore.me'
-      ).href;
+      const transform = store.urls.imageCdn && store.deployment.imageTransformsEnabled;
+      const path = transform
+        ? `/cdn-cgi/image/width=100,quality=80,format=auto/${normalizedPath}`
+        : `/${normalizedPath}`;
+      return new URL(path, store.urls.imageCdn ?? store.urls.site).href;
     } catch {
       return undefined;
     }
@@ -148,22 +158,22 @@ export function generateOrderConfirmationHTML(orderData: OrderData): string {
     <head>
       <meta charset="utf-8">
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
-      <title>Order Confirmation - Voltique</title>
+      <title>Order Confirmation - ${safeStoreName}</title>
     </head>
     <body style="margin: 0; padding: 0; background-color: #f6f9fc; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Ubuntu, sans-serif;">
       <div style="background-color: #ffffff; margin: 0 auto; padding: 20px 0 48px; margin-bottom: 64px; max-width: 600px;">
         
         <!-- Header -->
         <div style="text-align: center; padding: 32px 0; border-bottom: 1px solid #e6ebf1;">
-          <h1 style="color: #f97316; font-size: 32px; font-weight: bold; margin: 0; padding: 0;">Voltique</h1>
-          <p style="color: #64748b; font-size: 14px; margin: 8px 0 0;">Premium Outdoor Gear</p>
+          <h1 style="color: #f97316; font-size: 32px; font-weight: bold; margin: 0; padding: 0;">${safeStoreName}</h1>
+          <p style="color: #64748b; font-size: 14px; margin: 8px 0 0;">${safeTagline}</p>
         </div>
 
         <!-- Order Confirmation -->
         <div style="padding: 24px 32px;">
           <h2 style="color: #1e293b; font-size: 24px; font-weight: bold; margin: 0 0 16px;">Order Confirmed!</h2>
           <p style="color: #64748b; font-size: 16px; line-height: 24px; margin: 0 0 16px;">Hi ${escapeHtmlText(orderData.customerName)},</p>
-          <p style="color: #64748b; font-size: 16px; line-height: 24px; margin: 0 0 16px;">Thank you for your order! Your gear is being prepared and will be shipped soon.</p>
+          <p style="color: #64748b; font-size: 16px; line-height: 24px; margin: 0 0 16px;">Thank you for your order! It is being prepared and will be shipped soon.</p>
           
           <div style="background-color: #f1f5f9; border-radius: 8px; padding: 16px; margin: 16px 0;">
             <p style="color: #1e293b; font-size: 18px; font-weight: bold; margin: 0 0 8px;">Order #${escapeHtmlText(orderData.orderNumber)}</p>
@@ -224,7 +234,7 @@ export function generateOrderConfirmationHTML(orderData: OrderData): string {
         <!-- Footer -->
         <div style="text-align: center; padding: 32px 32px 0; border-top: 1px solid #e6ebf1;">
           <p style="color: #64748b; font-size: 12px; line-height: 16px; margin: 0 0 8px;">Questions about your order? Reply to this email or contact our support team.</p>
-          <p style="color: #64748b; font-size: 12px; line-height: 16px; margin: 0 0 8px;">Thank you for choosing Voltique!</p>
+          <p style="color: #64748b; font-size: 12px; line-height: 16px; margin: 0 0 8px;">Thank you for choosing ${safeStoreName}!</p>
         </div>
 
       </div>

--- a/lib/utils/order-update-guards.ts
+++ b/lib/utils/order-update-guards.ts
@@ -32,6 +32,8 @@ export const SERVER_OWNED_ORDER_EXTENSION_KEYS = [
   'checkout_shipping_before_discount',
   'checkout_shipping_discount',
   'checkout_tax',
+  'checkout_shipping_tax',
+  'checkout_line_allocations',
   'checkout_tender',
   'checkout_tender_state',
   'checkout_total',

--- a/lib/utils/refund-validation.ts
+++ b/lib/utils/refund-validation.ts
@@ -1,0 +1,130 @@
+/** Pure, storage-agnostic refund validation and cumulative-money helpers. */
+
+export const MAX_REFUND_RECORDS = 100;
+export const MAX_REFUND_LINE_IDS = 100;
+export const MAX_REFUND_TEXT_LENGTH = 128;
+
+export type RefundStatus =
+  | 'pending'
+  | 'requires_action'
+  | 'succeeded'
+  | 'failed'
+  | 'canceled';
+
+export type RefundStatusClass = 'reserved' | 'settled' | 'released' | 'legacy' | 'unknown';
+
+export interface RefundRecord {
+  id?: string;
+  idempotency_key?: string;
+  request_fingerprint?: string;
+  stripe_refund_id?: string;
+  amount?: number;
+  status?: RefundStatus | string;
+  type?: 'full' | 'partial';
+  items?: string[];
+  settled_sequence?: number;
+  requested_at?: string;
+  processed_at?: string;
+  provider_status?: string;
+  [key: string]: unknown;
+}
+
+export interface OrderExtensions {
+  refunds?: unknown;
+  stripe_amount_refunded?: unknown;
+  [key: string]: unknown;
+}
+
+export function isPositiveSafeInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value > 0;
+}
+
+/** Classify both current Stripe states and status-less legacy ledger entries. */
+export function classifyRefundStatus(status: unknown): RefundStatusClass {
+  if (status === undefined || status === null || status === '') return 'legacy';
+  if (status === 'pending' || status === 'requires_action') return 'reserved';
+  if (status === 'succeeded') return 'settled';
+  if (status === 'failed' || status === 'canceled') return 'released';
+  return 'unknown';
+}
+
+/** Pending and requires-action refunds reserve balance and block fulfillment. */
+export function isUnsettledRefund(record: RefundRecord | null | undefined): boolean {
+  return classifyRefundStatus(record?.status) === 'reserved';
+}
+
+export function hasPendingRefund(extensions: OrderExtensions | null | undefined): boolean {
+  const refunds = extensions?.refunds;
+  return Array.isArray(refunds) && refunds.some(
+    (entry) => entry !== null && typeof entry === 'object' && isUnsettledRefund(entry as RefundRecord)
+  );
+}
+
+/**
+ * Sum balance-reserving ledger entries using positive safe integers only.
+ *
+ * Oversized ledgers and arithmetic overflow return MAX_SAFE_INTEGER. That is a
+ * deliberate fail-closed result: corrupt storage must never open room for an
+ * additional refund.
+ */
+export function computeRefundedTotal(extensions: OrderExtensions | null | undefined): number {
+  const refunds = extensions?.refunds;
+  if (!Array.isArray(refunds)) return 0;
+  if (refunds.length > MAX_REFUND_RECORDS) return Number.MAX_SAFE_INTEGER;
+
+  let total = 0;
+  for (const raw of refunds) {
+    if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
+      return Number.MAX_SAFE_INTEGER;
+    }
+    const refund = raw as RefundRecord;
+    const status = classifyRefundStatus(refund.status);
+    if (status === 'released') continue;
+    if (status === 'unknown' || !isPositiveSafeInteger(refund.amount)) {
+      return Number.MAX_SAFE_INTEGER;
+    }
+    if (total > Number.MAX_SAFE_INTEGER - refund.amount) return Number.MAX_SAFE_INTEGER;
+    total += refund.amount;
+  }
+  return total;
+}
+
+export type RefundAmountResult = { ok: true; amount: number } | { ok: false; error: string };
+
+/** Validate an explicit partial-refund amount against the remaining balance. */
+export function assertRefundWithinRemaining(
+  totalAmount: number,
+  alreadyRefunded: number,
+  requestedAmount: number
+): { ok: true } | { ok: false; error: string } {
+  if (!isPositiveSafeInteger(totalAmount)) {
+    return { ok: false, error: 'Order total must be a positive safe integer' };
+  }
+  if (!Number.isSafeInteger(alreadyRefunded) || alreadyRefunded < 0) {
+    return { ok: false, error: 'Recorded refund total is invalid' };
+  }
+  if (!isPositiveSafeInteger(requestedAmount)) {
+    return { ok: false, error: 'Refund amount must be a positive safe integer' };
+  }
+  if (alreadyRefunded >= totalAmount || requestedAmount > totalAmount - alreadyRefunded) {
+    return { ok: false, error: 'Refund exceeds remaining refundable amount' };
+  }
+  return { ok: true };
+}
+
+/** A full refund always means the remaining refundable amount. */
+export function resolveFullRefundAmount(
+  totalAmount: number,
+  alreadyRefunded: number
+): RefundAmountResult {
+  if (!isPositiveSafeInteger(totalAmount)) {
+    return { ok: false, error: 'Order total must be a positive safe integer' };
+  }
+  if (!Number.isSafeInteger(alreadyRefunded) || alreadyRefunded < 0) {
+    return { ok: false, error: 'Recorded refund total is invalid' };
+  }
+  if (alreadyRefunded >= totalAmount) {
+    return { ok: false, error: 'Order is already fully refunded' };
+  }
+  return { ok: true, amount: totalAmount - alreadyRefunded };
+}

--- a/lib/utils/refund-validation.ts
+++ b/lib/utils/refund-validation.ts
@@ -35,6 +35,25 @@ export interface OrderExtensions {
   [key: string]: unknown;
 }
 
+/**
+ * SQL fragment for the future atomic shipment transition. Keep the JSON
+ * validity guard and object-element check: legacy scalar or malformed metadata
+ * must not throw or create substring false positives.
+ */
+export const SHIPMENT_NO_UNSETTLED_REFUNDS_SQL = `NOT EXISTS (
+  SELECT 1
+  FROM json_each(
+    CASE
+      WHEN json_valid(COALESCE(orders.extensions, '{}')) = 1
+        THEN COALESCE(orders.extensions, '{}')
+      ELSE '{}'
+    END,
+    '$.refunds'
+  ) AS refund
+  WHERE refund.type = 'object'
+    AND json_extract(refund.value, '$.status') IN ('pending', 'requires_action')
+)`;
+
 export function isPositiveSafeInteger(value: unknown): value is number {
   return typeof value === 'number' && Number.isSafeInteger(value) && value > 0;
 }

--- a/lib/utils/settings.ts
+++ b/lib/utils/settings.ts
@@ -56,11 +56,13 @@ export async function getRefundPolicy() {
   const refundSettings = await getSettings('refund');
   
   return {
-    refundShipping: refundSettings['refund.shipping_refunded'] || false,
-    refundShippingOnFullReturn: refundSettings['refund.shipping_refunded_on_full_return'] || false,
+    refundShipping: refundSettings['refund.shipping_refunded_partial'] === true,
+    refundShippingOnFullReturn: refundSettings['refund.shipping_refunded_full'] === true,
     restockingFeePercent: refundSettings['refund.restocking_fee_percent'] || 0,
     minimumRefundAmount: refundSettings['refund.minimum_refund_amount'] || 0,
-    applyRestockingFeeOnPartialReturn: refundSettings['refund.apply_restocking_fee_on_partial'] !== false
+    applyRestockingFeeOnPartialReturn: refundSettings['refund.apply_restocking_fee_on_partial'] !== false,
+    externalFullRestockEnabled:
+      refundSettings['refund.external_full_restock_enabled'] === true,
   };
 }
 
@@ -115,4 +117,5 @@ export interface RefundPolicy {
   restockingFeePercent: number;
   minimumRefundAmount: number;
   applyRestockingFeeOnPartialReturn: boolean;
+  externalFullRestockEnabled: boolean;
 }

--- a/lib/webhooks/processed-events.ts
+++ b/lib/webhooks/processed-events.ts
@@ -1,0 +1,214 @@
+import { getCloudflareContext } from '@opennextjs/cloudflare';
+
+const DEFAULT_LEASE_MS = 5 * 60 * 1000;
+const MAX_ERROR_LENGTH = 2_000;
+
+type SqlValue = string | number | null;
+
+export interface ProcessedEventsExecutor {
+  first<T>(query: string, bindings: readonly SqlValue[]): Promise<T | null>;
+  run(query: string, bindings: readonly SqlValue[]): Promise<{ changes: number }>;
+}
+
+export type WebhookEventOutcome = 'handled' | 'ignored' | 'permanent_rejection';
+
+export type WebhookEventClaim =
+  | {
+      state: 'acquired';
+      claimToken: string;
+      attemptCount: number;
+      leaseExpiresAt: string;
+    }
+  | { state: 'completed'; outcome: string | null }
+  | { state: 'busy' };
+
+interface ClaimedRow {
+  claim_token: string;
+  attempt_count: number;
+  lease_expires_at: string;
+}
+
+interface ObservedRow {
+  status: 'processing' | 'completed' | 'failed';
+  outcome: string | null;
+}
+
+const CLAIM_SQL = `
+INSERT INTO processed_webhook_events (
+  event_id,
+  event_type,
+  status,
+  attempt_count,
+  claim_token,
+  claimed_at,
+  lease_expires_at,
+  completed_at,
+  last_error,
+  outcome,
+  created_at,
+  updated_at
+) VALUES (?, ?, 'processing', 1, ?, ?, ?, NULL, NULL, NULL, ?, ?)
+ON CONFLICT(event_id) DO UPDATE SET
+  event_type = excluded.event_type,
+  status = 'processing',
+  attempt_count = processed_webhook_events.attempt_count + 1,
+  claim_token = excluded.claim_token,
+  claimed_at = excluded.claimed_at,
+  lease_expires_at = excluded.lease_expires_at,
+  completed_at = NULL,
+  last_error = NULL,
+  outcome = NULL,
+  updated_at = excluded.updated_at
+WHERE processed_webhook_events.status = 'failed'
+   OR (
+     processed_webhook_events.status = 'processing'
+     AND processed_webhook_events.lease_expires_at <= ?
+   )
+RETURNING claim_token, attempt_count, lease_expires_at
+`;
+
+const READ_SQL = `
+SELECT status, outcome
+FROM processed_webhook_events
+WHERE event_id = ?
+`;
+
+function createExecutor(database: D1Database): ProcessedEventsExecutor {
+  return {
+    first<T>(query: string, bindings: readonly SqlValue[]) {
+      return database.prepare(query).bind(...bindings).first<T>();
+    },
+    async run(query: string, bindings: readonly SqlValue[]) {
+      const result = await database.prepare(query).bind(...bindings).run();
+      return { changes: result.meta.changes };
+    },
+  };
+}
+
+async function resolveExecutor(
+  executor?: ProcessedEventsExecutor
+): Promise<ProcessedEventsExecutor> {
+  if (executor) return executor;
+  const { env } = await getCloudflareContext({ async: true });
+  return createExecutor(env.DB);
+}
+
+export function createProcessedEventsExecutor(
+  database: D1Database
+): ProcessedEventsExecutor {
+  return createExecutor(database);
+}
+
+export async function claimWebhookEvent(
+  input: {
+    eventId: string;
+    eventType: string;
+    now?: Date;
+    leaseDurationMs?: number;
+    claimToken?: string;
+  },
+  providedExecutor?: ProcessedEventsExecutor
+): Promise<WebhookEventClaim> {
+  const executor = await resolveExecutor(providedExecutor);
+  const now = input.now ?? new Date();
+  const leaseDurationMs = input.leaseDurationMs ?? DEFAULT_LEASE_MS;
+  if (!Number.isSafeInteger(leaseDurationMs) || leaseDurationMs <= 0) {
+    throw new Error('Webhook lease duration must be a positive integer');
+  }
+
+  const nowIso = now.toISOString();
+  const leaseExpiresAt = new Date(now.getTime() + leaseDurationMs).toISOString();
+  const claimToken = input.claimToken ?? crypto.randomUUID();
+  const claimed = await executor.first<ClaimedRow>(CLAIM_SQL, [
+    input.eventId,
+    input.eventType,
+    claimToken,
+    nowIso,
+    leaseExpiresAt,
+    nowIso,
+    nowIso,
+    nowIso,
+  ]);
+
+  if (claimed) {
+    return {
+      state: 'acquired',
+      claimToken: claimed.claim_token,
+      attemptCount: claimed.attempt_count,
+      leaseExpiresAt: claimed.lease_expires_at,
+    };
+  }
+
+  const observed = await executor.first<ObservedRow>(READ_SQL, [input.eventId]);
+  if (observed?.status === 'completed') {
+    return { state: 'completed', outcome: observed.outcome };
+  }
+  return { state: 'busy' };
+}
+
+export async function completeWebhookEvent(
+  input: {
+    eventId: string;
+    claimToken: string;
+    outcome: WebhookEventOutcome;
+    now?: Date;
+  },
+  providedExecutor?: ProcessedEventsExecutor
+): Promise<boolean> {
+  const executor = await resolveExecutor(providedExecutor);
+  const nowIso = (input.now ?? new Date()).toISOString();
+  const result = await executor.run(`
+UPDATE processed_webhook_events
+SET status = 'completed',
+    claim_token = NULL,
+    lease_expires_at = NULL,
+    completed_at = ?,
+    last_error = NULL,
+    outcome = ?,
+    updated_at = ?
+WHERE event_id = ?
+  AND status = 'processing'
+  AND claim_token = ?
+`, [nowIso, input.outcome, nowIso, input.eventId, input.claimToken]);
+  return result.changes === 1;
+}
+
+export async function failWebhookEvent(
+  input: {
+    eventId: string;
+    claimToken: string;
+    error: unknown;
+    now?: Date;
+  },
+  providedExecutor?: ProcessedEventsExecutor
+): Promise<boolean> {
+  const executor = await resolveExecutor(providedExecutor);
+  const nowIso = (input.now ?? new Date()).toISOString();
+  const message = (input.error instanceof Error ? input.error.message : String(input.error))
+    .slice(0, MAX_ERROR_LENGTH);
+  const result = await executor.run(`
+UPDATE processed_webhook_events
+SET status = 'failed',
+    claim_token = NULL,
+    lease_expires_at = NULL,
+    last_error = ?,
+    updated_at = ?
+WHERE event_id = ?
+  AND status = 'processing'
+  AND claim_token = ?
+`, [message, nowIso, input.eventId, input.claimToken]);
+  return result.changes === 1;
+}
+
+export async function cleanupCompletedWebhookEvents(
+  completedBefore: Date,
+  providedExecutor?: ProcessedEventsExecutor
+): Promise<number> {
+  const executor = await resolveExecutor(providedExecutor);
+  const result = await executor.run(`
+DELETE FROM processed_webhook_events
+WHERE status = 'completed'
+  AND completed_at < ?
+`, [completedBefore.toISOString()]);
+  return result.changes;
+}

--- a/migrations/0008_add_processed_webhook_events.sql
+++ b/migrations/0008_add_processed_webhook_events.sql
@@ -1,0 +1,25 @@
+-- Durable, core Stripe webhook idempotency and retry state.
+CREATE TABLE processed_webhook_events (
+  event_id TEXT PRIMARY KEY,
+  event_type TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('processing', 'completed', 'failed')),
+  attempt_count INTEGER NOT NULL DEFAULT 0 CHECK (attempt_count >= 0),
+  claim_token TEXT,
+  claimed_at TEXT,
+  lease_expires_at TEXT,
+  completed_at TEXT,
+  last_error TEXT,
+  outcome TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  CHECK (
+    (status = 'processing' AND claim_token IS NOT NULL AND lease_expires_at IS NOT NULL)
+    OR status IN ('completed', 'failed')
+  )
+);
+
+CREATE INDEX idx_processed_webhook_events_status_lease
+  ON processed_webhook_events(status, lease_expires_at);
+
+CREATE INDEX idx_processed_webhook_events_completed_at
+  ON processed_webhook_events(completed_at);

--- a/migrations/0009_add_order_effects.sql
+++ b/migrations/0009_add_order_effects.sql
@@ -1,0 +1,23 @@
+CREATE TABLE order_effects (
+  effect_key TEXT PRIMARY KEY,
+  order_id TEXT NOT NULL REFERENCES orders(id),
+  effect_type TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('pending','processing','succeeded','failed')),
+  attempt_count INTEGER NOT NULL DEFAULT 0 CHECK (attempt_count >= 0),
+  claim_token TEXT,
+  lease_expires_at TEXT,
+  next_attempt_at TEXT,
+  last_error TEXT,
+  result TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  completed_at TEXT,
+  CHECK (
+    (status = 'processing' AND claim_token IS NOT NULL AND lease_expires_at IS NOT NULL)
+    OR status IN ('pending','succeeded','failed')
+  )
+);
+
+CREATE INDEX idx_order_effects_retry
+  ON order_effects(status, next_attempt_at, lease_expires_at);
+CREATE INDEX idx_order_effects_order ON order_effects(order_id);

--- a/migrations/0010_add_inventory_adjustments.sql
+++ b/migrations/0010_add_inventory_adjustments.sql
@@ -1,0 +1,29 @@
+CREATE TABLE inventory_adjustments (
+  adjustment_key TEXT PRIMARY KEY,
+  order_id TEXT NOT NULL REFERENCES orders(id),
+  line_id TEXT,
+  variant_id TEXT NOT NULL,
+  kind TEXT NOT NULL CHECK (kind IN ('paid_decrement','refund_restock')),
+  quantity INTEGER NOT NULL CHECK (quantity > 0),
+  status TEXT NOT NULL CHECK (
+    status IN ('pending','processing','succeeded','skipped','needs_review','failed')
+  ),
+  attempt_count INTEGER NOT NULL DEFAULT 0 CHECK (attempt_count >= 0),
+  claim_token TEXT,
+  lease_expires_at TEXT,
+  next_attempt_at TEXT,
+  result TEXT,
+  last_error TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  completed_at TEXT,
+  CHECK (
+    (status = 'processing' AND claim_token IS NOT NULL AND lease_expires_at IS NOT NULL)
+    OR status IN ('pending','succeeded','skipped','needs_review','failed')
+  )
+);
+
+CREATE INDEX idx_inventory_adjustments_retry
+  ON inventory_adjustments(status, next_attempt_at, lease_expires_at);
+CREATE INDEX idx_inventory_adjustments_order
+  ON inventory_adjustments(order_id, kind);

--- a/migrations/0011_add_external_refund_restock_setting.sql
+++ b/migrations/0011_add_external_refund_restock_setting.sql
@@ -1,0 +1,11 @@
+INSERT OR IGNORE INTO admin_settings (
+  key, value, category, description, data_type, created_at, updated_at
+) VALUES (
+  'refund.external_full_restock_enabled',
+  'false',
+  'refund',
+  'Restock every outstanding line after a full Stripe Dashboard refund',
+  'boolean',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "zustand": "^5.0.6"
       },
       "devDependencies": {
+        "@cloudflare/vitest-pool-workers": "0.20.1",
         "@cloudflare/workers-types": "^5.20260801.1",
         "@opennextjs/cloudflare": "^1.20.2",
         "@tailwindcss/postcss": "^4.3.3",
@@ -1438,6 +1439,502 @@
         "workerd": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.20.1.tgz",
+      "integrity": "sha512-eN5jHaX78lY/btWlyWIiNtTIgmXnI0CvwC6CPukgRjHoXs66jqX0AEKUsUJOeybfXEmZUhhy5FP/Xx+6wNwI7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cjs-module-lexer": "1.2.3",
+        "esbuild": "0.28.1",
+        "miniflare": "5.20260730.0-alpha",
+        "wrangler": "4.118.0",
+        "zod": "4.4.3"
+      },
+      "peerDependencies": {
+        "@vitest/runner": "^4.1.0",
+        "@vitest/snapshot": "^4.1.0",
+        "vitest": "^4.1.0"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
@@ -8281,6 +8778,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
+      "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/class-variance-authority": {
       "version": "0.7.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
+    "test:workers": "vitest run --config vitest.workers.config.mts",
     "test:watch": "vitest",
     "predeploy": "node scripts/check-deploy-config.mjs",
     "deploy": "npm run clean && npm run build:worker && opennextjs-cloudflare deploy",
@@ -73,6 +74,7 @@
     "zustand": "^5.0.6"
   },
   "devDependencies": {
+    "@cloudflare/vitest-pool-workers": "0.20.1",
     "@cloudflare/workers-types": "^5.20260801.1",
     "@opennextjs/cloudflare": "^1.20.2",
     "@tailwindcss/postcss": "^4.3.3",

--- a/tests/integration/cloudflare-test.d.ts
+++ b/tests/integration/cloudflare-test.d.ts
@@ -1,0 +1,14 @@
+/// <reference types="@cloudflare/vitest-pool-workers/types" />
+
+declare global {
+  namespace Cloudflare {
+    interface Env {
+      TEST_MIGRATIONS: Array<{
+        name: string;
+        queries: string[];
+      }>;
+    }
+  }
+}
+
+export {};

--- a/tests/integration/d1-harness.test.ts
+++ b/tests/integration/d1-harness.test.ts
@@ -20,6 +20,7 @@ describe('real D1 Workers harness', () => {
       '0005_add_reviews_tables.sql',
       '0006_add_review_reminders.sql',
       '0007_add_analytics_cache.sql',
+      '0008_add_processed_webhook_events.sql',
     ]);
   });
 

--- a/tests/integration/d1-harness.test.ts
+++ b/tests/integration/d1-harness.test.ts
@@ -21,6 +21,7 @@ describe('real D1 Workers harness', () => {
       '0006_add_review_reminders.sql',
       '0007_add_analytics_cache.sql',
       '0008_add_processed_webhook_events.sql',
+      '0009_add_order_effects.sql',
     ]);
   });
 

--- a/tests/integration/d1-harness.test.ts
+++ b/tests/integration/d1-harness.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { env } from 'cloudflare:workers';
+import { applyTestMigrations } from './helpers/d1';
+
+beforeEach(async () => {
+  await applyTestMigrations();
+});
+
+describe('real D1 Workers harness', () => {
+  it('applies the production migration sequence', async () => {
+    const result = await env.DB.prepare(
+      'SELECT name FROM d1_migrations ORDER BY id'
+    ).all<{ name: string }>();
+
+    expect(result.results.map(({ name }) => name)).toEqual([
+      '0001_initial_schema.sql',
+      '0002_add_admin_users.sql',
+      '0003_add_cms_pages.sql',
+      '0004_add_mcp_tables.sql',
+      '0005_add_reviews_tables.sql',
+      '0006_add_review_reminders.sql',
+      '0007_add_analytics_cache.sql',
+    ]);
+  });
+
+  it('serializes concurrent primary-key claims against real D1', async () => {
+    await env.DB.exec('CREATE TABLE harness_claims (event_id TEXT PRIMARY KEY)');
+
+    const attempts = await Promise.allSettled([
+      env.DB.prepare('INSERT INTO harness_claims (event_id) VALUES (?)').bind('evt_same').run(),
+      env.DB.prepare('INSERT INTO harness_claims (event_id) VALUES (?)').bind('evt_same').run(),
+    ]);
+    const stored = await env.DB.prepare(
+      'SELECT COUNT(*) AS count FROM harness_claims WHERE event_id = ?'
+    ).bind('evt_same').first<{ count: number }>();
+
+    expect(attempts.filter(({ status }) => status === 'fulfilled')).toHaveLength(1);
+    expect(attempts.filter(({ status }) => status === 'rejected')).toHaveLength(1);
+    expect(stored?.count).toBe(1);
+  });
+
+  it('rolls back every statement when a D1 batch fails', async () => {
+    await env.DB.exec('CREATE TABLE harness_batch (event_id TEXT PRIMARY KEY)');
+
+    await expect(env.DB.batch([
+      env.DB.prepare('INSERT INTO harness_batch (event_id) VALUES (?)').bind('evt_batch'),
+      env.DB.prepare('INSERT INTO harness_batch (event_id) VALUES (?)').bind('evt_batch'),
+    ])).rejects.toThrow();
+
+    const stored = await env.DB.prepare(
+      'SELECT COUNT(*) AS count FROM harness_batch'
+    ).first<{ count: number }>();
+    expect(stored?.count).toBe(0);
+  });
+});

--- a/tests/integration/d1-harness.test.ts
+++ b/tests/integration/d1-harness.test.ts
@@ -23,6 +23,7 @@ describe('real D1 Workers harness', () => {
       '0008_add_processed_webhook_events.sql',
       '0009_add_order_effects.sql',
       '0010_add_inventory_adjustments.sql',
+      '0011_add_external_refund_restock_setting.sql',
     ]);
   });
 

--- a/tests/integration/d1-harness.test.ts
+++ b/tests/integration/d1-harness.test.ts
@@ -22,6 +22,7 @@ describe('real D1 Workers harness', () => {
       '0007_add_analytics_cache.sql',
       '0008_add_processed_webhook_events.sql',
       '0009_add_order_effects.sql',
+      '0010_add_inventory_adjustments.sql',
     ]);
   });
 

--- a/tests/integration/helpers/d1.ts
+++ b/tests/integration/helpers/d1.ts
@@ -1,0 +1,6 @@
+import { env } from 'cloudflare:workers';
+import { applyD1Migrations } from 'cloudflare:test';
+
+export async function applyTestMigrations(): Promise<void> {
+  await applyD1Migrations(env.DB, env.TEST_MIGRATIONS);
+}

--- a/tests/integration/lib/payments/refund-fulfillment-contract.test.ts
+++ b/tests/integration/lib/payments/refund-fulfillment-contract.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { env } from 'cloudflare:workers';
+import { SHIPMENT_NO_UNSETTLED_REFUNDS_SQL } from '@/lib/utils/refund-validation';
+import { applyTestMigrations } from '../../helpers/d1';
+
+async function insertOrder(id: string, extensions: string | null): Promise<void> {
+  await env.DB.prepare(`
+INSERT INTO orders (
+  id, status, total_amount, currency_code, items, payment_status,
+  extensions, created_at, updated_at
+) VALUES (?, 'processing', ?, 'USD', '[]', 'paid', ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+`).bind(id, JSON.stringify({ amount: 100, currency: 'USD' }), extensions).run();
+}
+
+beforeEach(async () => {
+  await applyTestMigrations();
+  await env.DB.prepare("DELETE FROM orders WHERE id LIKE 'U09-SHIP-%'").run();
+});
+
+describe('future shipment refund-hold SQL contract', () => {
+  it('blocks reserved refunds without tripping on legacy JSON shapes', async () => {
+    await insertOrder('U09-SHIP-ABSENT', null);
+    await insertOrder('U09-SHIP-MALFORMED', '{malformed');
+    await insertOrder('U09-SHIP-SCALAR', JSON.stringify({ refunds: 'pending' }));
+    await insertOrder('U09-SHIP-SUBSTRING', JSON.stringify({ refunds: ['pending'] }));
+    await insertOrder('U09-SHIP-SETTLED', JSON.stringify({
+      refunds: [{ status: 'succeeded' }, { status: 'failed' }],
+    }));
+    await insertOrder('U09-SHIP-PENDING', JSON.stringify({ refunds: [{ status: 'pending' }] }));
+    await insertOrder('U09-SHIP-ACTION', JSON.stringify({
+      refunds: [{ status: 'requires_action' }],
+    }));
+
+    const result = await env.DB.prepare(`
+SELECT id FROM orders
+WHERE id LIKE 'U09-SHIP-%'
+  AND ${SHIPMENT_NO_UNSETTLED_REFUNDS_SQL}
+ORDER BY id
+`).all<{ id: string }>();
+
+    expect(result.results.map(({ id }) => id)).toEqual([
+      'U09-SHIP-ABSENT',
+      'U09-SHIP-MALFORMED',
+      'U09-SHIP-SCALAR',
+      'U09-SHIP-SETTLED',
+      'U09-SHIP-SUBSTRING',
+    ]);
+  });
+});

--- a/tests/integration/lib/payments/refund-ledger.test.ts
+++ b/tests/integration/lib/payments/refund-ledger.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { env } from 'cloudflare:workers';
+import { drizzle } from 'drizzle-orm/d1';
+import * as schema from '@/lib/db/schema';
+import { decideRefundLedgerAction } from '@/lib/payments/refund-ledger';
+import { mutateRefundLedger, parseRefundExtensions } from '@/lib/payments/refund-ledger-store';
+import { applyTestMigrations } from '../../helpers/d1';
+
+const db = drizzle(env.DB, { schema });
+const orderId = 'U09-REFUND-CAS';
+const now = new Date('2026-08-05T22:00:00.000Z');
+
+async function insertOrder(extensions: Record<string, unknown> = {}): Promise<void> {
+  await env.DB.prepare(`
+INSERT INTO orders (
+  id, status, total_amount, currency_code, items, payment_status,
+  external_references, extensions, created_at, updated_at
+) VALUES (?, 'processing', ?, 'USD', '[]', 'paid', ?, ?, ?, ?)
+`).bind(
+    orderId,
+    JSON.stringify({ amount: 1_000, currency: 'USD' }),
+    JSON.stringify({ payment_intent_id: 'pi_refund' }),
+    JSON.stringify({ payment_intent_id: 'pi_refund', ...extensions }),
+    now.toISOString(),
+    now.toISOString()
+  ).run();
+}
+
+async function storedExtensions(): Promise<Record<string, unknown>> {
+  const row = await env.DB.prepare('SELECT extensions FROM orders WHERE id = ?')
+    .bind(orderId).first<{ extensions: string }>();
+  return parseRefundExtensions(row?.extensions) ?? {};
+}
+
+beforeEach(async () => {
+  await applyTestMigrations();
+  await env.DB.prepare('DELETE FROM orders WHERE id = ?').bind(orderId).run();
+});
+
+describe('refund ledger CAS in real D1', () => {
+  it('preserves two non-conflicting writes that race at the same timestamp', async () => {
+    await insertOrder({ refunds: [], refunds_version: 0 });
+    const append = (id: string) => mutateRefundLedger(db, orderId, (context) => ({
+      action: 'write',
+      extensions: {
+        ...context.extensions,
+        refunds: [...context.refunds, { id, amount: 100, status: 'succeeded' }],
+        refunds_version: context.nextVersion,
+      },
+    }), { now: () => now });
+
+    const results = await Promise.all([append('refund-a'), append('refund-b')]);
+    expect(results.every((result) => result.ok)).toBe(true);
+    const extensions = await storedExtensions();
+    expect(extensions.refunds_version).toBe(2);
+    expect((extensions.refunds as Array<{ id: string }>).map((entry) => entry.id).sort())
+      .toEqual(['refund-a', 'refund-b']);
+  });
+
+  it('allows only one concurrent reservation to consume limited balance', async () => {
+    await insertOrder({ refunds: [], refunds_version: 0 });
+    const reserve = (lineId: string) => mutateRefundLedger(db, orderId, async (context) => {
+      const decision = await decideRefundLedgerAction(context.refunds, {
+        orderId,
+        type: 'partial',
+        amount: 600,
+        lineIds: [lineId],
+        totalAmount: 1_000,
+      });
+      if (decision.action !== 'reserve') return { action: 'skip' as const };
+      return {
+        action: 'write' as const,
+        extensions: {
+          ...context.extensions,
+          refunds: [...context.refunds, {
+            id: decision.idempotencyKey,
+            idempotency_key: decision.idempotencyKey,
+            amount: decision.refundAmount,
+            status: 'pending',
+          }],
+          refunds_version: context.nextVersion,
+        },
+      };
+    }, { now: () => now });
+
+    await Promise.all([reserve('line-a'), reserve('line-b')]);
+    const extensions = await storedExtensions();
+    expect(extensions.refunds_version).toBe(1);
+    expect(extensions.refunds).toHaveLength(1);
+  });
+
+  it('fails closed on a corrupt monotonic version', async () => {
+    await insertOrder({ refunds: [], refunds_version: 'invalid' });
+    await expect(mutateRefundLedger(db, orderId, () => ({ action: 'skip' })))
+      .resolves.toEqual({ ok: false, reason: 'invalid_ledger' });
+  });
+});

--- a/tests/integration/lib/payments/refund-lifecycle.test.ts
+++ b/tests/integration/lib/payments/refund-lifecycle.test.ts
@@ -1,0 +1,211 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { env } from 'cloudflare:workers';
+import {
+  applyRefundLifecycleToOrder,
+  readExternalRestockEnabled,
+} from '@/app/api/webhooks/stripe/handlers/refund-handlers';
+import { drainInventoryAdjustments } from '@/lib/services/inventory-adjustments';
+import { applyTestMigrations } from '../../helpers/d1';
+
+const now = new Date('2026-08-06T20:00:00.000Z');
+const productId = 'u09-refund-lifecycle-product';
+const variantId = 'u09-refund-lifecycle-variant';
+const paymentIntentId = 'pi_u09_lifecycle';
+
+async function insertOrder(orderId: string, refunds: Array<Record<string, unknown>>): Promise<void> {
+  const items = [{
+    id: 'line-returned', product_id: productId, variant_id: variantId,
+    sku: 'U09-REFUND', quantity: 2,
+    unit_price: { amount: 500, currency: 'USD' },
+    total_price: { amount: 1_000, currency: 'USD' },
+    product_name: 'Refund lifecycle product',
+  }];
+  await env.DB.prepare(`
+INSERT INTO orders (
+  id, status, total_amount, currency_code, items, payment_status,
+  external_references, extensions, created_at, updated_at
+) VALUES (?, 'processing', ?, 'USD', ?, 'paid', ?, ?, ?, ?)
+`).bind(
+    orderId,
+    JSON.stringify({ amount: 1_000, currency: 'USD' }),
+    JSON.stringify(items),
+    JSON.stringify({ payment_intent_id: paymentIntentId }),
+    JSON.stringify({ payment_intent_id: paymentIntentId, refunds, refunds_version: 0 }),
+    now.toISOString(),
+    now.toISOString()
+  ).run();
+}
+
+async function inventoryQuantity(): Promise<number> {
+  const row = await env.DB.prepare(`
+SELECT json_extract(inventory, '$.quantity') AS quantity
+FROM product_variants WHERE id = ?
+`).bind(variantId).first<{ quantity: number }>();
+  return row!.quantity;
+}
+
+beforeEach(async () => {
+  await applyTestMigrations();
+  await env.DB.prepare(`
+UPDATE admin_settings SET value = 'false' WHERE key = 'refund.external_full_restock_enabled'
+`).run();
+  await env.DB.exec('DROP TRIGGER IF EXISTS u09_reject_refund_restock_insert');
+  await env.DB.prepare("DELETE FROM inventory_adjustments WHERE order_id LIKE 'U09-LIFECYCLE-%'").run();
+  await env.DB.prepare("DELETE FROM orders WHERE id LIKE 'U09-LIFECYCLE-%'").run();
+  await env.DB.prepare('DELETE FROM product_variants WHERE id = ?').bind(variantId).run();
+  await env.DB.prepare('DELETE FROM products WHERE id = ?').bind(productId).run();
+  await env.DB.prepare(`
+INSERT INTO products (id, name, status, created_at, updated_at)
+VALUES (?, 'Refund lifecycle product', 'active', ?, ?)
+`).bind(productId, now.toISOString(), now.toISOString()).run();
+  await env.DB.prepare(`
+INSERT INTO product_variants (
+  id, product_id, sku, option_values, price, status, inventory, created_at, updated_at
+) VALUES (?, ?, 'U09-REFUND', '[]', ?, 'active', ?, ?, ?)
+`).bind(
+    variantId,
+    productId,
+    JSON.stringify({ amount: 500, currency: 'USD' }),
+    JSON.stringify({ track_inventory: true, quantity: 0, allow_backorder: false }),
+    now.toISOString(),
+    now.toISOString()
+  ).run();
+});
+
+describe('refund lifecycle persistence in real D1', () => {
+  it('defaults external restock off and fails closed for malformed settings', async () => {
+    await expect(readExternalRestockEnabled(env.DB)).resolves.toBe(false);
+    await env.DB.prepare(`
+UPDATE admin_settings SET value = '"yes"' WHERE key = 'refund.external_full_restock_enabled'
+`).run();
+    await expect(readExternalRestockEnabled(env.DB)).rejects.toThrow('must be boolean');
+  });
+
+  it('rejects a provider currency that conflicts with the bound order', async () => {
+    const orderId = 'U09-LIFECYCLE-CURRENCY';
+    await insertOrder(orderId, [{
+      idempotency_key: 'request-currency', amount: 1_000, type: 'full',
+      items: [], status: 'pending',
+    }]);
+
+    await expect(applyRefundLifecycleToOrder({
+      database: env.DB,
+      paymentIntentId,
+      providerCurrency: 'EUR',
+      providerRefunds: [{
+        id: 're_currency', amount: 1_000, status: 'succeeded',
+        paymentIntentId, requestId: 'request-currency',
+      }],
+      chargeAmountRefunded: 1_000,
+      mode: 'charge',
+      externalRestockEnabled: false,
+      now: () => now,
+    })).rejects.toThrow('order currency');
+  });
+
+  it('settles and stages one line exactly once across distinct refund events', async () => {
+    const orderId = 'U09-LIFECYCLE-CONVERGE';
+    await insertOrder(orderId, [
+      {
+        idempotency_key: 'request-a', amount: 400, type: 'partial',
+        items: ['line-returned'], status: 'pending',
+      },
+      {
+        idempotency_key: 'request-b', amount: 600, type: 'partial',
+        items: ['line-returned'], status: 'pending',
+      },
+    ]);
+    const first = {
+      id: 're_a', amount: 400, status: 'succeeded',
+      paymentIntentId, requestId: 'request-a',
+    };
+    const second = {
+      id: 're_b', amount: 600, status: 'succeeded',
+      paymentIntentId, requestId: 'request-b',
+    };
+
+    await applyRefundLifecycleToOrder({
+      database: env.DB,
+      paymentIntentId,
+      providerCurrency: 'USD',
+      providerRefunds: [first],
+      chargeAmountRefunded: 400,
+      mode: 'charge',
+      externalRestockEnabled: false,
+      now: () => now,
+    });
+    await applyRefundLifecycleToOrder({
+      database: env.DB,
+      paymentIntentId,
+      providerCurrency: 'USD',
+      providerRefunds: [first, second],
+      chargeAmountRefunded: 1_000,
+      mode: 'charge',
+      externalRestockEnabled: false,
+      now: () => new Date(now.getTime() + 1_000),
+    });
+
+    const adjustment = await env.DB.prepare(`
+SELECT adjustment_key, status, quantity FROM inventory_adjustments WHERE order_id = ?
+`).bind(orderId).all<{ adjustment_key: string; status: string; quantity: number }>();
+    expect(adjustment.results).toEqual([{
+      adjustment_key: `restock:${orderId}:line-returned:v1`,
+      status: 'pending',
+      quantity: 2,
+    }]);
+    expect(await inventoryQuantity()).toBe(0);
+
+    const drained = await drainInventoryAdjustments({
+      database: env.DB, orderId, kind: 'refund_restock', now: () => now,
+    });
+    expect(drained).toMatchObject({ claimed: 1, succeeded: 1 });
+    expect(await inventoryQuantity()).toBe(2);
+    const order = await env.DB.prepare(
+      'SELECT status, payment_status FROM orders WHERE id = ?'
+    ).bind(orderId).first<{ status: string; payment_status: string }>();
+    expect(order).toEqual({ status: 'cancelled', payment_status: 'refunded' });
+  });
+
+  it('rolls back ledger settlement when its restock insert cannot commit', async () => {
+    const orderId = 'U09-LIFECYCLE-ATOMIC';
+    await insertOrder(orderId, [{
+      idempotency_key: 'request-atomic', amount: 1_000, type: 'full',
+      items: [], status: 'pending',
+    }]);
+    await env.DB.prepare(`
+CREATE TRIGGER u09_reject_refund_restock_insert
+BEFORE INSERT ON inventory_adjustments
+WHEN NEW.order_id = 'U09-LIFECYCLE-ATOMIC'
+BEGIN
+  SELECT RAISE(ABORT, 'restock insert rejected');
+END
+`).run();
+
+    await expect(applyRefundLifecycleToOrder({
+      database: env.DB,
+      paymentIntentId,
+      providerCurrency: 'USD',
+      providerRefunds: [{
+        id: 're_atomic', amount: 1_000, status: 'succeeded',
+        paymentIntentId, requestId: 'request-atomic',
+      }],
+      chargeAmountRefunded: 1_000,
+      mode: 'charge',
+      externalRestockEnabled: false,
+      now: () => now,
+    })).rejects.toThrow('restock insert rejected');
+
+    const order = await env.DB.prepare(
+      'SELECT payment_status, extensions FROM orders WHERE id = ?'
+    ).bind(orderId).first<{ payment_status: string; extensions: string }>();
+    expect(order?.payment_status).toBe('paid');
+    expect(JSON.parse(order!.extensions)).toMatchObject({
+      refunds_version: 0,
+      refunds: [{ status: 'pending' }],
+    });
+    const count = await env.DB.prepare(
+      'SELECT COUNT(*) AS count FROM inventory_adjustments WHERE order_id = ?'
+    ).bind(orderId).first<{ count: number }>();
+    expect(count?.count).toBe(0);
+  });
+});

--- a/tests/integration/lib/services/inventory-adjustments.test.ts
+++ b/tests/integration/lib/services/inventory-adjustments.test.ts
@@ -1,0 +1,424 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { env } from 'cloudflare:workers';
+import {
+  InventoryUnavailableError,
+  applyClaimedInventoryAdjustment,
+  assertCheckoutInventoryAvailable,
+  claimNextInventoryAdjustment,
+  drainInventoryAdjustments,
+  stageInventoryAdjustments,
+  stagePaidInventoryAdjustments,
+} from '@/lib/services/inventory-adjustments';
+import { drainOrderEffects, stagePaidOrderEffects } from '@/lib/services/order-effects';
+import type { Order, OrderItem } from '@/lib/types/order';
+import { Money } from '@/lib/money';
+import { applyTestMigrations } from '../../helpers/d1';
+
+const start = new Date('2026-08-05T20:00:00.000Z');
+const productId = 'u09-inventory-product';
+
+function line(variantId: string, quantity: number, id = `line-${variantId}`): OrderItem {
+  return {
+    id,
+    product_id: productId,
+    variant_id: variantId,
+    sku: `SKU-${variantId}`,
+    quantity,
+    unit_price: Money.fromMinor(1_000).toJSON(),
+    total_price: Money.fromMinor(1_000 * quantity).toJSON(),
+    product_name: 'Inventory test product',
+  };
+}
+
+function order(id: string, items: OrderItem[], paymentStatus: Order['payment_status'] = 'paid'): Order {
+  return {
+    id,
+    status: paymentStatus === 'paid' ? 'processing' : 'pending',
+    payment_status: paymentStatus,
+    total_amount: Money.fromMinor(1_000).toJSON(),
+    currency_code: 'USD',
+    items,
+    extensions: {},
+  };
+}
+
+async function insertOrder(value: Order): Promise<void> {
+  await env.DB.prepare(`
+INSERT INTO orders (id, status, total_amount, currency_code, items, payment_status,
+                    extensions, created_at, updated_at)
+VALUES (?, ?, ?, ?, ?, ?, '{}', ?, ?)
+`).bind(
+    value.id,
+    value.status,
+    JSON.stringify(value.total_amount),
+    value.currency_code,
+    JSON.stringify(value.items),
+    value.payment_status,
+    start.toISOString(),
+    start.toISOString()
+  ).run();
+}
+
+async function insertVariant(
+  id: string,
+  inventory: Record<string, unknown>,
+  status = 'active'
+): Promise<void> {
+  await env.DB.prepare(`
+INSERT INTO product_variants (
+  id, product_id, sku, option_values, price, status, inventory, created_at, updated_at
+) VALUES (?, ?, ?, '[]', ?, ?, ?, ?, ?)
+`).bind(
+    id,
+    productId,
+    `U09-${id}`,
+    JSON.stringify(Money.fromMinor(1_000).toJSON()),
+    status,
+    JSON.stringify(inventory),
+    start.toISOString(),
+    start.toISOString()
+  ).run();
+}
+
+async function quantity(variantId: string): Promise<number> {
+  const row = await env.DB.prepare(`
+SELECT json_extract(inventory, '$.quantity') AS quantity
+FROM product_variants WHERE id = ?
+`).bind(variantId).first<{ quantity: number }>();
+  return row!.quantity;
+}
+
+async function adjustmentStatuses(): Promise<Array<{ adjustment_key: string; status: string }>> {
+  const rows = await env.DB.prepare(`
+SELECT adjustment_key, status FROM inventory_adjustments ORDER BY adjustment_key
+`).all<{ adjustment_key: string; status: string }>();
+  return rows.results;
+}
+
+beforeEach(async () => {
+  await applyTestMigrations();
+  await env.DB.exec('DROP TRIGGER IF EXISTS u09_reject_inventory_terminal');
+  await env.DB.prepare("DELETE FROM inventory_adjustments WHERE order_id LIKE 'U09-%'").run();
+  await env.DB.prepare("DELETE FROM order_effects WHERE order_id LIKE 'U09-%'").run();
+  await env.DB.prepare("DELETE FROM orders WHERE id LIKE 'U09-%'").run();
+  await env.DB.prepare("DELETE FROM product_variants WHERE product_id = ?").bind(productId).run();
+  await env.DB.prepare(`
+INSERT INTO products (id, name, status, created_at, updated_at)
+VALUES (?, 'Inventory test product', 'active', ?, ?)
+ON CONFLICT(id) DO NOTHING
+`).bind(productId, start.toISOString(), start.toISOString()).run();
+});
+
+describe('authoritative checkout inventory in real D1', () => {
+  it('aggregates duplicate variant lines before the pre-charge stock check', async () => {
+    await insertVariant('u09-aggregate', {
+      track_inventory: true,
+      quantity: 2,
+      allow_backorder: false,
+    });
+    const items = [line('u09-aggregate', 1, 'line-a'), line('u09-aggregate', 2, 'line-b')];
+
+    await expect(assertCheckoutInventoryAvailable(items, { database: env.DB }))
+      .rejects.toEqual(expect.objectContaining<Partial<InventoryUnavailableError>>({
+        variantIds: ['u09-aggregate'],
+      }));
+
+    await env.DB.prepare(`
+UPDATE product_variants SET inventory = json_set(inventory, '$.quantity', 3) WHERE id = ?
+`).bind('u09-aggregate').run();
+    await expect(assertCheckoutInventoryAvailable(items, { database: env.DB }))
+      .resolves.toBeUndefined();
+  });
+
+  it('treats untracked and backorderable variants as fulfillable', async () => {
+    await insertVariant('u09-untracked', { track_inventory: false, quantity: 0 });
+    await insertVariant('u09-backorder', {
+      track_inventory: true,
+      quantity: 0,
+      allow_backorder: true,
+    });
+
+    await expect(assertCheckoutInventoryAvailable([
+      line('u09-untracked', 99),
+      line('u09-backorder', 4),
+    ], { database: env.DB })).resolves.toBeUndefined();
+  });
+});
+
+describe('durable inventory adjustments in real D1', () => {
+  it('keeps paid decrements dormant until the order is authoritatively paid', async () => {
+    const pending = order('U09-PENDING', [line('u09-pending', 1)], 'pending');
+    await insertOrder(pending);
+    await insertVariant('u09-pending', { track_inventory: true, quantity: 1 });
+    await stagePaidInventoryAdjustments(pending, { database: env.DB, now: start });
+    await stageInventoryAdjustments([{
+      adjustmentKey: 'restock:U09-PENDING:line-u09-pending:v1',
+      orderId: pending.id!,
+      lineId: 'line-u09-pending',
+      variantId: 'u09-pending',
+      kind: 'refund_restock',
+      quantity: 1,
+    }], { database: env.DB, now: start });
+
+    await expect(claimNextInventoryAdjustment(env.DB, {
+      orderId: pending.id,
+      claimToken: 'pending-owner',
+      now: start,
+    })).resolves.toBeNull();
+    await expect(claimNextInventoryAdjustment(env.DB, {
+      orderId: pending.id,
+      kind: 'refund_restock',
+      claimToken: 'pending-restock-owner',
+      now: start,
+    })).resolves.toBeNull();
+    expect(await quantity('u09-pending')).toBe(1);
+
+    await env.DB.prepare("UPDATE orders SET payment_status = 'paid' WHERE id = ?")
+      .bind(pending.id).run();
+    await expect(claimNextInventoryAdjustment(env.DB, {
+      orderId: pending.id,
+      claimToken: 'paid-owner',
+      now: start,
+    })).resolves.toMatchObject({ claim_token: 'paid-owner' });
+  });
+
+  it('aggregates duplicate paid lines into one exactly-once decrement', async () => {
+    const paid = order('U09-DUPLICATE', [
+      line('u09-duplicate', 1, 'line-a'),
+      line('u09-duplicate', 2, 'line-b'),
+    ]);
+    await insertOrder(paid);
+    await insertVariant('u09-duplicate', { track_inventory: true, quantity: 7 });
+
+    await stagePaidInventoryAdjustments(paid, { database: env.DB, now: start });
+    await stagePaidInventoryAdjustments(paid, { database: env.DB, now: start });
+    const staged = await env.DB.prepare(`
+SELECT COUNT(*) AS count, MAX(quantity) AS quantity FROM inventory_adjustments WHERE order_id = ?
+`).bind(paid.id).first<{ count: number; quantity: number }>();
+    expect(staged).toEqual({ count: 1, quantity: 3 });
+
+    const drained = await drainInventoryAdjustments({
+      database: env.DB,
+      orderId: paid.id,
+      now: () => start,
+    });
+    expect(drained).toMatchObject({ claimed: 1, succeeded: 1 });
+    expect(await quantity('u09-duplicate')).toBe(4);
+  });
+
+  it('lets only one of two paid orders consume the last tracked unit', async () => {
+    const first = order('U09-RACE-A', [line('u09-race', 1, 'line-a')]);
+    const second = order('U09-RACE-B', [line('u09-race', 1, 'line-b')]);
+    await insertOrder(first);
+    await insertOrder(second);
+    await insertVariant('u09-race', {
+      track_inventory: true,
+      quantity: 1,
+      allow_backorder: false,
+    });
+    await stagePaidInventoryAdjustments(first, { database: env.DB, now: start });
+    await stagePaidInventoryAdjustments(second, { database: env.DB, now: start });
+
+    await Promise.all([
+      drainInventoryAdjustments({ database: env.DB, orderId: first.id, now: () => start }),
+      drainInventoryAdjustments({ database: env.DB, orderId: second.id, now: () => start }),
+    ]);
+
+    expect(await quantity('u09-race')).toBe(0);
+    expect((await adjustmentStatuses()).map(({ status }) => status).sort())
+      .toEqual(['needs_review', 'succeeded']);
+  });
+
+  it('uses changes() to skip untracked stock and permits negative backorders', async () => {
+    const paid = order('U09-POLICY', [
+      line('u09-policy-untracked', 2),
+      line('u09-policy-backorder', 3),
+    ]);
+    await insertOrder(paid);
+    await insertVariant('u09-policy-untracked', { track_inventory: false, quantity: 8 });
+    await insertVariant('u09-policy-backorder', {
+      track_inventory: true,
+      quantity: 1,
+      allow_backorder: true,
+    });
+    await stagePaidInventoryAdjustments(paid, { database: env.DB, now: start });
+
+    const drained = await drainInventoryAdjustments({
+      database: env.DB,
+      orderId: paid.id,
+      now: () => start,
+    });
+    expect(drained).toMatchObject({ claimed: 2, succeeded: 1, skipped: 1 });
+    expect(await quantity('u09-policy-untracked')).toBe(8);
+    expect(await quantity('u09-policy-backorder')).toBe(-2);
+  });
+
+  it('terminals fractional tracked inventory for review without mutating it', async () => {
+    const paid = order('U09-FRACTIONAL', [line('u09-fractional', 1)]);
+    await insertOrder(paid);
+    await insertVariant('u09-fractional', { track_inventory: true, quantity: 1.5 });
+    await stagePaidInventoryAdjustments(paid, { database: env.DB, now: start });
+
+    const drained = await drainInventoryAdjustments({
+      database: env.DB,
+      orderId: paid.id,
+      now: () => start,
+    });
+
+    expect(drained).toMatchObject({ claimed: 1, needsReview: 1, failed: 0 });
+    expect(await quantity('u09-fractional')).toBe(1.5);
+  });
+
+  it('terminals a safe-integer overflow for review without restocking', async () => {
+    const paid = order('U09-OVERFLOW', [line('u09-overflow', 1)]);
+    await insertOrder(paid);
+    await insertVariant('u09-overflow', {
+      track_inventory: true,
+      quantity: Number.MAX_SAFE_INTEGER,
+    });
+    await stageInventoryAdjustments([{
+      adjustmentKey: 'restock:U09-OVERFLOW:line-u09-overflow:v1',
+      orderId: paid.id!,
+      lineId: 'line-u09-overflow',
+      variantId: 'u09-overflow',
+      kind: 'refund_restock',
+      quantity: 1,
+    }], { database: env.DB, now: start });
+
+    const drained = await drainInventoryAdjustments({
+      database: env.DB,
+      orderId: paid.id,
+      now: () => start,
+    });
+
+    expect(drained).toMatchObject({ claimed: 1, needsReview: 1, failed: 0 });
+    expect(await quantity('u09-overflow')).toBe(Number.MAX_SAFE_INTEGER);
+  });
+
+  it('terminals malformed inventory JSON for review instead of retrying forever', async () => {
+    const paid = order('U09-MALFORMED', [line('u09-malformed', 1)]);
+    await insertOrder(paid);
+    await insertVariant('u09-malformed', { track_inventory: true, quantity: 2 });
+    await env.DB.prepare('UPDATE product_variants SET inventory = ? WHERE id = ?')
+      .bind('{malformed', 'u09-malformed').run();
+    await stagePaidInventoryAdjustments(paid, { database: env.DB, now: start });
+
+    const drained = await drainInventoryAdjustments({
+      database: env.DB,
+      orderId: paid.id,
+      now: () => start,
+    });
+
+    expect(drained).toMatchObject({ claimed: 1, needsReview: 1, failed: 0 });
+    const variant = await env.DB.prepare('SELECT inventory FROM product_variants WHERE id = ?')
+      .bind('u09-malformed').first<{ inventory: string }>();
+    expect(variant?.inventory).toBe('{malformed');
+  });
+
+  it('rejects a stale owner after takeover before its mutation batch', async () => {
+    const paid = order('U09-TAKEOVER', [line('u09-takeover', 1)]);
+    await insertOrder(paid);
+    await insertVariant('u09-takeover', { track_inventory: true, quantity: 2 });
+    await stagePaidInventoryAdjustments(paid, { database: env.DB, now: start });
+    const stale = await claimNextInventoryAdjustment(env.DB, {
+      orderId: paid.id,
+      claimToken: 'owner-stale',
+      leaseDurationMs: 1_000,
+      now: start,
+    });
+    const current = await claimNextInventoryAdjustment(env.DB, {
+      orderId: paid.id,
+      claimToken: 'owner-current',
+      leaseDurationMs: 1_000,
+      now: new Date(start.getTime() + 1_001),
+    });
+
+    await expect(applyClaimedInventoryAdjustment(env.DB, stale!, start)).resolves.toBeNull();
+    expect(await quantity('u09-takeover')).toBe(2);
+    await expect(applyClaimedInventoryAdjustment(env.DB, current!, start)).resolves.toBe('succeeded');
+    expect(await quantity('u09-takeover')).toBe(1);
+  });
+
+  it('rolls back the variant mutation if the terminal marker fails', async () => {
+    const paid = order('U09-ROLLBACK', [line('u09-rollback', 1)]);
+    await insertOrder(paid);
+    await insertVariant('u09-rollback', { track_inventory: true, quantity: 2 });
+    await stagePaidInventoryAdjustments(paid, { database: env.DB, now: start });
+    const claimed = await claimNextInventoryAdjustment(env.DB, {
+      orderId: paid.id,
+      claimToken: 'owner-rollback',
+      now: start,
+    });
+    await env.DB.prepare(`
+CREATE TRIGGER u09_reject_inventory_terminal
+BEFORE UPDATE OF status ON inventory_adjustments
+WHEN OLD.adjustment_key = 'paid:U09-ROLLBACK:inventory:u09-rollback:v1'
+  AND NEW.status IN ('succeeded', 'skipped', 'needs_review')
+BEGIN
+  SELECT RAISE(ABORT, 'terminal marker rejected');
+END
+`).run();
+
+    await expect(applyClaimedInventoryAdjustment(env.DB, claimed!, start)).rejects.toThrow();
+    expect(await quantity('u09-rollback')).toBe(2);
+    await expect(env.DB.prepare(`
+SELECT status, claim_token FROM inventory_adjustments WHERE adjustment_key = ?
+`).bind(claimed!.adjustment_key).first()).resolves.toEqual({
+      status: 'processing',
+      claim_token: 'owner-rollback',
+    });
+  });
+
+  it('restocks a sold line once across distinct refund-event convergence calls', async () => {
+    const paid = order('U09-RESTOCK', [line('u09-restock', 2, 'sold-line-1')]);
+    await insertOrder(paid);
+    await insertVariant('u09-restock', { track_inventory: true, quantity: 0 });
+    const restock = {
+      adjustmentKey: 'restock:U09-RESTOCK:sold-line-1:v1',
+      orderId: paid.id!,
+      lineId: 'sold-line-1',
+      variantId: 'u09-restock',
+      kind: 'refund_restock' as const,
+      quantity: 2,
+    };
+
+    await stageInventoryAdjustments([restock], { database: env.DB, now: start });
+    await stageInventoryAdjustments([restock], {
+      database: env.DB,
+      now: new Date(start.getTime() + 1_000),
+    });
+    await drainInventoryAdjustments({ database: env.DB, orderId: paid.id, now: () => start });
+    await drainInventoryAdjustments({ database: env.DB, orderId: paid.id, now: () => start });
+
+    expect(await quantity('u09-restock')).toBe(2);
+    expect(await adjustmentStatuses()).toEqual([
+      { adjustment_key: restock.adjustmentKey, status: 'succeeded' },
+    ]);
+  });
+
+  it('runs the default inventory recipient only through a paid order effect', async () => {
+    const pending = order('U09-EFFECT', [line('u09-effect', 1)], 'pending');
+    await insertOrder(pending);
+    await insertVariant('u09-effect', { track_inventory: true, quantity: 2 });
+    await stagePaidOrderEffects(pending, { database: env.DB, now: start, includeEmail: false });
+    await env.DB.prepare("DELETE FROM order_effects WHERE effect_type <> 'inventory'").run();
+
+    await expect(drainOrderEffects({
+      database: env.DB,
+      orderId: pending.id,
+      now: () => start,
+    })).resolves.toEqual({ claimed: 0, succeeded: 0, failed: 0 });
+    expect(await quantity('u09-effect')).toBe(2);
+
+    await env.DB.prepare("UPDATE orders SET payment_status = 'paid' WHERE id = ?")
+      .bind(pending.id).run();
+    const paid = { ...pending, status: 'processing' as const, payment_status: 'paid' as const };
+    await expect(drainOrderEffects({
+      database: env.DB,
+      orderId: paid.id,
+      getOrder: async () => paid,
+      now: () => start,
+    })).resolves.toEqual({ claimed: 1, succeeded: 1, failed: 0 });
+    expect(await quantity('u09-effect')).toBe(1);
+  });
+});

--- a/tests/integration/lib/services/order-effects.test.ts
+++ b/tests/integration/lib/services/order-effects.test.ts
@@ -1,0 +1,305 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { env } from 'cloudflare:workers';
+import {
+  claimNextOrderEffect,
+  completeOrderEffect,
+  drainOrderEffects,
+  failOrderEffect,
+  stagePaidOrderEffects,
+  type ClaimedOrderEffect,
+} from '@/lib/services/order-effects';
+import type { Order } from '@/lib/types/order';
+import { Money } from '@/lib/money';
+import { applyTestMigrations } from '../../helpers/d1';
+
+const start = new Date('2026-08-05T18:00:00.000Z');
+
+function order(paymentStatus: Order['payment_status'] = 'pending'): Order {
+  return {
+    id: 'WEB-RECOVERY-1',
+    customer_id: 'customer-1',
+    status: paymentStatus === 'paid' ? 'processing' : 'pending',
+    payment_status: paymentStatus,
+    total_amount: Money.fromMinor(2_500).toJSON(),
+    currency_code: 'USD',
+    shipping_address: {
+      line1: '1 Main St', city: 'Denver', region: 'CO', postal_code: '80202',
+      country: 'US', recipient: 'Customer', email: 'customer@example.com',
+    },
+    items: [{
+      id: 'line-1', product_id: 'product-1', variant_id: 'variant-1', sku: 'SKU-1',
+      quantity: 1, unit_price: Money.fromMinor(2_000).toJSON(),
+      total_price: Money.fromMinor(2_000).toJSON(), product_name: 'Product',
+    }],
+    extensions: {
+      email: 'customer@example.com',
+      discount_codes: [' save ', 'ALPHA', 'SAVE'],
+      checkout_discount: Money.fromMinor(100).toJSON(),
+      checkout_catalog_subtotal: Money.fromMinor(2_000).toJSON(),
+      checkout_shipping: Money.fromMinor(300).toJSON(),
+      checkout_tax: Money.fromMinor(200).toJSON(),
+      checkout_tender: Money.zero('USD').toJSON(),
+      checkout_tender_state: { reservation: 'tender-1' },
+    },
+  };
+}
+
+async function insertOrder(value: Order = order()): Promise<void> {
+  await env.DB.prepare(`
+INSERT INTO orders (
+  id, customer_id, status, total_amount, currency_code, shipping_address,
+  items, payment_status, extensions, created_at, updated_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+`).bind(
+    value.id,
+    null,
+    value.status,
+    JSON.stringify(value.total_amount),
+    value.currency_code,
+    JSON.stringify(value.shipping_address),
+    JSON.stringify(value.items),
+    value.payment_status,
+    JSON.stringify(value.extensions ?? {}),
+    start.toISOString(),
+    start.toISOString()
+  ).run();
+}
+
+async function keepOnly(effectType: string): Promise<void> {
+  await env.DB.prepare('DELETE FROM order_effects WHERE effect_type <> ?').bind(effectType).run();
+}
+
+beforeEach(async () => {
+  await applyTestMigrations();
+  await env.DB.exec('DROP TRIGGER IF EXISTS reject_subscription_effect');
+  await env.DB.prepare('DELETE FROM order_effects WHERE order_id = ?')
+    .bind('WEB-RECOVERY-1').run();
+  await env.DB.prepare('DELETE FROM orders WHERE id = ?').bind('WEB-RECOVERY-1').run();
+});
+
+describe('durable paid-order effects in real D1', () => {
+  it('stages the complete deterministic set atomically and idempotently', async () => {
+    const pending = order();
+    await insertOrder(pending);
+
+    await stagePaidOrderEffects(pending, { database: env.DB, now: start });
+    await stagePaidOrderEffects(pending, { database: env.DB, now: start });
+    const rows = await env.DB.prepare(`
+SELECT effect_key, effect_type, status, attempt_count
+FROM order_effects ORDER BY effect_key
+`).all<{
+      effect_key: string;
+      effect_type: string;
+      status: string;
+      attempt_count: number;
+    }>();
+
+    expect(rows.results).toEqual([
+      { effect_key: 'paid:WEB-RECOVERY-1:confirmation-email:v1', effect_type: 'confirmation_email', status: 'pending', attempt_count: 0 },
+      { effect_key: 'paid:WEB-RECOVERY-1:coupon:ALPHA:v1', effect_type: 'coupon', status: 'pending', attempt_count: 0 },
+      { effect_key: 'paid:WEB-RECOVERY-1:coupon:SAVE:v1', effect_type: 'coupon', status: 'pending', attempt_count: 0 },
+      { effect_key: 'paid:WEB-RECOVERY-1:gift-card:v1', effect_type: 'gift_card', status: 'pending', attempt_count: 0 },
+      { effect_key: 'paid:WEB-RECOVERY-1:inventory:v1', effect_type: 'inventory', status: 'pending', attempt_count: 0 },
+      { effect_key: 'paid:WEB-RECOVERY-1:subscription:v1', effect_type: 'subscription', status: 'pending', attempt_count: 0 },
+    ]);
+
+    await env.DB.prepare(`
+CREATE TRIGGER reject_subscription_effect
+BEFORE INSERT ON order_effects
+WHEN NEW.effect_type = 'subscription'
+BEGIN
+  SELECT RAISE(ABORT, 'subscription staging failed');
+END
+`).run();
+    await env.DB.exec('DELETE FROM order_effects');
+    await expect(stagePaidOrderEffects(pending, {
+      database: env.DB,
+      now: new Date(start.getTime() + 1_000),
+    })).rejects.toThrow();
+    const count = await env.DB.prepare('SELECT COUNT(*) AS count FROM order_effects')
+      .first<{ count: number }>();
+    expect(count?.count).toBe(0);
+  });
+
+  it('keeps pre-CAS rows dormant and claims them only after authoritative paid state', async () => {
+    const pending = order();
+    await insertOrder(pending);
+    await stagePaidOrderEffects(pending, { database: env.DB, now: start });
+
+    await expect(claimNextOrderEffect(env.DB, {
+      orderId: pending.id,
+      now: start,
+      claimToken: 'owner-pending',
+    })).resolves.toBeNull();
+
+    await env.DB.prepare("UPDATE orders SET payment_status = 'paid' WHERE id = ?")
+      .bind(pending.id).run();
+    await expect(claimNextOrderEffect(env.DB, {
+      orderId: pending.id,
+      now: start,
+      claimToken: 'owner-paid',
+    })).resolves.toMatchObject({ claim_token: 'owner-paid', attempt_count: 1 });
+  });
+
+  it('serializes concurrent claims and rejects a stale owner after lease takeover', async () => {
+    const paid = order('paid');
+    await insertOrder(paid);
+    await stagePaidOrderEffects(paid, { database: env.DB, now: start, includeEmail: false });
+    await keepOnly('inventory');
+
+    const concurrent = await Promise.all([
+      claimNextOrderEffect(env.DB, { now: start, claimToken: 'owner-a', leaseDurationMs: 1_000 }),
+      claimNextOrderEffect(env.DB, { now: start, claimToken: 'owner-b', leaseDurationMs: 1_000 }),
+    ]);
+    expect(concurrent.filter(Boolean)).toHaveLength(1);
+    const stale = concurrent.find(Boolean)!;
+    const current = await claimNextOrderEffect(env.DB, {
+      now: new Date(start.getTime() + 1_001),
+      claimToken: 'owner-current',
+      leaseDurationMs: 1_000,
+    });
+    expect(current).toMatchObject({ claim_token: 'owner-current', attempt_count: 2 });
+
+    await expect(completeOrderEffect(env.DB, stale, { late: true }, new Date(start.getTime() + 1_002)))
+      .resolves.toBe(false);
+    await expect(failOrderEffect(env.DB, stale, new Error('late'), new Date(start.getTime() + 1_002)))
+      .resolves.toBe(false);
+    await expect(completeOrderEffect(env.DB, current!, { applied: true }, new Date(start.getTime() + 1_003)))
+      .resolves.toBe(true);
+    const row = await env.DB.prepare(`
+SELECT status, attempt_count, claim_token, result FROM order_effects
+`).first<{ status: string; attempt_count: number; claim_token: string | null; result: string }>();
+    expect(row).toEqual({
+      status: 'succeeded',
+      attempt_count: 2,
+      claim_token: null,
+      result: JSON.stringify({ applied: true }),
+    });
+  });
+
+  it('uses five-minute exponential retry and caps long-lived attempts at six hours', async () => {
+    const paid = order('paid');
+    await insertOrder(paid);
+    await stagePaidOrderEffects(paid, { database: env.DB, now: start, includeEmail: false });
+    await keepOnly('inventory');
+    const first = await claimNextOrderEffect(env.DB, {
+      now: start,
+      claimToken: 'owner-first',
+    });
+    expect(first).not.toBeNull();
+    await failOrderEffect(env.DB, first!, new Error('temporary'), start);
+    const retryRow = await env.DB.prepare(`
+SELECT status, next_attempt_at, last_error FROM order_effects
+`).first<{ status: string; next_attempt_at: string; last_error: string }>();
+    expect(retryRow).toEqual({
+      status: 'failed',
+      next_attempt_at: new Date(start.getTime() + 5 * 60 * 1_000).toISOString(),
+      last_error: 'temporary',
+    });
+    await expect(claimNextOrderEffect(env.DB, {
+      now: new Date(start.getTime() + 5 * 60 * 1_000 - 1),
+      claimToken: 'too-early',
+    })).resolves.toBeNull();
+
+    await env.DB.prepare(`
+UPDATE order_effects
+SET status = 'processing', attempt_count = 99, claim_token = 'owner-old',
+    lease_expires_at = ?, next_attempt_at = NULL
+`).bind(new Date(start.getTime() + 60_000).toISOString()).run();
+    const old: ClaimedOrderEffect = {
+      ...first!,
+      attempt_count: 99,
+      claim_token: 'owner-old',
+    };
+    await failOrderEffect(env.DB, old, new Error('still failing'), start);
+    const capped = await env.DB.prepare('SELECT next_attempt_at FROM order_effects')
+      .first<{ next_attempt_at: string }>();
+    expect(capped?.next_attempt_at).toBe(
+      new Date(start.getTime() + 6 * 60 * 60 * 1_000).toISOString()
+    );
+  });
+
+  it('recovers stage→paid→skipped-inline work and invokes every idempotent recipient', async () => {
+    const pending = order();
+    const paid = order('paid');
+    await insertOrder(pending);
+    await stagePaidOrderEffects(pending, { database: env.DB, now: start });
+    await env.DB.prepare("UPDATE orders SET payment_status = 'paid', status = 'processing' WHERE id = ?")
+      .bind(pending.id).run();
+
+    const runInventory = vi.fn(async (_order: Order, effect: ClaimedOrderEffect) => ({
+      adjustment: effect.effect_key,
+    }));
+    const redeem = vi.fn(async () => ({ redeemed: true, alreadyRedeemed: false }));
+    const applyTender = vi.fn(async () => undefined);
+    const orderPaid = vi.fn(async () => undefined);
+    const sendConfirmation = vi.fn(async () => ({ success: true, id: 'email-1' }));
+    const result = await drainOrderEffects({
+      database: env.DB,
+      getOrder: vi.fn(async () => paid),
+      runInventory,
+      redeem,
+      capabilities: {
+        giftCards: {
+          resolveTender: vi.fn(),
+          verifyReservedTender: vi.fn(),
+          applyTender,
+        },
+        subscriptions: { validateCheckout: vi.fn(), orderPaid },
+      },
+      sendConfirmation,
+      now: () => new Date(start.getTime() + 1_000),
+      limit: 25,
+    });
+
+    expect(result).toEqual({ claimed: 6, succeeded: 6, failed: 0 });
+    expect(runInventory).toHaveBeenCalledOnce();
+    expect(redeem).toHaveBeenCalledTimes(2);
+    expect(applyTender).toHaveBeenCalledOnce();
+    expect(orderPaid).toHaveBeenCalledOnce();
+    expect(sendConfirmation).toHaveBeenCalledWith(
+      paid,
+      'order-confirmation/WEB-RECOVERY-1/v1'
+    );
+    const statuses = await env.DB.prepare('SELECT DISTINCT status FROM order_effects')
+      .all<{ status: string }>();
+    expect(statuses.results).toEqual([{ status: 'succeeded' }]);
+  });
+
+  it('records coupon reconciliation and keeps inventory/email failures durably retryable', async () => {
+    const paid = order('paid');
+    paid.extensions!.discount_codes = ['SAVE'];
+    await insertOrder(paid);
+    await stagePaidOrderEffects(paid, { database: env.DB, now: start });
+    await env.DB.prepare(
+      "DELETE FROM order_effects WHERE effect_type NOT IN ('coupon','inventory','confirmation_email')"
+    ).run();
+    const reconcile = vi.fn(async () => undefined);
+    const result = await drainOrderEffects({
+      database: env.DB,
+      getOrder: vi.fn(async () => paid),
+      redeem: vi.fn(async () => ({ redeemed: false, alreadyRedeemed: false })),
+      recordCouponReconciliation: reconcile,
+      sendConfirmation: vi.fn(async () => ({ success: false, error: 'provider unavailable' })),
+      now: () => start,
+      limit: 10,
+    });
+
+    expect(result).toEqual({ claimed: 3, succeeded: 1, failed: 2 });
+    expect(reconcile).toHaveBeenCalledWith({ orderId: paid.id, code: 'SAVE' });
+    const rows = await env.DB.prepare(`
+SELECT effect_type, status, next_attempt_at, last_error
+FROM order_effects ORDER BY effect_type
+`).all<{
+      effect_type: string;
+      status: string;
+      next_attempt_at: string | null;
+      last_error: string | null;
+    }>();
+    expect(rows.results).toEqual([
+      { effect_type: 'confirmation_email', status: 'failed', next_attempt_at: new Date(start.getTime() + 300_000).toISOString(), last_error: 'provider unavailable' },
+      { effect_type: 'coupon', status: 'succeeded', next_attempt_at: null, last_error: null },
+      { effect_type: 'inventory', status: 'failed', next_attempt_at: new Date(start.getTime() + 300_000).toISOString(), last_error: 'Inventory effect handler is not configured' },
+    ]);
+  });
+});

--- a/tests/integration/lib/services/order-effects.test.ts
+++ b/tests/integration/lib/services/order-effects.test.ts
@@ -266,7 +266,7 @@ SET status = 'processing', attempt_count = 99, claim_token = 'owner-old',
     expect(statuses.results).toEqual([{ status: 'succeeded' }]);
   });
 
-  it('records coupon reconciliation and keeps inventory/email failures durably retryable', async () => {
+  it('records coupon reconciliation, queues email retry, and terminals missing inventory for review', async () => {
     const paid = order('paid');
     paid.extensions!.discount_codes = ['SAVE'];
     await insertOrder(paid);
@@ -285,7 +285,7 @@ SET status = 'processing', attempt_count = 99, claim_token = 'owner-old',
       limit: 10,
     });
 
-    expect(result).toEqual({ claimed: 3, succeeded: 1, failed: 2 });
+    expect(result).toEqual({ claimed: 3, succeeded: 2, failed: 1 });
     expect(reconcile).toHaveBeenCalledWith({ orderId: paid.id, code: 'SAVE' });
     const rows = await env.DB.prepare(`
 SELECT effect_type, status, next_attempt_at, last_error
@@ -299,7 +299,15 @@ FROM order_effects ORDER BY effect_type
     expect(rows.results).toEqual([
       { effect_type: 'confirmation_email', status: 'failed', next_attempt_at: new Date(start.getTime() + 300_000).toISOString(), last_error: 'provider unavailable' },
       { effect_type: 'coupon', status: 'succeeded', next_attempt_at: null, last_error: null },
-      { effect_type: 'inventory', status: 'failed', next_attempt_at: new Date(start.getTime() + 300_000).toISOString(), last_error: 'Inventory effect handler is not configured' },
+      { effect_type: 'inventory', status: 'succeeded', next_attempt_at: null, last_error: null },
     ]);
+    const adjustment = await env.DB.prepare(`
+SELECT status, result FROM inventory_adjustments WHERE order_id = ?
+`).bind(paid.id).first<{ status: string; result: string }>();
+    expect(adjustment).toMatchObject({ status: 'needs_review' });
+    expect(JSON.parse(adjustment!.result)).toMatchObject({
+      outcome: 'needs_review',
+      variantId: 'variant-1',
+    });
   });
 });

--- a/tests/integration/lib/webhooks/processed-events.test.ts
+++ b/tests/integration/lib/webhooks/processed-events.test.ts
@@ -1,0 +1,173 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { env } from 'cloudflare:workers';
+import {
+  claimWebhookEvent,
+  completeWebhookEvent,
+  createProcessedEventsExecutor,
+  failWebhookEvent,
+} from '@/lib/webhooks/processed-events';
+import { applyTestMigrations } from '../../helpers/d1';
+
+const start = new Date('2026-08-05T18:00:00.000Z');
+
+beforeEach(async () => {
+  await applyTestMigrations();
+});
+
+describe('durable webhook claims in real D1', () => {
+  it('grants one owner under concurrent same-event delivery', async () => {
+    const executor = createProcessedEventsExecutor(env.DB);
+
+    const claims = await Promise.all([
+      claimWebhookEvent({
+        eventId: 'evt_race',
+        eventType: 'payment_intent.succeeded',
+        claimToken: 'owner_a',
+        now: start,
+      }, executor),
+      claimWebhookEvent({
+        eventId: 'evt_race',
+        eventType: 'payment_intent.succeeded',
+        claimToken: 'owner_b',
+        now: start,
+      }, executor),
+    ]);
+    const row = await env.DB.prepare(`
+      SELECT status, attempt_count, claim_token
+      FROM processed_webhook_events
+      WHERE event_id = ?
+    `).bind('evt_race').first<{
+      status: string;
+      attempt_count: number;
+      claim_token: string;
+    }>();
+
+    expect(claims.map(({ state }) => state).sort()).toEqual(['acquired', 'busy']);
+    expect(row).toMatchObject({ status: 'processing', attempt_count: 1 });
+    expect(['owner_a', 'owner_b']).toContain(row?.claim_token);
+  });
+
+  it('retries an owned failure without deleting its audit row', async () => {
+    const executor = createProcessedEventsExecutor(env.DB);
+    const first = await claimWebhookEvent({
+      eventId: 'evt_retry',
+      eventType: 'payment_intent.succeeded',
+      claimToken: 'owner_first',
+      now: start,
+    }, executor);
+    expect(first.state).toBe('acquired');
+    if (first.state !== 'acquired') throw new Error('Expected first claim ownership');
+
+    await expect(failWebhookEvent({
+      eventId: 'evt_retry',
+      claimToken: first.claimToken,
+      error: new Error('D1 downstream failed'),
+      now: start,
+    }, executor)).resolves.toBe(true);
+
+    const retry = await claimWebhookEvent({
+      eventId: 'evt_retry',
+      eventType: 'payment_intent.succeeded',
+      claimToken: 'owner_retry',
+      now: new Date(start.getTime() + 1_000),
+    }, executor);
+    expect(retry).toMatchObject({
+      state: 'acquired',
+      claimToken: 'owner_retry',
+      attemptCount: 2,
+    });
+
+    const rows = await env.DB.prepare(
+      'SELECT COUNT(*) AS count FROM processed_webhook_events WHERE event_id = ?'
+    ).bind('evt_retry').first<{ count: number }>();
+    expect(rows?.count).toBe(1);
+  });
+
+  it('allows stale takeover and rejects the stale owner token', async () => {
+    const executor = createProcessedEventsExecutor(env.DB);
+    const stale = await claimWebhookEvent({
+      eventId: 'evt_stale',
+      eventType: 'payment_intent.succeeded',
+      claimToken: 'owner_stale',
+      leaseDurationMs: 1_000,
+      now: start,
+    }, executor);
+    expect(stale.state).toBe('acquired');
+
+    const current = await claimWebhookEvent({
+      eventId: 'evt_stale',
+      eventType: 'payment_intent.succeeded',
+      claimToken: 'owner_current',
+      leaseDurationMs: 1_000,
+      now: new Date(start.getTime() + 1_001),
+    }, executor);
+    expect(current).toMatchObject({
+      state: 'acquired',
+      claimToken: 'owner_current',
+      attemptCount: 2,
+    });
+
+    await expect(completeWebhookEvent({
+      eventId: 'evt_stale',
+      claimToken: 'owner_stale',
+      outcome: 'handled',
+      now: new Date(start.getTime() + 1_002),
+    }, executor)).resolves.toBe(false);
+    await expect(failWebhookEvent({
+      eventId: 'evt_stale',
+      claimToken: 'owner_stale',
+      error: new Error('late failure'),
+      now: new Date(start.getTime() + 1_002),
+    }, executor)).resolves.toBe(false);
+    await expect(completeWebhookEvent({
+      eventId: 'evt_stale',
+      claimToken: 'owner_current',
+      outcome: 'handled',
+      now: new Date(start.getTime() + 1_003),
+    }, executor)).resolves.toBe(true);
+  });
+
+  it('keeps completed events terminal across later deliveries', async () => {
+    const executor = createProcessedEventsExecutor(env.DB);
+    const claim = await claimWebhookEvent({
+      eventId: 'evt_done',
+      eventType: 'payment_intent.succeeded',
+      claimToken: 'owner_done',
+      now: start,
+    }, executor);
+    if (claim.state !== 'acquired') throw new Error('Expected claim ownership');
+
+    await expect(completeWebhookEvent({
+      eventId: 'evt_done',
+      claimToken: claim.claimToken,
+      outcome: 'permanent_rejection',
+      now: start,
+    }, executor)).resolves.toBe(true);
+    await expect(claimWebhookEvent({
+      eventId: 'evt_done',
+      eventType: 'payment_intent.succeeded',
+      claimToken: 'owner_late',
+      now: new Date(start.getTime() + 86_400_000),
+    }, executor)).resolves.toEqual({
+      state: 'completed',
+      outcome: 'permanent_rejection',
+    });
+
+    const row = await env.DB.prepare(`
+      SELECT status, attempt_count, claim_token, outcome
+      FROM processed_webhook_events
+      WHERE event_id = ?
+    `).bind('evt_done').first<{
+      status: string;
+      attempt_count: number;
+      claim_token: string | null;
+      outcome: string;
+    }>();
+    expect(row).toEqual({
+      status: 'completed',
+      attempt_count: 1,
+      claim_token: null,
+      outcome: 'permanent_rejection',
+    });
+  });
+});

--- a/tests/unit/app/api/orders-refund-ledger.test.ts
+++ b/tests/unit/app/api/orders-refund-ledger.test.ts
@@ -1,0 +1,264 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mocks = vi.hoisted(() => ({
+  refundsCreate: vi.fn(),
+  refundsRetrieve: vi.fn(),
+  writes: [] as Array<Record<string, unknown>>,
+  order: {} as Record<string, any>,
+}));
+
+vi.mock('@/lib/auth/unified-auth', () => ({
+  PERMISSIONS: { ORDERS_UPDATE: 'orders:update' },
+  authenticateRequest: vi.fn(async () => ({ success: true, tokenInfo: { tokenName: 'test' } })),
+}));
+vi.mock('@/lib/db', () => ({ getDbAsync: vi.fn(async () => ({})) }));
+vi.mock('@/lib/stripe', () => ({
+  getStripeClient: () => ({
+    refunds: { create: mocks.refundsCreate, retrieve: mocks.refundsRetrieve },
+  }),
+}));
+vi.mock('@/lib/payments/refund-ledger-store', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/payments/refund-ledger-store')>();
+  return {
+    ...actual,
+    mutateRefundLedger: vi.fn(async (_db, _orderId, mutate) => {
+      const extensions = mocks.order.extensions;
+      const refunds = Array.isArray(extensions.refunds) ? extensions.refunds : [];
+      const version = extensions.refunds_version ?? 0;
+      const decision = await mutate({
+        order: mocks.order,
+        extensions,
+        refunds,
+        version,
+        nextVersion: version + 1,
+        nowIso: '2026-08-05T22:00:00.000Z',
+      });
+      if (decision.action === 'write') {
+        mocks.order = {
+          ...mocks.order,
+          ...(decision.columns ?? {}),
+          extensions: decision.extensions,
+          updated_at: '2026-08-05T22:00:00.000Z',
+        };
+        mocks.writes.push(decision.extensions);
+        return { ok: true, skipped: false, order: mocks.order };
+      }
+      return { ok: true, skipped: true, order: mocks.order };
+    }),
+  };
+});
+
+import { POST } from '@/app/api/orders/refund/route';
+import {
+  deriveRefundIdempotencyKey,
+  deriveRefundRequestFingerprint,
+} from '@/lib/payments/refund-idempotency';
+
+function request(overrides: Record<string, unknown> = {}) {
+  return new NextRequest('http://localhost/api/orders/refund', {
+    method: 'POST',
+    body: JSON.stringify({
+      orderId: 'WEB-REFUND-1',
+      type: 'partial',
+      reason: 'Customer return',
+      amount: 400,
+      items: ['line-1'],
+      notes: '',
+      ...overrides,
+    }),
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+beforeEach(() => {
+  mocks.writes.length = 0;
+  mocks.order = {
+    id: 'WEB-REFUND-1',
+    status: 'processing',
+    payment_status: 'paid',
+    total_amount: { amount: 1_000, currency: 'USD' },
+    currency_code: 'USD',
+    items: [{ id: 'line-1', product_id: 'product-1', variant_id: 'variant-1' }],
+    external_references: { payment_intent_id: 'pi_refund' },
+    extensions: { payment_intent_id: 'pi_refund', refunds: [], refunds_version: 0 },
+    updated_at: '2026-08-05T21:00:00.000Z',
+  };
+  mocks.refundsCreate.mockResolvedValue({
+    id: 're_1', amount: 400, status: 'succeeded', payment_intent: 'pi_refund',
+  });
+  mocks.refundsRetrieve.mockResolvedValue({
+    id: 're_1', amount: 400, status: 'succeeded', payment_intent: 'pi_refund',
+  });
+});
+
+describe('refund route durable ordering', () => {
+  it('persists pending before Stripe and forwards the key as SDK options', async () => {
+    mocks.refundsCreate.mockImplementation(async (_params, options) => {
+      expect(mocks.writes).toHaveLength(1);
+      expect((mocks.writes[0].refunds as Array<{ status: string }>)[0].status).toBe('pending');
+      expect(options.idempotencyKey).toMatch(/^refund:[a-f0-9]{64}$/);
+      return {
+        id: 're_1', amount: 400, status: 'succeeded', payment_intent: 'pi_refund',
+      };
+    });
+
+    const response = await POST(request());
+    expect(response.status).toBe(200);
+    expect(mocks.refundsCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ payment_intent: 'pi_refund', amount: 400 }),
+      { idempotencyKey: expect.stringMatching(/^refund:[a-f0-9]{64}$/) }
+    );
+    expect((mocks.order.extensions.refunds as Array<{ status: string }>)[0].status)
+      .toBe('succeeded');
+  });
+
+  it('keeps an ambiguous transport failure pending for exact-key retry', async () => {
+    mocks.refundsCreate.mockRejectedValue(new Error('connection reset'));
+    const response = await POST(request());
+    expect(response.status).toBe(503);
+    expect((mocks.order.extensions.refunds as Array<{ status: string }>)[0].status)
+      .toBe('pending');
+    expect(mocks.writes).toHaveLength(1);
+  });
+
+  it('returns a settled response retry without calling Stripe twice', async () => {
+    const first = await POST(request());
+    const retry = await POST(request());
+    expect(first.status).toBe(200);
+    expect(retry.status).toBe(200);
+    expect(await retry.json()).toMatchObject({ success: true, duplicate: true });
+    expect(mocks.refundsCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns a completed full-refund retry after payment status becomes refunded', async () => {
+    mocks.refundsCreate.mockResolvedValue({
+      id: 're_full', amount: 1_000, status: 'succeeded', payment_intent: 'pi_refund',
+    });
+    const fullRequest = request({ type: 'full', amount: undefined, items: [] });
+    const first = await POST(fullRequest);
+    const retry = await POST(request({ type: 'full', amount: undefined, items: [] }));
+    expect(first.status).toBe(200);
+    expect(retry.status).toBe(200);
+    expect(mocks.order.payment_status).toBe('refunded');
+    expect(mocks.refundsCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns 202 and retains reserved balance for delayed provider status', async () => {
+    mocks.refundsCreate.mockResolvedValue({
+      id: 're_pending', amount: 400, status: 'pending', payment_intent: 'pi_refund',
+    });
+    const response = await POST(request());
+    expect(response.status).toBe(202);
+    expect((mocks.order.extensions.refunds as Array<{ status: string }>)[0].status)
+      .toBe('pending');
+  });
+
+  it('retrieves a known delayed refund on retry and preserves requires_action', async () => {
+    mocks.refundsCreate.mockResolvedValue({
+      id: 're_action', amount: 400, status: 'requires_action', payment_intent: 'pi_refund',
+    });
+    const first = await POST(request());
+    expect(first.status).toBe(202);
+    expect(await first.json()).toMatchObject({
+      refund: { status: 'requires_action', providerStatus: 'requires_action' },
+    });
+
+    mocks.refundsRetrieve.mockResolvedValue({
+      id: 're_action', amount: 400, status: 'succeeded', payment_intent: 'pi_refund',
+    });
+    const retry = await POST(request());
+    expect(retry.status).toBe(200);
+    expect(mocks.refundsCreate).toHaveBeenCalledTimes(1);
+    expect(mocks.refundsRetrieve).toHaveBeenCalledWith('re_action');
+  });
+
+  it('blocks an old unresolved create reservation for manual reconciliation', async () => {
+    const idempotencyKey = await deriveRefundIdempotencyKey({
+      orderId: 'WEB-REFUND-1', type: 'partial', refundAmount: 400,
+      settledSequence: 0, lineIds: ['line-1'],
+    });
+    const requestFingerprint = await deriveRefundRequestFingerprint({
+      orderId: 'WEB-REFUND-1', type: 'partial', refundAmount: 400,
+      lineIds: ['line-1'],
+    });
+    mocks.order.extensions.refunds = [{
+      id: idempotencyKey,
+      idempotency_key: idempotencyKey,
+      request_fingerprint: requestFingerprint,
+      settled_sequence: 0,
+      amount: 400,
+      type: 'partial',
+      items: ['line-1'],
+      status: 'pending',
+      requested_at: '2020-01-01T00:00:00.000Z',
+    }];
+    const response = await POST(request());
+    expect(response.status).toBe(409);
+    expect(mocks.refundsCreate).not.toHaveBeenCalled();
+    expect(mocks.refundsRetrieve).not.toHaveBeenCalled();
+  });
+
+  it('releases an explicit failed result and rejects unknown line ids before Stripe', async () => {
+    mocks.refundsCreate.mockResolvedValue({
+      id: 're_failed', amount: 400, status: 'failed', payment_intent: 'pi_refund',
+    });
+    const failed = await POST(request());
+    expect(failed.status).toBe(502);
+    expect((mocks.order.extensions.refunds as Array<{ status: string }>)[0].status)
+      .toBe('failed');
+
+    mocks.order.extensions = { payment_intent_id: 'pi_refund', refunds: [], refunds_version: 0 };
+    mocks.refundsCreate.mockClear();
+    const invalid = await POST(request({ items: ['unknown-line'] }));
+    expect(invalid.status).toBe(400);
+    expect(mocks.refundsCreate).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['amount', { id: 're_wrong', amount: 399, status: 'succeeded', payment_intent: 'pi_refund' }],
+    ['PaymentIntent', { id: 're_wrong', amount: 400, status: 'succeeded', payment_intent: 'pi_other' }],
+  ])('keeps the reservation pending when Stripe returns the wrong %s', async (_field, result) => {
+    mocks.refundsCreate.mockResolvedValue(result);
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(502);
+    expect(await response.json()).toMatchObject({
+      error: 'Payment provider returned an inconsistent refund',
+    });
+    expect((mocks.order.extensions.refunds as Array<{ status: string }>)[0].status)
+      .toBe('pending');
+    expect(mocks.writes).toHaveLength(1);
+  });
+
+  it('keeps a known reservation pending when Stripe retrieves a different refund id', async () => {
+    mocks.refundsCreate.mockResolvedValue({
+      id: 're_expected', amount: 400, status: 'requires_action', payment_intent: 'pi_refund',
+    });
+    expect((await POST(request())).status).toBe(202);
+    mocks.refundsRetrieve.mockResolvedValue({
+      id: 're_other', amount: 400, status: 'succeeded', payment_intent: 'pi_refund',
+    });
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(502);
+    expect(mocks.refundsRetrieve).toHaveBeenCalledWith('re_expected');
+    expect((mocks.order.extensions.refunds as Array<{ status: string }>)[0].status)
+      .toBe('requires_action');
+  });
+
+  it('rejects a malformed persisted Stripe refund floor before calling Stripe', async () => {
+    mocks.order.extensions.stripe_amount_refunded = '100';
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toMatchObject({
+      error: 'Recorded Stripe refund total is invalid',
+    });
+    expect(mocks.refundsCreate).not.toHaveBeenCalled();
+    expect(mocks.refundsRetrieve).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/app/api/payment-intent-authority.test.ts
+++ b/tests/unit/app/api/payment-intent-authority.test.ts
@@ -44,6 +44,7 @@ import { POST } from '@/app/api/payment-intent/route';
 const quote = {
   currency: 'USD',
   items: [{
+    id: 'line_stable_1',
     product_id: 'prod_1', variant_id: 'var_1', sku: 'SKU-1', quantity: 1,
     unit_price: { amount: 2_000, currency: 'USD' },
     total_price: { amount: 2_000, currency: 'USD' }, product_name: 'Catalog name',
@@ -54,6 +55,14 @@ const quote = {
   discount: { amount: 100, currency: 'USD' },
   shipping: { amount: 500, currency: 'USD' },
   tax: { amount: 200, currency: 'USD' },
+  shippingTax: { amount: 20, currency: 'USD' },
+  lineAllocations: [{
+    lineId: 'line_stable_1', productId: 'prod_1', variantId: 'var_1', quantity: 1,
+    catalogSubtotal: { amount: 2_000, currency: 'USD' },
+    merchandiseDiscount: { amount: 100, currency: 'USD' },
+    netMerchandise: { amount: 1_900, currency: 'USD' },
+    tax: { amount: 180, currency: 'USD' }, promotionCodes: ['SAVE'],
+  }],
   tender: { amount: 0, currency: 'USD' },
   total: { amount: 2_600, currency: 'USD' },
   discountCodes: ['SAVE'],
@@ -106,6 +115,10 @@ describe('payment-intent durable authority boundary', () => {
       status: 'pending',
       total_amount: { amount: 2_600, currency: 'USD' },
       items: quote.items,
+      extensions: expect.objectContaining({
+        checkout_line_allocations: quote.lineAllocations,
+        checkout_shipping_tax: quote.shippingTax,
+      }),
       shipping_address: expect.objectContaining({
         company: 'Buyer LLC',
         email: 'buyer@example.com',

--- a/tests/unit/app/api/payment-intent-authority.test.ts
+++ b/tests/unit/app/api/payment-intent-authority.test.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   createPaymentIntent: vi.fn(),
   cancelPaymentIntent: vi.fn(),
   priceCheckout: vi.fn(),
+  assertCheckoutInventoryAvailable: vi.fn(),
 }));
 
 vi.mock('@clerk/nextjs/server', () => ({
@@ -28,6 +29,17 @@ vi.mock('@/lib/stripe', () => ({
   createPaymentIntent: mocks.createPaymentIntent,
   cancelPaymentIntent: mocks.cancelPaymentIntent,
 }));
+vi.mock('@/lib/services/inventory-adjustments', () => {
+  class InventoryUnavailableError extends Error {
+    constructor(public readonly variantIds: string[]) {
+      super('inventory unavailable');
+    }
+  }
+  return {
+    InventoryUnavailableError,
+    assertCheckoutInventoryAvailable: mocks.assertCheckoutInventoryAvailable,
+  };
+});
 vi.mock('@/lib/db', () => ({
   getDbAsync: vi.fn(async () => ({
     insert: () => ({
@@ -94,6 +106,7 @@ beforeEach(() => {
   mocks.insertFails = false;
   mocks.cancelPaymentIntent.mockResolvedValue(undefined);
   mocks.priceCheckout.mockResolvedValue(quote);
+  mocks.assertCheckoutInventoryAvailable.mockResolvedValue(undefined);
   mocks.createPaymentIntent.mockResolvedValue({
     id: 'pi_authoritative',
     client_secret: 'pi_authoritative_secret_x',
@@ -148,6 +161,20 @@ describe('payment-intent durable authority boundary', () => {
     expect(response.status).toBe(503);
     expect(mocks.cancelPaymentIntent).toHaveBeenCalledWith('pi_authoritative');
     expect(await response.json()).not.toHaveProperty('clientSecret');
+  });
+
+  it('returns 409 before creating a PaymentIntent when aggregate stock is unavailable', async () => {
+    const { InventoryUnavailableError } = await import('@/lib/services/inventory-adjustments');
+    mocks.assertCheckoutInventoryAvailable.mockRejectedValue(
+      new InventoryUnavailableError(['var_1'])
+    );
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(409);
+    expect(mocks.assertCheckoutInventoryAvailable).toHaveBeenCalledWith(quote.items);
+    expect(mocks.createPaymentIntent).not.toHaveBeenCalled();
+    expect(mocks.insertValues).not.toHaveBeenCalled();
   });
 
   it('rejects a syntactically invalid optional checkout email', async () => {

--- a/tests/unit/app/api/stripe-webhook-refunds.test.ts
+++ b/tests/unit/app/api/stripe-webhook-refunds.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mocks = vi.hoisted(() => ({
+  constructWebhookEvent: vi.fn(),
+  claimWebhookEvent: vi.fn(),
+  completeWebhookEvent: vi.fn(),
+  failWebhookEvent: vi.fn(),
+  handleChargeRefunded: vi.fn(),
+  handleRefundLifecycle: vi.fn(),
+}));
+
+vi.mock('@/lib/stripe', () => ({ constructWebhookEvent: mocks.constructWebhookEvent }));
+vi.mock('@/lib/services/order-finalization', () => ({
+  PaymentVerificationError: class PaymentVerificationError extends Error {},
+  finalizeOrderPayment: vi.fn(),
+}));
+vi.mock('@/lib/webhooks/processed-events', () => ({
+  claimWebhookEvent: mocks.claimWebhookEvent,
+  completeWebhookEvent: mocks.completeWebhookEvent,
+  failWebhookEvent: mocks.failWebhookEvent,
+}));
+vi.mock('@/app/api/webhooks/stripe/handlers/refund-handlers', () => ({
+  handleChargeRefunded: mocks.handleChargeRefunded,
+  handleRefundLifecycle: mocks.handleRefundLifecycle,
+}));
+
+import { POST } from '@/app/api/webhooks/stripe/route';
+
+function request() {
+  return new NextRequest('https://example.test/api/webhooks/stripe', {
+    method: 'POST', headers: { 'stripe-signature': 'signed' }, body: '{}',
+  });
+}
+
+beforeEach(() => {
+  mocks.claimWebhookEvent.mockResolvedValue({ state: 'acquired', claimToken: 'claim-refund' });
+  mocks.completeWebhookEvent.mockResolvedValue(true);
+  mocks.failWebhookEvent.mockResolvedValue(true);
+  mocks.handleChargeRefunded.mockResolvedValue('handled');
+  mocks.handleRefundLifecycle.mockResolvedValue('handled');
+});
+
+describe('Stripe refund webhook dispatch', () => {
+  it('dispatches charge.refunded to authoritative charge reconciliation', async () => {
+    const charge = { id: 'ch_1' };
+    mocks.constructWebhookEvent.mockResolvedValue({
+      id: 'evt_charge_refunded', type: 'charge.refunded', data: { object: charge },
+    });
+
+    expect((await POST(request())).status).toBe(200);
+    expect(mocks.handleChargeRefunded).toHaveBeenCalledWith(charge);
+    expect(mocks.completeWebhookEvent).toHaveBeenCalledWith({
+      eventId: 'evt_charge_refunded', claimToken: 'claim-refund', outcome: 'handled',
+    });
+  });
+
+  it.each(['refund.updated', 'refund.failed', 'charge.refund.updated'])(
+    'dispatches %s to lifecycle reconciliation',
+    async (type) => {
+      const refund = { id: `re_${type}` };
+      mocks.constructWebhookEvent.mockResolvedValue({
+        id: `evt_${type}`, type, data: { object: refund },
+      });
+
+      expect((await POST(request())).status).toBe(200);
+      expect(mocks.handleRefundLifecycle).toHaveBeenCalledWith(refund);
+    }
+  );
+
+  it('leaves the durable webhook claim retryable when refund reconciliation fails', async () => {
+    mocks.constructWebhookEvent.mockResolvedValue({
+      id: 'evt_refund_retry', type: 'refund.updated', data: { object: { id: 're_retry' } },
+    });
+    mocks.handleRefundLifecycle.mockRejectedValue(new Error('D1 unavailable'));
+
+    expect((await POST(request())).status).toBe(500);
+    expect(mocks.failWebhookEvent).toHaveBeenCalledWith({
+      eventId: 'evt_refund_retry',
+      claimToken: 'claim-refund',
+      error: expect.objectContaining({ message: 'D1 unavailable' }),
+    });
+    expect(mocks.completeWebhookEvent).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/app/api/stripe-webhook-retry.test.ts
+++ b/tests/unit/app/api/stripe-webhook-retry.test.ts
@@ -4,6 +4,9 @@ import { NextRequest } from 'next/server';
 const mocks = vi.hoisted(() => ({
   constructWebhookEvent: vi.fn(),
   finalizeOrderPayment: vi.fn(),
+  claimWebhookEvent: vi.fn(),
+  completeWebhookEvent: vi.fn(),
+  failWebhookEvent: vi.fn(),
 }));
 
 vi.mock('@/lib/stripe', () => ({
@@ -18,6 +21,12 @@ vi.mock('@/lib/services/order-finalization', () => {
   };
 });
 
+vi.mock('@/lib/webhooks/processed-events', () => ({
+  claimWebhookEvent: mocks.claimWebhookEvent,
+  completeWebhookEvent: mocks.completeWebhookEvent,
+  failWebhookEvent: mocks.failWebhookEvent,
+}));
+
 import { POST } from '@/app/api/webhooks/stripe/route';
 import { PaymentVerificationError } from '@/lib/services/order-finalization';
 
@@ -31,9 +40,13 @@ function webhookRequest() {
 
 beforeEach(() => {
   mocks.constructWebhookEvent.mockResolvedValue({
+    id: 'evt_payment',
     type: 'payment_intent.succeeded',
     data: { object: { id: 'pi_1', metadata: { orderId: 'WEB-1' } } },
   });
+  mocks.claimWebhookEvent.mockResolvedValue({ state: 'acquired', claimToken: 'claim_1' });
+  mocks.completeWebhookEvent.mockResolvedValue(true);
+  mocks.failWebhookEvent.mockResolvedValue(true);
 });
 
 describe('Stripe webhook retry behavior', () => {
@@ -43,6 +56,12 @@ describe('Stripe webhook retry behavior', () => {
     const response = await POST(webhookRequest());
 
     expect(response.status).toBe(500);
+    expect(mocks.failWebhookEvent).toHaveBeenCalledWith({
+      eventId: 'evt_payment',
+      claimToken: 'claim_1',
+      error: expect.objectContaining({ message: 'D1 unavailable' }),
+    });
+    expect(mocks.completeWebhookEvent).not.toHaveBeenCalled();
   });
 
   it('acknowledges permanent payment verification rejection', async () => {
@@ -53,5 +72,72 @@ describe('Stripe webhook retry behavior', () => {
     const response = await POST(webhookRequest());
 
     expect(response.status).toBe(200);
+    expect(mocks.completeWebhookEvent).toHaveBeenCalledWith({
+      eventId: 'evt_payment',
+      claimToken: 'claim_1',
+      outcome: 'permanent_rejection',
+    });
+    expect(mocks.failWebhookEvent).not.toHaveBeenCalled();
+  });
+
+  it('records a signed payment event without an order binding as permanently rejected', async () => {
+    mocks.constructWebhookEvent.mockResolvedValue({
+      id: 'evt_unbound',
+      type: 'payment_intent.succeeded',
+      data: { object: { id: 'pi_unbound', metadata: {} } },
+    });
+
+    const response = await POST(webhookRequest());
+
+    expect(response.status).toBe(200);
+    expect(mocks.finalizeOrderPayment).not.toHaveBeenCalled();
+    expect(mocks.completeWebhookEvent).toHaveBeenCalledWith({
+      eventId: 'evt_unbound',
+      claimToken: 'claim_1',
+      outcome: 'permanent_rejection',
+    });
+  });
+
+  it('acknowledges only terminal completed duplicates', async () => {
+    mocks.claimWebhookEvent.mockResolvedValue({
+      state: 'completed',
+      outcome: 'handled',
+    });
+
+    const response = await POST(webhookRequest());
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ received: true, duplicate: true });
+    expect(mocks.finalizeOrderPayment).not.toHaveBeenCalled();
+    expect(mocks.completeWebhookEvent).not.toHaveBeenCalled();
+  });
+
+  it('returns retryable 503 for an active owner', async () => {
+    mocks.claimWebhookEvent.mockResolvedValue({ state: 'busy' });
+
+    const response = await POST(webhookRequest());
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get('retry-after')).toBe('5');
+    expect(mocks.finalizeOrderPayment).not.toHaveBeenCalled();
+  });
+
+  it('returns retryable 503 when ownership is lost before completion', async () => {
+    mocks.completeWebhookEvent.mockResolvedValue(false);
+
+    const response = await POST(webhookRequest());
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get('retry-after')).toBe('5');
+    expect(mocks.failWebhookEvent).not.toHaveBeenCalled();
+  });
+
+  it('returns 500 without dispatch when the durable claim fails', async () => {
+    mocks.claimWebhookEvent.mockRejectedValue(new Error('D1 claim unavailable'));
+
+    const response = await POST(webhookRequest());
+
+    expect(response.status).toBe(500);
+    expect(mocks.finalizeOrderPayment).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/app/api/stripe-webhook-retry.test.ts
+++ b/tests/unit/app/api/stripe-webhook-retry.test.ts
@@ -2,13 +2,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { NextRequest } from 'next/server';
 
 const mocks = vi.hoisted(() => ({
-  constructEvent: vi.fn(),
+  constructWebhookEvent: vi.fn(),
   finalizeOrderPayment: vi.fn(),
 }));
 
 vi.mock('@/lib/stripe', () => ({
-  getStripe: () => ({ webhooks: { constructEvent: mocks.constructEvent } }),
-  getWebhookSecret: () => 'whsec_test',
+  constructWebhookEvent: mocks.constructWebhookEvent,
 }));
 
 vi.mock('@/lib/services/order-finalization', () => {
@@ -31,7 +30,7 @@ function webhookRequest() {
 }
 
 beforeEach(() => {
-  mocks.constructEvent.mockReturnValue({
+  mocks.constructWebhookEvent.mockResolvedValue({
     type: 'payment_intent.succeeded',
     data: { object: { id: 'pi_1', metadata: { orderId: 'WEB-1' } } },
   });

--- a/tests/unit/app/api/stripe-webhook-signature.test.ts
+++ b/tests/unit/app/api/stripe-webhook-signature.test.ts
@@ -4,6 +4,9 @@ import { NextRequest } from 'next/server';
 const mocks = vi.hoisted(() => ({
   constructWebhookEvent: vi.fn(),
   finalizeOrderPayment: vi.fn(),
+  claimWebhookEvent: vi.fn(),
+  completeWebhookEvent: vi.fn(),
+  failWebhookEvent: vi.fn(),
 }));
 
 vi.mock('@/lib/stripe', () => ({
@@ -13,6 +16,12 @@ vi.mock('@/lib/stripe', () => ({
 vi.mock('@/lib/services/order-finalization', () => ({
   PaymentVerificationError: class PaymentVerificationError extends Error {},
   finalizeOrderPayment: mocks.finalizeOrderPayment,
+}));
+
+vi.mock('@/lib/webhooks/processed-events', () => ({
+  claimWebhookEvent: mocks.claimWebhookEvent,
+  completeWebhookEvent: mocks.completeWebhookEvent,
+  failWebhookEvent: mocks.failWebhookEvent,
 }));
 
 import { POST } from '@/app/api/webhooks/stripe/route';
@@ -31,6 +40,9 @@ beforeEach(() => {
     type: 'unhandled.test',
     data: { object: {} },
   });
+  mocks.claimWebhookEvent.mockResolvedValue({ state: 'acquired', claimToken: 'claim_1' });
+  mocks.completeWebhookEvent.mockResolvedValue(true);
+  mocks.failWebhookEvent.mockResolvedValue(true);
 });
 
 describe('Stripe webhook signature verification', () => {
@@ -39,6 +51,7 @@ describe('Stripe webhook signature verification', () => {
 
     expect(response.status).toBe(400);
     expect(mocks.constructWebhookEvent).not.toHaveBeenCalled();
+    expect(mocks.claimWebhookEvent).not.toHaveBeenCalled();
   });
 
   it('passes the exact raw body and signature to async verification', async () => {
@@ -47,6 +60,15 @@ describe('Stripe webhook signature verification', () => {
 
     expect(response.status).toBe(200);
     expect(mocks.constructWebhookEvent).toHaveBeenCalledWith(rawBody, 't=1,v1=signed');
+    expect(mocks.claimWebhookEvent).toHaveBeenCalledWith({
+      eventId: 'evt_valid',
+      eventType: 'unhandled.test',
+    });
+    expect(mocks.completeWebhookEvent).toHaveBeenCalledWith({
+      eventId: 'evt_valid',
+      claimToken: 'claim_1',
+      outcome: 'ignored',
+    });
   });
 
   it('rejects verification failures without dispatching', async () => {
@@ -56,5 +78,6 @@ describe('Stripe webhook signature verification', () => {
 
     expect(response.status).toBe(400);
     expect(mocks.finalizeOrderPayment).not.toHaveBeenCalled();
+    expect(mocks.claimWebhookEvent).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/app/api/stripe-webhook-signature.test.ts
+++ b/tests/unit/app/api/stripe-webhook-signature.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mocks = vi.hoisted(() => ({
+  constructWebhookEvent: vi.fn(),
+  finalizeOrderPayment: vi.fn(),
+}));
+
+vi.mock('@/lib/stripe', () => ({
+  constructWebhookEvent: mocks.constructWebhookEvent,
+}));
+
+vi.mock('@/lib/services/order-finalization', () => ({
+  PaymentVerificationError: class PaymentVerificationError extends Error {},
+  finalizeOrderPayment: mocks.finalizeOrderPayment,
+}));
+
+import { POST } from '@/app/api/webhooks/stripe/route';
+
+function request(body: string, signature?: string) {
+  return new NextRequest('https://example.test/api/webhooks/stripe', {
+    method: 'POST',
+    headers: signature ? { 'stripe-signature': signature } : undefined,
+    body,
+  });
+}
+
+beforeEach(() => {
+  mocks.constructWebhookEvent.mockResolvedValue({
+    id: 'evt_valid',
+    type: 'unhandled.test',
+    data: { object: {} },
+  });
+});
+
+describe('Stripe webhook signature verification', () => {
+  it('rejects a missing signature before verification', async () => {
+    const response = await POST(request('{}'));
+
+    expect(response.status).toBe(400);
+    expect(mocks.constructWebhookEvent).not.toHaveBeenCalled();
+  });
+
+  it('passes the exact raw body and signature to async verification', async () => {
+    const rawBody = '{ "spacing": "must survive" }';
+    const response = await POST(request(rawBody, 't=1,v1=signed'));
+
+    expect(response.status).toBe(200);
+    expect(mocks.constructWebhookEvent).toHaveBeenCalledWith(rawBody, 't=1,v1=signed');
+  });
+
+  it('rejects verification failures without dispatching', async () => {
+    mocks.constructWebhookEvent.mockRejectedValue(new Error('bad signature'));
+
+    const response = await POST(request('{}', 'invalid'));
+
+    expect(response.status).toBe(400);
+    expect(mocks.finalizeOrderPayment).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/lib/admin/order-return-calculation.test.ts
+++ b/tests/unit/lib/admin/order-return-calculation.test.ts
@@ -9,8 +9,8 @@ const policy = {
 };
 
 const items = [
-  { product_id: 'p1', variant_id: 'v1', quantity: 1, unit_price: { amount: 10, currency: 'USD' } },
-  { product_id: 'p2', variant_id: 'v2', quantity: 1, unit_price: 10 },
+  { id: 'line-1', product_id: 'p1', variant_id: 'v1', quantity: 1, unit_price: { amount: 10, currency: 'USD' } },
+  { id: 'line-2', product_id: 'p2', variant_id: 'v2', quantity: 1, unit_price: 10 },
 ];
 
 describe('admin partial-return calculation', () => {
@@ -25,9 +25,16 @@ describe('admin partial-return calculation', () => {
         checkout_shipping_before_discount: { amount: 500, currency: 'USD' },
         checkout_shipping_discount: { amount: 100, currency: 'USD' },
       },
-    }, ['p1-v1'], policy);
+    }, ['line-1'], policy);
 
-    expect(result).toMatchObject({ subtotal: 1_000, tax: 90, discount: 100, shipping: 0, total: 990 });
+    expect(result).toMatchObject({
+      subtotal: 1_000,
+      tax: 90,
+      discount: 100,
+      shipping: 0,
+      total: 990,
+      allocationMethod: 'legacy_proportional',
+    });
   });
 
   it('keeps documented legacy cents and decimal-major shipping fallbacks', () => {
@@ -35,8 +42,104 @@ describe('admin partial-return calculation', () => {
       currency_code: 'USD',
       items,
       extensions: { subtotal: 2_000, tax_amount: 180, discount_amount: 200, shipping_cost: 5 },
-    }, ['p1-v1', 'p2-v2'], policy);
+    }, ['line-1', 'line-2'], policy);
 
-    expect(result).toMatchObject({ subtotal: 2_000, tax: 180, discount: 200, shipping: 500, total: 2_480 });
+    expect(result).toMatchObject({
+      subtotal: 2_000,
+      tax: 180,
+      discount: 200,
+      shipping: 500,
+      total: 2_480,
+      allocationMethod: 'legacy_full_order',
+    });
+  });
+
+  it('sums exact targeted discount and provider tax snapshots by stable line id', () => {
+    const result = calculatePartialReturnMinor({
+      currency_code: 'USD',
+      items,
+      extensions: {
+        checkout_catalog_subtotal: { amount: 2_000, currency: 'USD' },
+        checkout_merchandise_discount: { amount: 500, currency: 'USD' },
+        checkout_tax: { amount: 165, currency: 'USD' },
+        checkout_shipping_tax: { amount: 15, currency: 'USD' },
+        checkout_shipping_before_discount: { amount: 500, currency: 'USD' },
+        checkout_shipping_discount: { amount: 0, currency: 'USD' },
+        checkout_line_allocations: [
+          {
+            lineId: 'line-1', productId: 'p1', variantId: 'v1', quantity: 1,
+            catalogSubtotal: { amount: 1_000, currency: 'USD' },
+            merchandiseDiscount: { amount: 500, currency: 'USD' },
+            netMerchandise: { amount: 500, currency: 'USD' },
+            tax: { amount: 50, currency: 'USD' }, promotionCodes: ['TARGET'],
+          },
+          {
+            lineId: 'line-2', productId: 'p2', variantId: 'v2', quantity: 1,
+            catalogSubtotal: { amount: 1_000, currency: 'USD' },
+            merchandiseDiscount: { amount: 0, currency: 'USD' },
+            netMerchandise: { amount: 1_000, currency: 'USD' },
+            tax: { amount: 100, currency: 'USD' }, promotionCodes: [],
+          },
+        ],
+      },
+    }, ['line-1'], policy);
+
+    expect(result).toMatchObject({
+      subtotal: 1_000,
+      tax: 50,
+      discount: 500,
+      shipping: 0,
+      total: 550,
+      allocationMethod: 'exact_snapshot',
+    });
+  });
+
+  it('includes separately allocated shipping tax only when shipping is refunded', () => {
+    const exactOrder = {
+      currency_code: 'USD',
+      items,
+      extensions: {
+        checkout_catalog_subtotal: { amount: 2_000, currency: 'USD' },
+        checkout_merchandise_discount: { amount: 0, currency: 'USD' },
+        checkout_tax: { amount: 215, currency: 'USD' },
+        checkout_shipping_tax: { amount: 15, currency: 'USD' },
+        checkout_shipping_before_discount: { amount: 500, currency: 'USD' },
+        checkout_shipping_discount: { amount: 0, currency: 'USD' },
+        checkout_line_allocations: items.map((item) => ({
+          lineId: item.id,
+          productId: item.product_id,
+          variantId: item.variant_id,
+          quantity: item.quantity,
+          catalogSubtotal: { amount: 1_000, currency: 'USD' },
+          merchandiseDiscount: { amount: 0, currency: 'USD' },
+          netMerchandise: { amount: 1_000, currency: 'USD' },
+          tax: { amount: 100, currency: 'USD' },
+          promotionCodes: [],
+        })),
+      },
+    };
+
+    expect(calculatePartialReturnMinor(exactOrder, ['line-1', 'line-2'], policy))
+      .toMatchObject({ tax: 215, shipping: 500, total: 2_715 });
+  });
+
+  it('rejects a present but internally inconsistent exact snapshot', () => {
+    expect(() => calculatePartialReturnMinor({
+      currency_code: 'USD',
+      items: [items[0]],
+      extensions: {
+        checkout_catalog_subtotal: { amount: 1_000, currency: 'USD' },
+        checkout_merchandise_discount: { amount: 500, currency: 'USD' },
+        checkout_tax: { amount: 50, currency: 'USD' },
+        checkout_shipping_tax: { amount: 0, currency: 'USD' },
+        checkout_line_allocations: [{
+          lineId: 'line-1', productId: 'p1', variantId: 'v1', quantity: 1,
+          catalogSubtotal: { amount: 1_000, currency: 'USD' },
+          merchandiseDiscount: { amount: 500, currency: 'USD' },
+          netMerchandise: { amount: 501, currency: 'USD' },
+          tax: { amount: 50, currency: 'USD' }, promotionCodes: [],
+        }],
+      },
+    }, ['line-1'], policy)).toThrow('corrupt');
   });
 });

--- a/tests/unit/lib/payments/refund-email.test.ts
+++ b/tests/unit/lib/payments/refund-email.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({ send: vi.fn() }));
+
+vi.mock('@/lib/utils/email', () => ({
+  getResendClient: () => ({ emails: { send: mocks.send } }),
+}));
+vi.mock('@/lib/store-config', () => ({
+  getStoreConfig: () => ({
+    identity: { name: 'Test Store' },
+    contact: { senderEmail: 'Test Store <orders@example.com>', supportEmail: 'help@example.com' },
+  }),
+}));
+
+import { sendRefundSettledEmail } from '@/lib/payments/refund-email';
+
+beforeEach(() => {
+  mocks.send.mockResolvedValue({ data: { id: 'email_1' }, error: null });
+});
+
+describe('refund settlement email', () => {
+  it('uses generic store identity and a refund-stable provider key', async () => {
+    await expect(sendRefundSettledEmail({
+      orderId: 'WEB-1', refundId: 're_1', amount: 425, currencyCode: 'USD',
+      customerEmail: 'customer@example.com', customerName: '<Customer>',
+    })).resolves.toEqual({ success: true, id: 'email_1' });
+
+    expect(mocks.send).toHaveBeenCalledWith(expect.objectContaining({
+      from: 'Test Store <orders@example.com>',
+      to: ['customer@example.com'],
+      subject: 'Refund processed for order #WEB-1 - Test Store',
+      html: expect.stringContaining('&lt;Customer&gt;'),
+    }), { idempotencyKey: 'refund/re_1/succeeded/v1' });
+  });
+
+  it('is a no-op when the order has no customer email', async () => {
+    await expect(sendRefundSettledEmail({
+      orderId: 'WEB-1', refundId: 're_1', amount: 425, currencyCode: 'USD',
+    })).resolves.toEqual({ success: true });
+    expect(mocks.send).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/lib/payments/refund-idempotency.test.ts
+++ b/tests/unit/lib/payments/refund-idempotency.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import {
+  deriveRefundIdempotencyKey,
+  normalizeRefundLineIds,
+} from '@/lib/payments/refund-idempotency';
+
+describe('refund idempotency', () => {
+  it('is stable across line ordering and changes for domain inputs', async () => {
+    const base = {
+      orderId: 'WEB-ORDER-1',
+      type: 'partial' as const,
+      refundAmount: 500,
+      settledSequence: 2,
+    };
+    const first = await deriveRefundIdempotencyKey({ ...base, lineIds: ['line-b', 'line-a'] });
+    const reordered = await deriveRefundIdempotencyKey({ ...base, lineIds: ['line-a', 'line-b'] });
+    const next = await deriveRefundIdempotencyKey({ ...base, settledSequence: 3, lineIds: ['line-a', 'line-b'] });
+
+    expect(first).toBe(reordered);
+    expect(first).toMatch(/^refund:[a-f0-9]{64}$/);
+    expect(next).not.toBe(first);
+  });
+
+  it('rejects duplicate, empty, oversized, and malformed inputs', async () => {
+    expect(() => normalizeRefundLineIds(['line-a', 'line-a'])).toThrow('duplicates');
+    expect(() => normalizeRefundLineIds(['   '])).toThrow('non-empty');
+    await expect(deriveRefundIdempotencyKey({
+      orderId: 'order', type: 'partial', refundAmount: 0, settledSequence: 0,
+    })).rejects.toThrow('positive safe integer');
+  });
+});

--- a/tests/unit/lib/payments/refund-ledger.test.ts
+++ b/tests/unit/lib/payments/refund-ledger.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest';
+import {
+  deriveRefundIdempotencyKey,
+  deriveRefundRequestFingerprint,
+} from '@/lib/payments/refund-idempotency';
+import { decideRefundLedgerAction } from '@/lib/payments/refund-ledger';
+
+describe('refund ledger decisions', () => {
+  it('reserves cumulative-safe partial and remaining full refunds', async () => {
+    await expect(decideRefundLedgerAction(
+      [{ amount: 200, status: 'succeeded' }],
+      { orderId: 'order-1', type: 'partial', amount: 300, lineIds: ['line-1'], totalAmount: 1_000 }
+    )).resolves.toMatchObject({ action: 'reserve', refundAmount: 300, settledSequence: 1 });
+
+    await expect(decideRefundLedgerAction(
+      [{ amount: 200, status: 'succeeded' }],
+      { orderId: 'order-1', type: 'full', totalAmount: 1_000 }
+    )).resolves.toMatchObject({ action: 'reserve', refundAmount: 800 });
+  });
+
+  it('counts pending reservations against over-refund', async () => {
+    await expect(decideRefundLedgerAction(
+      [{ amount: 700, status: 'pending', idempotency_key: 'different' }],
+      { orderId: 'order-1', type: 'partial', amount: 301, lineIds: ['line-2'], totalAmount: 1_000 }
+    )).resolves.toMatchObject({ action: 'reject', status: 400 });
+  });
+
+  it('reconciles only a byte-exact pending idempotency key', async () => {
+    const key = await deriveRefundIdempotencyKey({
+      orderId: 'order-1', type: 'partial', refundAmount: 250,
+      settledSequence: 0, lineIds: ['line-1'],
+    });
+    const fingerprint = await deriveRefundRequestFingerprint({
+      orderId: 'order-1', type: 'partial', refundAmount: 250, lineIds: ['line-1'],
+    });
+    await expect(decideRefundLedgerAction(
+      [{
+        amount: 250, status: 'pending', type: 'partial', items: ['line-1'],
+        settled_sequence: 0, idempotency_key: key, request_fingerprint: fingerprint,
+      }],
+      { orderId: 'order-1', type: 'partial', amount: 250, lineIds: ['line-1'], totalAmount: 1_000 }
+    )).resolves.toEqual({
+      action: 'reconcile', entryIndex: 0, idempotencyKey: key,
+      requestFingerprint: fingerprint, refundAmount: 250,
+    });
+
+    await expect(decideRefundLedgerAction(
+      [{
+        amount: 250, status: 'pending', type: 'partial', items: ['line-1'],
+        settled_sequence: 0, idempotency_key: 'refund:not-the-key',
+        request_fingerprint: fingerprint,
+      }],
+      { orderId: 'order-1', type: 'partial', amount: 250, lineIds: ['line-1'], totalAmount: 1_000 }
+    )).resolves.toMatchObject({ action: 'reject', status: 409 });
+  });
+
+  it('retries a pending refund after an unrelated reservation settles', async () => {
+    const firstKey = await deriveRefundIdempotencyKey({
+      orderId: 'order-1', type: 'partial', refundAmount: 100,
+      settledSequence: 0, lineIds: ['line-a'],
+    });
+    const waitingKey = await deriveRefundIdempotencyKey({
+      orderId: 'order-1', type: 'partial', refundAmount: 200,
+      settledSequence: 0, lineIds: ['line-b'],
+    });
+    const firstFingerprint = await deriveRefundRequestFingerprint({
+      orderId: 'order-1', type: 'partial', refundAmount: 100, lineIds: ['line-a'],
+    });
+    const waitingFingerprint = await deriveRefundRequestFingerprint({
+      orderId: 'order-1', type: 'partial', refundAmount: 200, lineIds: ['line-b'],
+    });
+    await expect(decideRefundLedgerAction([
+      {
+        amount: 100, status: 'succeeded', type: 'partial', items: ['line-a'],
+        settled_sequence: 0, idempotency_key: firstKey,
+        request_fingerprint: firstFingerprint, stripe_refund_id: 're_first',
+      },
+      {
+        amount: 200, status: 'pending', type: 'partial', items: ['line-b'],
+        settled_sequence: 0, idempotency_key: waitingKey,
+        request_fingerprint: waitingFingerprint,
+      },
+    ], {
+      orderId: 'order-1', type: 'partial', amount: 200,
+      lineIds: ['line-b'], totalAmount: 1_000,
+    })).resolves.toMatchObject({ action: 'reconcile', idempotencyKey: waitingKey });
+  });
+
+  it('returns an already completed identical request instead of reserving again', async () => {
+    const key = await deriveRefundIdempotencyKey({
+      orderId: 'order-1', type: 'partial', refundAmount: 250,
+      settledSequence: 0, lineIds: ['line-1'],
+    });
+    const fingerprint = await deriveRefundRequestFingerprint({
+      orderId: 'order-1', type: 'partial', refundAmount: 250, lineIds: ['line-1'],
+    });
+    await expect(decideRefundLedgerAction([{
+      amount: 250,
+      status: 'succeeded',
+      type: 'partial',
+      items: ['line-1'],
+      settled_sequence: 0,
+      idempotency_key: key,
+      request_fingerprint: fingerprint,
+      stripe_refund_id: 're_complete',
+      provider_status: 'succeeded',
+    }], {
+      orderId: 'order-1', type: 'partial', amount: 250,
+      lineIds: ['line-1'], totalAmount: 1_000,
+    })).resolves.toMatchObject({
+      action: 'completed', stripeRefundId: 're_complete', idempotencyKey: key,
+    });
+  });
+
+  it('rejects a new reservation at the record bound and any provider-floor divergence', async () => {
+    const full = Array.from({ length: 100 }, (_, index) => ({
+      amount: 1,
+      status: 'failed' as const,
+      id: `failed-${index}`,
+    }));
+    await expect(decideRefundLedgerAction(full, {
+      orderId: 'order-1', type: 'partial', amount: 1,
+      lineIds: ['line-1'], totalAmount: 1_000,
+    })).resolves.toMatchObject({ action: 'reject', status: 409 });
+
+    await expect(decideRefundLedgerAction([], {
+      orderId: 'order-1', type: 'partial', amount: 1,
+      lineIds: ['line-1'], totalAmount: 1_000, stripeRefundedFloor: 100,
+    })).resolves.toMatchObject({ action: 'reject', status: 409 });
+  });
+
+  it('releases failed entries into a new settled sequence', async () => {
+    const decision = await decideRefundLedgerAction(
+      [{ amount: 250, status: 'failed', idempotency_key: 'old' }],
+      { orderId: 'order-1', type: 'partial', amount: 250, lineIds: ['line-1'], totalAmount: 1_000 }
+    );
+    expect(decision).toMatchObject({ action: 'reserve', settledSequence: 1 });
+  });
+
+  it('uses the Stripe floor only as a reject gate, never a key input', async () => {
+    const request = {
+      orderId: 'order-1', type: 'full' as const, totalAmount: 1_000,
+    };
+    const normal = await decideRefundLedgerAction([], request);
+    const safeFloor = await decideRefundLedgerAction([], { ...request, stripeRefundedFloor: 0 });
+    expect(safeFloor).toEqual(normal);
+
+    await expect(decideRefundLedgerAction([], {
+      ...request,
+      stripeRefundedFloor: 100,
+    })).resolves.toMatchObject({ action: 'reject', status: 409 });
+  });
+
+  it('fails closed for malformed stored ledger entries', async () => {
+    await expect(decideRefundLedgerAction(
+      [{ amount: Number.NaN }],
+      { orderId: 'order-1', type: 'partial', amount: 100, lineIds: ['line-1'], totalAmount: 1_000 }
+    )).resolves.toMatchObject({ action: 'reject' });
+  });
+});

--- a/tests/unit/lib/payments/refund-lifecycle.test.ts
+++ b/tests/unit/lib/payments/refund-lifecycle.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest';
+import { decideRefundLifecycle } from '@/lib/payments/refund-lifecycle';
+
+const base = {
+  chargeAmountRefunded: 400,
+  totalAmount: 1_000,
+  orderLineIds: ['line-a', 'line-b'],
+  externalRestockEnabled: false,
+  nowIso: '2026-08-06T20:00:00.000Z',
+};
+
+describe('refund lifecycle decisions', () => {
+  it('settles a local reservation and selects only its returned lines', () => {
+    const decision = decideRefundLifecycle({
+      ...base,
+      mode: 'charge',
+      refunds: [{
+        idempotency_key: 'request-1', amount: 400, type: 'partial',
+        items: ['line-b'], status: 'pending',
+      }],
+      providerRefunds: [{
+        id: 're_local', amount: 400, status: 'succeeded',
+        paymentIntentId: 'pi_1', requestId: 'request-1',
+      }],
+    });
+
+    expect(decision.refunds[0]).toMatchObject({
+      status: 'succeeded', stripe_refund_id: 're_local',
+    });
+    expect(decision.restockLineIds).toEqual(['line-b']);
+    expect(decision.fullyRefunded).toBe(false);
+  });
+
+  it('records a Dashboard partial refund without guessing returned lines', () => {
+    const decision = decideRefundLifecycle({
+      ...base,
+      mode: 'charge',
+      refunds: [],
+      providerRefunds: [{
+        id: 're_external', amount: 400, status: 'succeeded', paymentIntentId: 'pi_1',
+      }],
+    });
+
+    expect(decision.refunds).toEqual([
+      expect.objectContaining({
+        stripe_refund_id: 're_external', source: 'stripe_dashboard', status: 'succeeded',
+      }),
+    ]);
+    expect(decision.restockLineIds).toEqual([]);
+  });
+
+  it('restocks all outstanding lines for an explicitly enabled full Dashboard refund', () => {
+    const decision = decideRefundLifecycle({
+      ...base,
+      chargeAmountRefunded: 1_000,
+      externalRestockEnabled: true,
+      mode: 'charge',
+      refunds: [],
+      providerRefunds: [{
+        id: 're_external_full', amount: 1_000, status: 'succeeded', paymentIntentId: 'pi_1',
+      }],
+    });
+
+    expect(decision.fullyRefunded).toBe(true);
+    expect(decision.restockLineIds).toEqual(['line-a', 'line-b']);
+  });
+
+  it('never appends an unknown refund from a lifecycle-only event', () => {
+    const decision = decideRefundLifecycle({
+      ...base,
+      mode: 'lifecycle',
+      targetRefundId: 're_unknown',
+      refunds: [],
+      providerRefunds: [{
+        id: 're_unknown', amount: 400, status: 'succeeded', paymentIntentId: 'pi_1',
+      }],
+    });
+
+    expect(decision.matchedTarget).toBe(false);
+    expect(decision.refunds).toEqual([]);
+    expect(decision.stripeAmountRefunded).toBe(400);
+  });
+
+  it('releases failed reservations and withholds completion effects while unsettled', () => {
+    const failed = decideRefundLifecycle({
+      ...base,
+      chargeAmountRefunded: 0,
+      mode: 'lifecycle',
+      targetRefundId: 're_failed',
+      refunds: [{
+        stripe_refund_id: 're_failed', amount: 400, type: 'partial',
+        items: ['line-a'], status: 'pending',
+      }],
+      providerRefunds: [{
+        id: 're_failed', amount: 400, status: 'failed', paymentIntentId: 'pi_1',
+      }],
+    });
+    expect(failed.refunds[0]).toMatchObject({ status: 'failed' });
+    expect(failed.restockLineIds).toEqual([]);
+
+    const pending = decideRefundLifecycle({
+      ...base,
+      chargeAmountRefunded: 0,
+      mode: 'lifecycle',
+      targetRefundId: 're_pending',
+      refunds: [{
+        stripe_refund_id: 're_pending', amount: 400, type: 'partial',
+        items: ['line-a'], status: 'pending',
+      }],
+      providerRefunds: [{
+        id: 're_pending', amount: 400, status: 'requires_action', paymentIntentId: 'pi_1',
+      }],
+    });
+    expect(pending.refunds[0]).toMatchObject({ status: 'requires_action' });
+    expect(pending.fullyRefunded).toBe(false);
+  });
+
+  it('fails closed on incomplete provider lists and amount conflicts', () => {
+    expect(() => decideRefundLifecycle({
+      ...base,
+      mode: 'charge',
+      refunds: [],
+      providerRefunds: [],
+    })).toThrow('does not match');
+
+    expect(() => decideRefundLifecycle({
+      ...base,
+      mode: 'charge',
+      refunds: [{ stripe_refund_id: 're_1', amount: 500, status: 'pending' }],
+      providerRefunds: [{
+        id: 're_1', amount: 400, status: 'succeeded', paymentIntentId: 'pi_1',
+      }],
+    })).toThrow('amount conflicts');
+  });
+});

--- a/tests/unit/lib/services/checkout-pricing.test.ts
+++ b/tests/unit/lib/services/checkout-pricing.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { priceCheckout } from '@/lib/services/checkout-pricing';
+import { mapProviderTaxAllocations, priceCheckout } from '@/lib/services/checkout-pricing';
 import { Money } from '@/lib/money';
 
 const address = {
@@ -36,7 +36,19 @@ function dependencies(overrides: Record<string, unknown> = {}) {
           'shipping.free_methods': [],
         }
       : { 'store.tax_rate': 10 }),
-    calculateTax: vi.fn(async () => ({ tax_amount_exclusive: 200 })),
+    calculateTax: vi.fn(async (params: any) => ({
+      tax_amount_exclusive: 200,
+      line_items: {
+        data: params.line_items.map((line: any, index: number) => ({
+          ...line,
+          amount_tax: index === 0 ? 200 : 0,
+        })),
+        has_more: false,
+      },
+      shipping_cost: params.shipping_cost
+        ? { amount: params.shipping_cost.amount, amount_tax: 0 }
+        : null,
+    })),
     ...overrides,
   };
 }
@@ -50,12 +62,19 @@ describe('server-authoritative checkout pricing', () => {
     }, { dependencies: dependencies() as any });
 
     expect(quote.items[0]).toMatchObject({
+      id: expect.stringMatching(/^line_[0-9a-f-]{36}$/),
       product_name: 'Catalog name',
       sku: 'SKU-1',
       unit_price: { amount: 2_000, currency: 'USD' },
       total_price: { amount: 4_000, currency: 'USD' },
     });
     expect(quote.total).toEqual({ amount: 4_700, currency: 'USD' });
+    expect(quote.lineAllocations).toEqual([expect.objectContaining({
+      lineId: quote.items[0].id,
+      catalogSubtotal: { amount: 4_000, currency: 'USD' },
+      merchandiseDiscount: { amount: 0, currency: 'USD' },
+      tax: { amount: 200, currency: 'USD' },
+    })]);
   });
 
   it('uses the shared enabled shipping defaults on a fresh install', async () => {
@@ -190,6 +209,171 @@ describe('server-authoritative checkout pricing', () => {
       discountCodes: ['NOOP'],
     }, { dependencies: deps as any });
     expect(quote.discountCodes).toEqual([]);
+  });
+
+  it('persists targeted promotion contribution and out-of-order provider tax by stable line id', async () => {
+    const calculateTax = vi.fn(async (params: any) => ({
+      tax_amount_exclusive: 155,
+      line_items: {
+        has_more: false,
+        data: [
+          { ...params.line_items[1], amount_tax: 100 },
+          { ...params.line_items[0], amount_tax: 50 },
+        ],
+      },
+      shipping_cost: { amount: 500, amount_tax: 5 },
+    }));
+    const deps = dependencies({
+      getProduct: vi.fn(async (id: string) => ({
+        id,
+        name: id,
+        status: 'active',
+        categories: id === 'prod_target' ? ['target'] : ['other'],
+        default_variant_id: `var_${id}`,
+        tax_category: 'txcd_99999999',
+      })),
+      getProductVariant: vi.fn(async (id: string) => ({
+        id,
+        product_id: id.replace(/^var_/, ''),
+        sku: id,
+        status: 'active',
+        option_values: [],
+        price: Money.fromMinor(1_000).toJSON(),
+      })),
+      validateCouponCode: vi.fn(async () => ({
+        canBeUsed: true,
+        coupon: { promotion_id: 'promo_target', code: 'TARGET' },
+      })),
+      getPromotionById: vi.fn(async () => ({
+        id: 'promo_target',
+        name: 'Targeted',
+        type: 'cart',
+        status: 'active',
+        stackable: true,
+        rules: {
+          conditions: [{ type: 'product_category', operator: 'in', value: ['target'] }],
+          actions: [{ type: 'fixed_discount', value: 500 }],
+        },
+      })),
+      calculateTax,
+    });
+
+    const quote = await priceCheckout({
+      items: [
+        { productId: 'prod_target', quantity: 1 },
+        { productId: 'prod_other', quantity: 1 },
+      ],
+      shippingAddress: address,
+      shippingMethodId: 'standard',
+      discountCodes: ['TARGET'],
+    }, { dependencies: deps as any });
+
+    expect(calculateTax).toHaveBeenCalledWith(expect.objectContaining({
+      expand: ['line_items'],
+      line_items: [
+        expect.objectContaining({ amount: 500, reference: `line:${quote.items[0].id}` }),
+        expect.objectContaining({ amount: 1_000, reference: `line:${quote.items[1].id}` }),
+      ],
+    }));
+    expect(quote.lineAllocations).toEqual([
+      expect.objectContaining({
+        lineId: quote.items[0].id,
+        merchandiseDiscount: { amount: 500, currency: 'USD' },
+        netMerchandise: { amount: 500, currency: 'USD' },
+        tax: { amount: 50, currency: 'USD' },
+        promotionCodes: ['TARGET'],
+      }),
+      expect.objectContaining({
+        lineId: quote.items[1].id,
+        merchandiseDiscount: { amount: 0, currency: 'USD' },
+        tax: { amount: 100, currency: 'USD' },
+        promotionCodes: [],
+      }),
+    ]);
+    expect(quote.shippingTax).toEqual({ amount: 5, currency: 'USD' });
+    expect(quote.lineAllocations.reduce((sum, line) => sum + line.tax.amount, 0) +
+      quote.shippingTax.amount).toBe(quote.tax.amount);
+  });
+
+  it.each([
+    ['missing lines', { line_items: undefined }],
+    ['paginated lines', { line_items: { has_more: true, data: [] } }],
+    ['missing count', { line_items: { has_more: false, data: [] } }],
+    ['unknown reference', {
+      line_items: { has_more: false, data: [{ reference: 'line:other', amount: 100, amount_tax: 5 }] },
+    }],
+    ['amount mismatch', {
+      line_items: { has_more: false, data: [{ reference: 'line:a', amount: 99, amount_tax: 5 }] },
+    }],
+    ['aggregate mismatch', {
+      line_items: { has_more: false, data: [{ reference: 'line:a', amount: 100, amount_tax: 5 }] },
+      tax_amount_exclusive: 6,
+    }],
+    ['shipping mismatch', {
+      line_items: { has_more: false, data: [{ reference: 'line:a', amount: 100, amount_tax: 5 }] },
+      shipping_cost: { amount: 49, amount_tax: 5 },
+      tax_amount_exclusive: 10,
+    }],
+  ])('rejects provider allocation mismatch: %s', (_name, override) => {
+    const valid = Object.assign({
+      line_items: {
+        has_more: false,
+        data: [{ reference: 'line:a', amount: 100, amount_tax: 5 }],
+      },
+      shipping_cost: { amount: 50, amount_tax: 5 },
+      tax_amount_exclusive: 10,
+    }, override);
+    expect(() => mapProviderTaxAllocations(valid as any, [{ lineId: 'a', amount: 100 }], 50))
+      .toThrow();
+  });
+
+  it('rejects duplicate provider references even when the line count matches', () => {
+    const calculation = {
+      line_items: {
+        has_more: false,
+        data: [
+          { reference: 'line:a', amount: 100, amount_tax: 5 },
+          { reference: 'line:a', amount: 100, amount_tax: 5 },
+        ],
+      },
+      shipping_cost: null,
+      tax_amount_exclusive: 10,
+    };
+    expect(() => mapProviderTaxAllocations(calculation as any, [
+      { lineId: 'a', amount: 100 },
+      { lineId: 'b', amount: 100 },
+    ], 0)).toThrow('duplicate');
+  });
+
+  it('uses largest remainders so fallback line taxes remain integer and sum exactly', async () => {
+    const deps = dependencies({
+      getProductVariant: vi.fn(async (id: string) => ({
+        id,
+        product_id: 'prod_1',
+        sku: id,
+        status: 'active',
+        option_values: [],
+        price: Money.fromMinor(1).toJSON(),
+      })),
+      getSettings: vi.fn(async (category: string) => category === 'shipping'
+        ? { 'shipping.methods': [{ id: 'standard', label: 'Standard', cost: 0, enabled: true }] }
+        : { 'store.tax_rate': 50 }),
+      calculateTax: vi.fn(async () => { throw new Error('offline'); }),
+    });
+    const quote = await priceCheckout({
+      items: [
+        { productId: 'prod_1', variantId: 'v1', quantity: 1 },
+        { productId: 'prod_1', variantId: 'v2', quantity: 1 },
+        { productId: 'prod_1', variantId: 'v3', quantity: 1 },
+      ],
+      shippingAddress: address,
+      shippingMethodId: 'standard',
+    }, { dependencies: deps as any });
+
+    const taxes = quote.lineAllocations.map((line) => line.tax.amount);
+    expect(taxes).toEqual([1, 1, 0]);
+    expect(taxes.every((amount) => Number.isSafeInteger(amount) && amount >= 0)).toBe(true);
+    expect(taxes.reduce((sum, amount) => sum + amount, 0)).toBe(quote.tax.amount);
   });
 
   it('fails closed when promotion eligibility cannot be proven', async () => {

--- a/tests/unit/lib/services/inventory-adjustments.test.ts
+++ b/tests/unit/lib/services/inventory-adjustments.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import {
+  canFulfillInventory,
+  isInventoryAvailable,
+  isVariantAvailable,
+} from '@/lib/inventory/availability';
+import {
+  assertCheckoutInventoryAvailable,
+  stageInventoryAdjustments,
+} from '@/lib/services/inventory-adjustments';
+
+describe('shared storefront and checkout availability policy', () => {
+  it('treats untracked and backorderable inventory as available', () => {
+    expect(isInventoryAvailable(undefined)).toBe(true);
+    expect(isInventoryAvailable({ track_inventory: false, quantity: 0 })).toBe(true);
+    expect(isInventoryAvailable({
+      track_inventory: true,
+      quantity: -4,
+      allow_backorder: true,
+    })).toBe(true);
+  });
+
+  it('requires enough integer stock for tracked non-backorderable demand', () => {
+    const inventory = { track_inventory: true, quantity: 3, allow_backorder: false };
+    expect(canFulfillInventory(inventory, 3)).toBe(true);
+    expect(canFulfillInventory(inventory, 4)).toBe(false);
+    expect(canFulfillInventory(inventory, 0)).toBe(false);
+    expect(canFulfillInventory({ ...inventory, quantity: 3.5 }, 1)).toBe(false);
+    expect(isInventoryAvailable({ ...inventory, quantity: 3.5 })).toBe(false);
+    expect(isInventoryAvailable({
+      track_inventory: true,
+      quantity: 3.5,
+      allow_backorder: true,
+    })).toBe(false);
+  });
+
+  it('combines active status with the same inventory policy', () => {
+    expect(isVariantAvailable({ status: 'active', inventory: undefined })).toBe(true);
+    expect(isVariantAvailable({
+      status: 'inactive',
+      inventory: { track_inventory: false },
+    })).toBe(false);
+    expect(isVariantAvailable({
+      status: 'active',
+      inventory: { track_inventory: true, quantity: 0 },
+    })).toBe(false);
+  });
+});
+
+describe('inventory adjustment input bounds', () => {
+  it('rejects malformed quantities before resolving D1', async () => {
+    await expect(assertCheckoutInventoryAvailable([{
+      product_id: 'product',
+      variant_id: 'variant',
+      sku: 'SKU',
+      quantity: 0,
+      unit_price: { amount: 1, currency: 'USD' },
+      total_price: { amount: 1, currency: 'USD' },
+      product_name: 'Product',
+    }])).rejects.toThrow('invalid quantity');
+  });
+
+  it('accepts an empty staging batch without resolving D1', async () => {
+    await expect(stageInventoryAdjustments([])).resolves.toBeUndefined();
+  });
+
+  it('rejects adjustment keys that do not match their domain identity', async () => {
+    await expect(stageInventoryAdjustments([{
+      adjustmentKey: 'restock:wrong',
+      orderId: 'order-1',
+      lineId: 'line-1',
+      variantId: 'variant-1',
+      kind: 'refund_restock',
+      quantity: 1,
+    }])).rejects.toThrow('identity is invalid');
+  });
+});

--- a/tests/unit/lib/services/order-finalization.test.ts
+++ b/tests/unit/lib/services/order-finalization.test.ts
@@ -7,6 +7,8 @@ const mocks = vi.hoisted(() => ({
   recordCouponReconciliation: vi.fn(),
   redeemCoupon: vi.fn(),
   sendOrderConfirmationEmail: vi.fn(),
+  stagePaidOrderEffects: vi.fn(),
+  drainOrderEffects: vi.fn(),
 }));
 
 vi.mock('@/lib/db', () => ({
@@ -21,6 +23,10 @@ vi.mock('@/lib/db', () => ({
 vi.mock('@/lib/stripe', () => ({ retrievePaymentIntent: mocks.retrievePaymentIntent }));
 vi.mock('@/lib/models/mach/couponInstance', () => ({ redeemCoupon: mocks.redeemCoupon }));
 vi.mock('@/lib/utils/email', () => ({ sendOrderConfirmationEmail: mocks.sendOrderConfirmationEmail }));
+vi.mock('@/lib/services/order-effects', () => ({
+  stagePaidOrderEffects: mocks.stagePaidOrderEffects,
+  drainOrderEffects: mocks.drainOrderEffects,
+}));
 vi.mock('@/lib/models/mach/orders', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/lib/models/mach/orders')>();
   return {
@@ -94,6 +100,8 @@ beforeEach(() => {
   mocks.redeemCoupon.mockResolvedValue({ redeemed: true });
   mocks.recordCouponReconciliation.mockResolvedValue(undefined);
   mocks.sendOrderConfirmationEmail.mockResolvedValue({ success: true });
+  mocks.stagePaidOrderEffects.mockResolvedValue(undefined);
+  mocks.drainOrderEffects.mockResolvedValue({ claimed: 5, succeeded: 4, failed: 1 });
 });
 
 describe('verified paid-order finalization', () => {
@@ -143,7 +151,7 @@ describe('verified paid-order finalization', () => {
     expect(mocks.promoteOrderToPaid).not.toHaveBeenCalled();
   });
 
-  it('runs paid effects only for the CAS winner', async () => {
+  it('stages before promotion and drains for winner and already-paid convergence', async () => {
     const first = await finalizeOrderPayment({
       orderId: mocks.record.id,
       paymentIntentId: 'pi_bound',
@@ -155,50 +163,51 @@ describe('verified paid-order finalization', () => {
     const promotionArgs = mocks.promoteOrderToPaid.mock.calls[0][0];
     expect(promotionArgs.orderId).toBe(mocks.record.id);
     expect(promotionArgs.amountReceived.toJSON()).toEqual({ amount: 2_500, currency: 'USD' });
-    expect(mocks.sendOrderConfirmationEmail).toHaveBeenCalledTimes(1);
-    expect(mocks.redeemCoupon).toHaveBeenCalledTimes(1);
+    expect(mocks.stagePaidOrderEffects).toHaveBeenCalledTimes(2);
+    expect(mocks.stagePaidOrderEffects.mock.invocationCallOrder[0])
+      .toBeLessThan(mocks.promoteOrderToPaid.mock.invocationCallOrder[0]);
+    expect(mocks.drainOrderEffects).toHaveBeenCalledWith(expect.objectContaining({
+      orderId: mocks.record.id,
+      limit: 25,
+    }));
 
     mocks.promoteOrderToPaid.mockResolvedValue({
       promoted: false,
       order: { ...first.order, payment_status: 'paid' },
     });
-    mocks.redeemCoupon.mockResolvedValue({ redeemed: false, alreadyRedeemed: true });
     await finalizeOrderPayment({
       orderId: mocks.record.id,
       paymentIntentId: 'pi_bound',
       customerId: 'user_1',
       enforceOwnership: true,
     });
-    expect(mocks.sendOrderConfirmationEmail).toHaveBeenCalledTimes(1);
-    expect(mocks.redeemCoupon).toHaveBeenCalledTimes(2);
+    expect(mocks.stagePaidOrderEffects).toHaveBeenCalledTimes(4);
+    expect(mocks.drainOrderEffects).toHaveBeenCalledTimes(2);
   });
 
-  it('promotes captured money when a coupon race requires reconciliation', async () => {
-    mocks.redeemCoupon.mockResolvedValue({ redeemed: false, alreadyRedeemed: false });
-
+  it('repairs deterministic rows after paid promotion before inline draining', async () => {
     await expect(finalizeOrderPayment({
       orderId: mocks.record.id,
       paymentIntentId: 'pi_bound',
     })).resolves.toMatchObject({ paid: true, promoted: true });
 
     expect(mocks.promoteOrderToPaid).toHaveBeenCalledOnce();
-    expect(mocks.recordCouponReconciliation).toHaveBeenCalledWith({
-      orderId: mocks.record.id,
-      code: 'SAVE',
-    });
     expect(mocks.promoteOrderToPaid.mock.invocationCallOrder[0])
-      .toBeLessThan(mocks.redeemCoupon.mock.invocationCallOrder[0]);
+      .toBeLessThan(mocks.stagePaidOrderEffects.mock.invocationCallOrder[1]);
+    expect(mocks.stagePaidOrderEffects.mock.invocationCallOrder[1])
+      .toBeLessThan(mocks.drainOrderEffects.mock.invocationCallOrder[0]);
   });
 
-  it('propagates transient coupon persistence errors after durable paid promotion', async () => {
-    mocks.redeemCoupon.mockRejectedValue(new Error('D1 unavailable'));
+  it('blocks paid promotion when pre-CAS effect staging fails', async () => {
+    mocks.stagePaidOrderEffects.mockRejectedValueOnce(new Error('effect staging unavailable'));
 
     await expect(finalizeOrderPayment({
       orderId: mocks.record.id,
       paymentIntentId: 'pi_bound',
-    })).rejects.toThrow('D1 unavailable');
+    })).rejects.toThrow('effect staging unavailable');
 
-    expect(mocks.promoteOrderToPaid).toHaveBeenCalledOnce();
+    expect(mocks.promoteOrderToPaid).not.toHaveBeenCalled();
+    expect(mocks.drainOrderEffects).not.toHaveBeenCalled();
   });
 
   it('does not consume coupons unless promotion proves the order is paid', async () => {
@@ -212,7 +221,7 @@ describe('verified paid-order finalization', () => {
       paymentIntentId: 'pi_bound',
     })).rejects.toThrow('without a paid winner');
 
-    expect(mocks.redeemCoupon).not.toHaveBeenCalled();
+    expect(mocks.drainOrderEffects).not.toHaveBeenCalled();
   });
 
   it('allows recovery when coupon audit proves the order already redeemed it', async () => {
@@ -246,7 +255,7 @@ describe('verified paid-order finalization', () => {
     })).resolves.toMatchObject({ paid: true, promoted: false });
   });
 
-  it('re-applies idempotent tender on paid retry without requiring an open reservation', async () => {
+  it('passes idempotent capabilities to each drain without re-verifying paid tender', async () => {
     const verifyReservedTender = vi.fn(async () => undefined);
     const applyTender = vi.fn(async () => undefined);
     const orderPaid = vi.fn(async () => undefined);
@@ -266,8 +275,6 @@ describe('verified paid-order finalization', () => {
       promoted: false,
       order: { ...first.order, payment_status: 'paid' },
     });
-    mocks.redeemCoupon.mockResolvedValue({ redeemed: false, alreadyRedeemed: true });
-
     await finalizeOrderPayment({
       orderId: mocks.record.id,
       paymentIntentId: 'pi_bound',
@@ -275,11 +282,12 @@ describe('verified paid-order finalization', () => {
     });
 
     expect(verifyReservedTender).toHaveBeenCalledTimes(1);
-    expect(applyTender).toHaveBeenCalledTimes(2);
-    expect(orderPaid).toHaveBeenCalledTimes(2);
+    expect(mocks.drainOrderEffects).toHaveBeenCalledTimes(2);
+    expect(mocks.drainOrderEffects).toHaveBeenNthCalledWith(1, expect.objectContaining({ capabilities }));
+    expect(mocks.drainOrderEffects).toHaveBeenNthCalledWith(2, expect.objectContaining({ capabilities }));
   });
 
-  it('propagates transient tender settlement failure after durable paid promotion', async () => {
+  it('acknowledges paid durability when an inline effect is queued for retry', async () => {
     const capabilities = {
       giftCards: {
         resolveTender: vi.fn(),
@@ -289,17 +297,18 @@ describe('verified paid-order finalization', () => {
       subscriptions: { validateCheckout: vi.fn(), orderPaid: vi.fn() },
     };
 
+    mocks.drainOrderEffects.mockResolvedValue({ claimed: 5, succeeded: 4, failed: 1 });
     await expect(finalizeOrderPayment({
       orderId: mocks.record.id,
       paymentIntentId: 'pi_bound',
       capabilities,
-    })).rejects.toThrow('tender store unavailable');
+    })).resolves.toMatchObject({ paid: true, promoted: true });
 
     expect(mocks.promoteOrderToPaid).toHaveBeenCalledOnce();
-    expect(mocks.sendOrderConfirmationEmail).not.toHaveBeenCalled();
+    expect(mocks.drainOrderEffects).toHaveBeenCalledWith(expect.objectContaining({ capabilities }));
   });
 
-  it('propagates transient subscription activation failure after durable paid promotion', async () => {
+  it('acknowledges paid state when inline drain infrastructure defers to scheduled recovery', async () => {
     const capabilities = {
       giftCards: {
         resolveTender: vi.fn(),
@@ -312,14 +321,21 @@ describe('verified paid-order finalization', () => {
       },
     };
 
+    const error = new Error('effect claim unavailable');
+    const errorLog = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    mocks.drainOrderEffects.mockRejectedValue(error);
     await expect(finalizeOrderPayment({
       orderId: mocks.record.id,
       paymentIntentId: 'pi_bound',
       capabilities,
-    })).rejects.toThrow('subscription store unavailable');
+    })).resolves.toMatchObject({ paid: true, promoted: true });
 
     expect(mocks.promoteOrderToPaid).toHaveBeenCalledOnce();
-    expect(mocks.sendOrderConfirmationEmail).not.toHaveBeenCalled();
+    expect(errorLog).toHaveBeenCalledWith(
+      `[checkout] Paid effects queued for retry on order ${mocks.record.id}:`,
+      error
+    );
+    errorLog.mockRestore();
   });
 
   it('verifies non-cash tender before paid promotion', async () => {
@@ -341,7 +357,7 @@ describe('verified paid-order finalization', () => {
   });
 
   it('does not report failure after paid CAS when confirmation email fails', async () => {
-    mocks.sendOrderConfirmationEmail.mockRejectedValue(new Error('email unavailable'));
+    mocks.drainOrderEffects.mockResolvedValue({ claimed: 5, succeeded: 4, failed: 1 });
 
     await expect(finalizeOrderPayment({
       orderId: mocks.record.id,

--- a/tests/unit/lib/stripe-client.test.ts
+++ b/tests/unit/lib/stripe-client.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const httpClient = { kind: 'fetch' };
+  const cryptoProvider = { kind: 'subtle' };
+  return {
+    constructor: vi.fn(),
+    createFetchHttpClient: vi.fn(() => httpClient),
+    createSubtleCryptoProvider: vi.fn(() => cryptoProvider),
+    paymentIntentsCreate: vi.fn(),
+    paymentIntentsRetrieve: vi.fn(),
+    paymentIntentsCancel: vi.fn(),
+    taxCalculationCreate: vi.fn(),
+    constructEventAsync: vi.fn(),
+    httpClient,
+    cryptoProvider,
+  };
+});
+
+vi.mock('@stripe/stripe-js', () => ({ loadStripe: vi.fn() }));
+
+vi.mock('stripe', () => {
+  class StripeMock {
+    static createFetchHttpClient = mocks.createFetchHttpClient;
+    static createSubtleCryptoProvider = mocks.createSubtleCryptoProvider;
+
+    paymentIntents = {
+      create: mocks.paymentIntentsCreate,
+      retrieve: mocks.paymentIntentsRetrieve,
+      cancel: mocks.paymentIntentsCancel,
+    };
+
+    tax = { calculations: { create: mocks.taxCalculationCreate } };
+    webhooks = { constructEventAsync: mocks.constructEventAsync };
+
+    constructor(apiKey: string, options: unknown) {
+      mocks.constructor(apiKey, options);
+    }
+  }
+
+  return { default: StripeMock };
+});
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.stubEnv('STRIPE_SECRET_KEY', 'sk_test_placeholder');
+  vi.stubEnv('NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY', 'pk_test_placeholder');
+});
+
+describe('Workers-safe Stripe client', () => {
+  it('memoizes one SDK client configured with fetch HTTP', async () => {
+    const { getStripe, getStripeClient } = await import('@/lib/stripe');
+
+    expect(getStripe()).toBe(getStripe());
+    expect(getStripeClient()).toBe(getStripe());
+    expect(mocks.constructor).toHaveBeenCalledOnce();
+    expect(mocks.constructor).toHaveBeenCalledWith('sk_test_placeholder', {
+      apiVersion: '2026-07-29.dahlia',
+      typescript: true,
+      httpClient: mocks.httpClient,
+    });
+    expect(mocks.createFetchHttpClient).toHaveBeenCalledOnce();
+  });
+
+  it('routes payment and tax helpers through the SDK client', async () => {
+    mocks.paymentIntentsCreate.mockResolvedValue({ id: 'pi_create' });
+    mocks.paymentIntentsRetrieve.mockResolvedValue({ id: 'pi_retrieve' });
+    mocks.paymentIntentsCancel.mockResolvedValue({ id: 'pi_cancel' });
+    mocks.taxCalculationCreate.mockResolvedValue({ id: 'taxcalc_1' });
+    const {
+      calculateTax,
+      cancelPaymentIntent,
+      createPaymentIntent,
+      retrievePaymentIntent,
+    } = await import('@/lib/stripe');
+
+    await expect(createPaymentIntent({ amount: 100, currency: 'usd' }))
+      .resolves.toEqual({ id: 'pi_create' });
+    await expect(retrievePaymentIntent('pi_retrieve')).resolves.toEqual({ id: 'pi_retrieve' });
+    await expect(cancelPaymentIntent('pi_cancel')).resolves.toBeUndefined();
+    await expect(calculateTax({
+      currency: 'usd',
+      customer_details: {
+        address: { country: 'US' },
+        address_source: 'shipping',
+      },
+      line_items: [{ amount: 100, reference: 'line:1' }],
+    })).resolves.toEqual({ id: 'taxcalc_1' });
+
+    expect(mocks.paymentIntentsCreate).toHaveBeenCalledWith({ amount: 100, currency: 'usd' });
+    expect(mocks.paymentIntentsRetrieve).toHaveBeenCalledWith('pi_retrieve');
+    expect(mocks.paymentIntentsCancel).toHaveBeenCalledWith('pi_cancel');
+    expect(mocks.taxCalculationCreate).toHaveBeenCalledOnce();
+  });
+
+  it('verifies webhook signatures asynchronously with SubtleCrypto', async () => {
+    const event = { id: 'evt_1', type: 'payment_intent.succeeded' };
+    mocks.constructEventAsync.mockResolvedValue(event);
+    const { constructWebhookEvent } = await import('@/lib/stripe');
+
+    await expect(constructWebhookEvent('{}', 'signed', 'whsec_test')).resolves.toBe(event);
+    expect(mocks.constructEventAsync).toHaveBeenCalledWith(
+      '{}',
+      'signed',
+      'whsec_test',
+      undefined,
+      mocks.cryptoProvider
+    );
+  });
+});

--- a/tests/unit/lib/utils/order-confirmation-email.test.ts
+++ b/tests/unit/lib/utils/order-confirmation-email.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  send: vi.fn(),
+}));
+
+vi.mock('resend', () => ({
+  Resend: class {
+    emails = { send: mocks.send };
+  },
+}));
+
+vi.mock('@/lib/store-config', () => ({
+  getStoreConfig: () => ({
+    identity: { name: 'Test Store', tagline: 'Test commerce' },
+    contact: { senderEmail: 'Test Store <orders@example.com>' },
+    urls: { site: 'https://store.example.com', imageCdn: 'https://images.example.com' },
+    deployment: { imageTransformsEnabled: true },
+  }),
+}));
+
+import { sendOrderConfirmationEmail } from '@/lib/utils/email';
+
+const orderData = {
+  orderNumber: 'WEB-EMAIL-1',
+  customerName: 'Customer',
+  customerEmail: 'customer@example.com',
+  items: [{
+    productId: 'product-1',
+    name: 'Product',
+    price: { amount: 1_000, currency: 'USD' },
+    quantity: 1,
+    imageUrl: '/catalog/product.jpg',
+  }],
+  subtotal: { amount: 1_000, currency: 'USD' },
+  shipping: { amount: 0, currency: 'USD' },
+  tax: { amount: 100, currency: 'USD' },
+  total: { amount: 1_100, currency: 'USD' },
+  shippingAddress: {
+    street: '1 Main', city: 'Denver', state: 'CO', zipCode: '80202', country: 'US',
+  },
+};
+
+beforeEach(() => {
+  mocks.send.mockResolvedValue({ data: { id: 'email-provider-1' }, error: null });
+});
+
+describe('order confirmation provider boundary', () => {
+  it('uses generic runtime configuration and forwards the deterministic provider key', async () => {
+    await expect(sendOrderConfirmationEmail(orderData, {
+      idempotencyKey: 'order-confirmation/WEB-EMAIL-1/v1',
+    })).resolves.toEqual({ success: true, id: 'email-provider-1' });
+
+    expect(mocks.send).toHaveBeenCalledWith(expect.objectContaining({
+      from: 'Test Store <orders@example.com>',
+      to: ['customer@example.com'],
+      subject: 'Order Confirmation #WEB-EMAIL-1 - Test Store',
+    }), { idempotencyKey: 'order-confirmation/WEB-EMAIL-1/v1' });
+    const html = mocks.send.mock.calls[0][0].html as string;
+    expect(html).toContain('Test Store');
+    expect(html).toContain('Test commerce');
+    expect(html).toContain('https://images.example.com/cdn-cgi/image/width=100,quality=80,format=auto/catalog/product.jpg');
+    expect(html).not.toContain('Voltique');
+  });
+
+  it('returns success false when the provider rejects the attempt', async () => {
+    mocks.send.mockResolvedValue({ data: null, error: { message: 'provider rejected' } });
+
+    await expect(sendOrderConfirmationEmail(orderData, {
+      idempotencyKey: 'order-confirmation/WEB-EMAIL-1/v1',
+    })).resolves.toEqual({ success: false, error: 'provider rejected' });
+  });
+});

--- a/tests/unit/lib/utils/refund-validation.test.ts
+++ b/tests/unit/lib/utils/refund-validation.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import {
+  assertRefundWithinRemaining,
+  classifyRefundStatus,
+  computeRefundedTotal,
+  hasPendingRefund,
+  resolveFullRefundAmount,
+} from '@/lib/utils/refund-validation';
+
+describe('refund validation', () => {
+  it('classifies current and legacy lifecycle states', () => {
+    expect(classifyRefundStatus(undefined)).toBe('legacy');
+    expect(classifyRefundStatus('pending')).toBe('reserved');
+    expect(classifyRefundStatus('requires_action')).toBe('reserved');
+    expect(classifyRefundStatus('succeeded')).toBe('settled');
+    expect(classifyRefundStatus('failed')).toBe('released');
+    expect(classifyRefundStatus('canceled')).toBe('released');
+    expect(classifyRefundStatus('mystery')).toBe('unknown');
+  });
+
+  it('counts reserved, settled, and legacy entries but releases failures', () => {
+    expect(computeRefundedTotal({ refunds: [
+      { amount: 100, status: 'pending' },
+      { amount: 200, status: 'requires_action' },
+      { amount: 300, status: 'succeeded' },
+      { amount: 400 },
+      { amount: 500, status: 'failed' },
+      { amount: 600, status: 'canceled' },
+    ] })).toBe(1_000);
+  });
+
+  it('fails closed for malformed, oversized, or overflowing ledgers', () => {
+    expect(computeRefundedTotal({ refunds: [{ amount: '100' }] })).toBe(Number.MAX_SAFE_INTEGER);
+    expect(computeRefundedTotal({ refunds: [{ amount: 100, status: 'mystery' }] }))
+      .toBe(Number.MAX_SAFE_INTEGER);
+    expect(computeRefundedTotal({ refunds: [
+      { amount: Number.MAX_SAFE_INTEGER },
+      { amount: 1 },
+    ] })).toBe(Number.MAX_SAFE_INTEGER);
+    expect(computeRefundedTotal({ refunds: Array.from({ length: 101 }, () => ({ amount: 1 })) }))
+      .toBe(Number.MAX_SAFE_INTEGER);
+  });
+
+  it('detects unsettled refunds and enforces cumulative safe-integer amounts', () => {
+    expect(hasPendingRefund({ refunds: [{ amount: 1, status: 'requires_action' }] })).toBe(true);
+    expect(assertRefundWithinRemaining(1_000, 400, 600)).toEqual({ ok: true });
+    expect(assertRefundWithinRemaining(1_000, 400, 601)).toMatchObject({ ok: false });
+    expect(assertRefundWithinRemaining(1_000, 0, 1.5)).toMatchObject({ ok: false });
+  });
+
+  it('defines full as exactly the remaining refundable amount', () => {
+    expect(resolveFullRefundAmount(1_000, 350)).toEqual({ ok: true, amount: 650 });
+    expect(resolveFullRefundAmount(1_000, 1_000)).toMatchObject({ ok: false });
+  });
+});

--- a/tests/unit/lib/webhooks/processed-events.test.ts
+++ b/tests/unit/lib/webhooks/processed-events.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from 'vitest';
+import {
+  claimWebhookEvent,
+  cleanupCompletedWebhookEvents,
+  completeWebhookEvent,
+  failWebhookEvent,
+  type ProcessedEventsExecutor,
+} from '@/lib/webhooks/processed-events';
+
+type SqlCall = {
+  query: string;
+  bindings: readonly (string | number | null)[];
+};
+
+class ScriptedExecutor implements ProcessedEventsExecutor {
+  readonly firstCalls: SqlCall[] = [];
+  readonly runCalls: SqlCall[] = [];
+  firstResults: unknown[] = [];
+  runChanges: number[] = [];
+
+  async first<T>(
+    query: string,
+    bindings: readonly (string | number | null)[]
+  ): Promise<T | null> {
+    this.firstCalls.push({ query, bindings });
+    const result = this.firstResults.shift();
+    return (result ?? null) as T | null;
+  }
+
+  async run(
+    query: string,
+    bindings: readonly (string | number | null)[]
+  ): Promise<{ changes: number }> {
+    this.runCalls.push({ query, bindings });
+    return { changes: this.runChanges.shift() ?? 0 };
+  }
+}
+
+const now = new Date('2026-08-05T18:00:00.000Z');
+
+describe('processed webhook event claims', () => {
+  it('uses one conditional upsert and returns acquired ownership', async () => {
+    const executor = new ScriptedExecutor();
+    executor.firstResults.push({
+      claim_token: 'claim_1',
+      attempt_count: 1,
+      lease_expires_at: '2026-08-05T18:05:00.000Z',
+    });
+
+    await expect(claimWebhookEvent({
+      eventId: 'evt_1',
+      eventType: 'payment_intent.succeeded',
+      claimToken: 'claim_1',
+      now,
+    }, executor)).resolves.toEqual({
+      state: 'acquired',
+      claimToken: 'claim_1',
+      attemptCount: 1,
+      leaseExpiresAt: '2026-08-05T18:05:00.000Z',
+    });
+
+    expect(executor.firstCalls).toHaveLength(1);
+    expect(executor.firstCalls[0].query).toContain('ON CONFLICT(event_id) DO UPDATE');
+    expect(executor.firstCalls[0].query).toContain("status = 'failed'");
+    expect(executor.firstCalls[0].query).toContain('lease_expires_at <= ?');
+    expect(executor.firstCalls[0].query).toContain('RETURNING claim_token');
+    expect(executor.firstCalls[0].bindings).toEqual([
+      'evt_1',
+      'payment_intent.succeeded',
+      'claim_1',
+      '2026-08-05T18:00:00.000Z',
+      '2026-08-05T18:05:00.000Z',
+      '2026-08-05T18:00:00.000Z',
+      '2026-08-05T18:00:00.000Z',
+      '2026-08-05T18:00:00.000Z',
+    ]);
+  });
+
+  it('distinguishes completed duplicates from busy/non-terminal rows', async () => {
+    const completedExecutor = new ScriptedExecutor();
+    completedExecutor.firstResults.push(
+      null,
+      { status: 'completed', outcome: 'handled' }
+    );
+    await expect(claimWebhookEvent({
+      eventId: 'evt_done',
+      eventType: 'payment_intent.succeeded',
+      claimToken: 'claim_done',
+      now,
+    }, completedExecutor)).resolves.toEqual({ state: 'completed', outcome: 'handled' });
+
+    const busyExecutor = new ScriptedExecutor();
+    busyExecutor.firstResults.push(
+      null,
+      { status: 'processing', outcome: null }
+    );
+    await expect(claimWebhookEvent({
+      eventId: 'evt_busy',
+      eventType: 'payment_intent.succeeded',
+      claimToken: 'claim_busy',
+      now,
+    }, busyExecutor)).resolves.toEqual({ state: 'busy' });
+  });
+
+  it('rejects invalid lease durations before querying', async () => {
+    const executor = new ScriptedExecutor();
+
+    await expect(claimWebhookEvent({
+      eventId: 'evt_invalid',
+      eventType: 'test',
+      leaseDurationMs: 0,
+      now,
+    }, executor)).rejects.toThrow('positive integer');
+    expect(executor.firstCalls).toHaveLength(0);
+  });
+
+  it('guards completion and failure updates with the owner token', async () => {
+    const executor = new ScriptedExecutor();
+    executor.runChanges.push(1, 0);
+
+    await expect(completeWebhookEvent({
+      eventId: 'evt_1',
+      claimToken: 'owner',
+      outcome: 'handled',
+      now,
+    }, executor)).resolves.toBe(true);
+    await expect(failWebhookEvent({
+      eventId: 'evt_2',
+      claimToken: 'stale',
+      error: new Error('temporary failure'),
+      now,
+    }, executor)).resolves.toBe(false);
+
+    expect(executor.runCalls[0].query).toContain("status = 'processing'");
+    expect(executor.runCalls[0].query).toContain('claim_token = ?');
+    expect(executor.runCalls[0].bindings).toEqual([
+      '2026-08-05T18:00:00.000Z',
+      'handled',
+      '2026-08-05T18:00:00.000Z',
+      'evt_1',
+      'owner',
+    ]);
+    expect(executor.runCalls[1].query).toContain("SET status = 'failed'");
+    expect(executor.runCalls[1].bindings).toEqual([
+      'temporary failure',
+      '2026-08-05T18:00:00.000Z',
+      'evt_2',
+      'stale',
+    ]);
+  });
+
+  it('bounds stored errors and cleans up completed rows only', async () => {
+    const executor = new ScriptedExecutor();
+    executor.runChanges.push(1, 3);
+
+    await failWebhookEvent({
+      eventId: 'evt_error',
+      claimToken: 'owner',
+      error: 'x'.repeat(3_000),
+      now,
+    }, executor);
+    await expect(cleanupCompletedWebhookEvents(now, executor)).resolves.toBe(3);
+
+    expect(executor.runCalls[0].bindings[0]).toHaveLength(2_000);
+    expect(executor.runCalls[1].query).toContain("WHERE status = 'completed'");
+    expect(executor.runCalls[1].query).not.toContain("status = 'failed'");
+  });
+});

--- a/tests/unit/worker-cron-routing.test.ts
+++ b/tests/unit/worker-cron-routing.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+describe('Worker scheduled routing contract', () => {
+  it('routes only the known five-minute and six-hour schedules', () => {
+    const source = readFileSync('worker.ts', 'utf8');
+    const config = readFileSync('wrangler.jsonc', 'utf8');
+
+    expect(config).toContain('"crons": ["*/5 * * * *", "0 */6 * * *"]');
+    expect(source).toContain('controller.cron === "*/5 * * * *"');
+    expect(source).toContain('drainOrderEffects({ database: env.DB, limit: 25 })');
+    expect(source).toContain('controller.cron !== "0 */6 * * *"');
+    expect(source).toContain('ignoring unknown scheduled trigger');
+    expect(source.indexOf('controller.cron !== "0 */6 * * *"'))
+      .toBeLessThan(source.indexOf('regenerateAnalytics(env)'));
+  });
+});

--- a/tests/unit/worker-cron-routing.test.ts
+++ b/tests/unit/worker-cron-routing.test.ts
@@ -9,6 +9,8 @@ describe('Worker scheduled routing contract', () => {
     expect(config).toContain('"crons": ["*/5 * * * *", "0 */6 * * *"]');
     expect(source).toContain('controller.cron === "*/5 * * * *"');
     expect(source).toContain('drainOrderEffects({ database: env.DB, limit: 25 })');
+    expect(source).toContain('drainInventoryAdjustments({ database: env.DB, limit: 25 })');
+    expect(source).toContain('Promise.all([');
     expect(source).toContain('controller.cron !== "0 */6 * * *"');
     expect(source).toContain('ignoring unknown scheduled trigger');
     expect(source.indexOf('controller.cron !== "0 */6 * * *"'))

--- a/vitest.workers.config.mts
+++ b/vitest.workers.config.mts
@@ -1,0 +1,28 @@
+import { fileURLToPath } from 'node:url';
+import { cloudflareTest, readD1Migrations } from '@cloudflare/vitest-pool-workers';
+import { defineConfig } from 'vitest/config';
+
+const migrationsPath = fileURLToPath(new URL('./migrations', import.meta.url));
+const migrations = await readD1Migrations(migrationsPath);
+
+export default defineConfig({
+  plugins: [
+    cloudflareTest({
+      miniflare: {
+        compatibilityDate: '2026-08-01',
+        compatibilityFlags: ['nodejs_compat'],
+        d1Databases: ['DB'],
+        bindings: { TEST_MIGRATIONS: migrations },
+      },
+    }),
+  ],
+  test: {
+    include: ['tests/integration/**/*.test.ts'],
+    clearMocks: true,
+  },
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('.', import.meta.url)),
+    },
+  },
+});

--- a/worker.ts
+++ b/worker.ts
@@ -15,15 +15,30 @@
 // @ts-ignore `.open-next/worker.js` is generated at build time by opennextjs-cloudflare
 import { default as handler } from "./.open-next/worker.js";
 import { regenerateAnalytics } from "@/lib/analytics/generate-insights";
+import { drainOrderEffects } from "@/lib/services/order-effects";
 
 export default {
   fetch: handler.fetch,
 
   async scheduled(
-    _controller: ScheduledController,
+    controller: ScheduledController,
     env: CloudflareEnv,
     ctx: ExecutionContext
   ) {
+    if (controller.cron === "*/5 * * * *") {
+      ctx.waitUntil(
+        drainOrderEffects({ database: env.DB, limit: 25 })
+          .then((result) => console.log("[cron] paid order effects drained", result))
+          .catch((err) => console.error("[cron] paid order effect drain failed:", err))
+      );
+      return;
+    }
+
+    if (controller.cron !== "0 */6 * * *") {
+      console.warn("[cron] ignoring unknown scheduled trigger", controller.cron);
+      return;
+    }
+
     ctx.waitUntil(
       regenerateAnalytics(env)
         .then(() => console.log("[cron] analytics cache regenerated"))

--- a/worker.ts
+++ b/worker.ts
@@ -16,6 +16,7 @@
 import { default as handler } from "./.open-next/worker.js";
 import { regenerateAnalytics } from "@/lib/analytics/generate-insights";
 import { drainOrderEffects } from "@/lib/services/order-effects";
+import { drainInventoryAdjustments } from "@/lib/services/inventory-adjustments";
 
 export default {
   fetch: handler.fetch,
@@ -27,9 +28,14 @@ export default {
   ) {
     if (controller.cron === "*/5 * * * *") {
       ctx.waitUntil(
-        drainOrderEffects({ database: env.DB, limit: 25 })
-          .then((result) => console.log("[cron] paid order effects drained", result))
-          .catch((err) => console.error("[cron] paid order effect drain failed:", err))
+        Promise.all([
+          drainOrderEffects({ database: env.DB, limit: 25 }),
+          drainInventoryAdjustments({ database: env.DB, limit: 25 }),
+        ])
+          .then(([effects, inventory]) =>
+            console.log("[cron] recovery queues drained", { effects, inventory })
+          )
+          .catch((err) => console.error("[cron] recovery queue drain failed:", err))
       );
       return;
     }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -7,8 +7,8 @@
   "name": "mercora",
   "main": "worker.ts",
   "triggers": {
-    // Regenerate the Admin BI dashboard cache every 6 hours.
-    "crons": ["0 */6 * * *"]
+    // Retry paid-order effects every five minutes and regenerate Admin BI every six hours.
+    "crons": ["*/5 * * * *", "0 */6 * * *"]
   },
   "compatibility_date": "2026-08-01",
   "compatibility_flags": [


### PR DESCRIPTION
## Summary

This is the complete U09 contribution: a reusable, Workers-safe checkout, webhook, inventory, and refund correctness layer for Mercora.

- use one memoized Stripe SDK client with fetch/Web Crypto in Node and Cloudflare Workers
- durably claim Stripe events with token-guarded leases, terminal outcomes, and retryable failures
- persist exact server-authored per-line discount and tax allocations
- recover post-payment inventory, coupon, capability, and confirmation-email effects from durable D1 rows
- make `product_variants.inventory` the shared storefront/checkout stock authority
- apply paid decrements and refund restocks exactly once through deterministic adjustment keys
- reserve refunds atomically before Stripe, enforce cumulative balance, and reuse deterministic provider idempotency keys
- reconcile Dashboard and delayed refund lifecycle events without guessing returned lines
- publish migration, webhook, repair, inventory-authority, and future fulfillment-hold operations contracts

## Why

The original demo could lose or repeat important effects when Stripe delivered duplicate events, a Worker isolate stopped between writes, or concurrent refund/inventory requests raced. Checkout also lacked an immutable per-line promotion/tax snapshot, and refund state was appended without a concurrency guard.

This PR moves those boundaries into D1-backed state machines and compare-and-swap operations so retries converge safely.

## Notable behavior

### Webhooks and recovery

- `processed_webhook_events` distinguishes acquired, busy, completed, failed, ignored, and permanent-rejection outcomes.
- Active duplicates return retryable `503`; completed redeliveries are no-ops.
- Five-minute cron recovery drains paid-order effects and inventory adjustments.
- Claim tokens prevent stale owners from completing work after lease takeover.

### Checkout and inventory

- Checkout resolves canonical catalog data and stores exact promotion/tax allocation by stable line id.
- Tracked, non-backorderable inventory is checked before PaymentIntent creation.
- Paid inventory is aggregated by variant and decremented once.
- Variant mutation and terminal adjustment state commit in one D1 batch.
- The separate MACH `inventory` table remains an inactive compatibility surface.

### Refunds

- A versioned refund ledger is reserved with CAS before Stripe is called.
- Pending and `requires_action` refunds reserve balance; failed/canceled refunds release it.
- Provider amount, PaymentIntent, refund id, and currency bindings are validated before settlement.
- `charge.refunded` is authoritative for appending Dashboard refunds and advancing the cumulative Stripe floor.
- Dashboard partial refunds never restock guessed lines.
- Full Dashboard restocking is explicit and defaults off through `refund.external_full_restock_enabled`.
- Refund settlement and deterministic restock-row insertion share one D1 transaction.
- Settlement emails use a provider-stable refund idempotency key.

## Migrations

Apply in numeric order before deploying the matching code:

- `0008_add_processed_webhook_events.sql`
- `0009_add_order_effects.sql`
- `0010_add_inventory_adjustments.sql`
- `0011_add_external_refund_restock_setting.sql`

See `docs/webhooks-refunds-inventory.md` for subscriptions, migration commands, inspection queries, and repair guidance.

## Intentional boundaries

- Mercora still has no shipment command. This PR publishes and tests the exact pending-refund SQL predicate that U13 must place inside its shipment CAS.
- MCP checkout remains outside the trusted paid/inventory boundary until it performs the same PaymentIntent verification.
- Legacy orders without exact line allocations retain explicit operator estimates; the code does not invent historical attribution.

## Validation

Run under Node 24:

- `npm test` — 67 files, 398 tests
- `npm run test:workers` — 7 files, 34 real-D1 tests
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `git diff --check origin/main...HEAD`

The real-D1 suite covers webhook races and lease takeover, transactional rollback, paid-effect recovery, concurrent stock consumption, stale adjustment ownership, atomic refund settlement/restock staging, cumulative refund CAS, exactly-once restocking, migration order, and the future shipment hold predicate.

No BeauTeas content, merchant/customer data, secrets, production identifiers, or subscription-specific behavior is included.