### PR TITLE
feat(mcp): enforce trusted agent commerce

### DIFF
--- a/app/api/mcp/route.ts
+++ b/app/api/mcp/route.ts
@@ -1,7 +1,15 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { authenticateAgent } from '../../../lib/mcp/auth';
+import {
+  authenticateAgent,
+  hasAgentManagementPermission,
+  hasPermission,
+  requiredScopeForTool,
+} from '../../../lib/mcp/auth';
 import { CapabilitiesResponse, MCPToolResponse } from '../../../lib/mcp/types';
+import { getCatalogCapabilities } from '../../../lib/mcp/catalog';
+import { parseAgentContext } from '../../../lib/mcp/context';
 import { createHttpErrorResponse } from '../../../lib/mcp/error-handler';
+import { isPlainRecord } from '../../../lib/public-request-validation';
 
 export async function GET(request: NextRequest) {
   // MCP Server Discovery endpoint
@@ -12,17 +20,7 @@ export async function GET(request: NextRequest) {
       return createHttpErrorResponse(auth.error?.message || 'Authentication failed', 401);
     }
 
-    // Simple capabilities response for now
-    const capabilities: CapabilitiesResponse = {
-      categories: ['Tents & Shelters', 'Sleeping Systems', 'Backpacks', 'Lighting', 'Cooking & Stoves'],
-      price_ranges: {
-        'Tents & Shelters': { min: 89, max: 899 },
-        'Sleeping Systems': { min: 79, max: 549 },
-        'Backpacks': { min: 89, max: 449 }
-      },
-      shipping_regions: ['Continental US', 'Alaska & Hawaii', 'Canada'],
-      specialties: ['Ultralight backpacking gear', 'Car camping essentials', 'Hiking equipment']
-    };
+    const capabilities: CapabilitiesResponse = await getCatalogCapabilities();
 
     const response: MCPToolResponse<CapabilitiesResponse> = {
       success: true,
@@ -50,16 +48,55 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
-  // MCP Tool execution endpoint
-  const auth = await authenticateAgent(request);
+  let body: any;
+  try {
+    body = await request.json();
+  } catch {
+    return createHttpErrorResponse('Invalid JSON body', 400);
+  }
+
+  if (!body || typeof body !== 'object') {
+    return createHttpErrorResponse('Invalid JSON body', 400);
+  }
+
+  const tool = typeof body.tool === 'string' ? body.tool : '';
+  if (!tool) return createHttpErrorResponse('tool is required', 400);
+  if (body.params != null && !isPlainRecord(body.params)) {
+    return createHttpErrorResponse('params must be an object', 400);
+  }
+  if (body.session_id != null && typeof body.session_id !== 'string') {
+    return createHttpErrorResponse('session_id must be a string', 400);
+  }
+  const params: any = body.params ?? {};
+  const session_id = body.session_id as string | undefined;
+  const auth = await authenticateAgent(request, { isOrderOp: tool === 'place_order' });
   
   if (!auth.success) {
     return createHttpErrorResponse(auth.error?.message || 'Authentication failed', 401);
   }
 
+  params.agent_context = parseAgentContext(request, auth.agentId) ?? { agentId: auth.agentId! };
+
+  const managementTools = new Set([
+    'create_agent',
+    'list_agents',
+    'get_agent_details',
+    'update_agent_status',
+    'rotate_agent_key',
+  ]);
+  if (managementTools.has(tool) && !hasAgentManagementPermission(auth.permissions)) {
+    return createHttpErrorResponse(
+      'Agent management requires admin or agents:manage permission',
+      403,
+    );
+  }
+
+  const requiredScope = requiredScopeForTool(tool);
+  if (requiredScope && !hasPermission(auth.permissions, requiredScope)) {
+    return createHttpErrorResponse(`This tool requires '${requiredScope}' permission`, 403);
+  }
+
   try {
-    const body = await request.json() as any;
-    const { tool, params, session_id } = body;
 
     // Route to appropriate tool handler
     switch (tool) {
@@ -77,15 +114,15 @@ export async function POST(request: NextRequest) {
 
       case 'add_to_cart':
         const { addToCart } = await import('../../../lib/mcp/tools/cart');
-        return NextResponse.json(await addToCart({ ...params, sessionId: session_id }, session_id || 'temp'));
+        return NextResponse.json(await addToCart({ ...params, sessionId: session_id || 'temp' }, session_id || 'temp', auth.agentId!));
 
       case 'update_cart':
         const { updateCart } = await import('../../../lib/mcp/tools/cart');
-        return NextResponse.json(await updateCart({ ...params, sessionId: session_id }, session_id || 'temp'));
+        return NextResponse.json(await updateCart({ ...params, sessionId: session_id || 'temp' }, session_id || 'temp', auth.agentId!));
 
       case 'remove_from_cart':
         const { removeFromCart } = await import('../../../lib/mcp/tools/cart');
-        return NextResponse.json(await removeFromCart({ ...params, sessionId: session_id }, session_id || 'temp'));
+        return NextResponse.json(await removeFromCart({ ...params, sessionId: session_id || 'temp' }, session_id || 'temp', auth.agentId!));
 
       case 'get_cart':
         const { getCartEstimate } = await import('../../../lib/mcp/tools/cart');
@@ -93,7 +130,7 @@ export async function POST(request: NextRequest) {
 
       case 'bulk_add_to_cart':
         const { bulkAddToCart } = await import('../../../lib/mcp/tools/cart');
-        return NextResponse.json(await bulkAddToCart({ ...params, sessionId: session_id }, session_id || 'temp'));
+        return NextResponse.json(await bulkAddToCart({ ...params, sessionId: session_id || 'temp' }, session_id || 'temp', auth.agentId!));
 
       case 'clear_cart':
         const { clearCart } = await import('../../../lib/mcp/tools/cart');
@@ -101,7 +138,11 @@ export async function POST(request: NextRequest) {
 
       case 'place_order':
         const { placeOrder } = await import('../../../lib/mcp/tools/order');
-        return NextResponse.json(await placeOrder(params, session_id || 'temp'));
+        return NextResponse.json(await placeOrder(params, session_id || 'temp', auth.agentId!));
+
+      case 'create_payment_intent':
+        const { createAgentPaymentIntent } = await import('../../../lib/mcp/tools/payment');
+        return NextResponse.json(await createAgentPaymentIntent(params, session_id || 'temp', auth.agentId!));
 
       case 'get_order_status':
         const { getOrderStatus } = await import('../../../lib/mcp/tools/order');
@@ -109,15 +150,15 @@ export async function POST(request: NextRequest) {
 
       case 'get_shipping_options':
         const { getShippingOptions } = await import('../../../lib/mcp/tools/shipping');
-        return NextResponse.json(await getShippingOptions(params, session_id || 'temp'));
+        return NextResponse.json(await getShippingOptions(params, session_id || 'temp', auth.agentId!));
 
       case 'validate_payment':
         const { validatePayment } = await import('../../../lib/mcp/tools/payment');
-        return NextResponse.json(await validatePayment(params, session_id || 'temp'));
+        return NextResponse.json(await validatePayment(params, session_id || 'temp', auth.agentId!));
 
       case 'create_agent':
         const { createAgent } = await import('../../../lib/mcp/tools/agent');
-        return NextResponse.json(await createAgent(params, session_id || 'temp', auth.agentId!));
+        return NextResponse.json(await createAgent(params, session_id || 'temp', auth.agentId!, auth.permissions));
 
       case 'list_agents':
         const { listAgents } = await import('../../../lib/mcp/tools/agent');
@@ -129,11 +170,27 @@ export async function POST(request: NextRequest) {
 
       case 'update_agent_status':
         const { updateAgentStatus } = await import('../../../lib/mcp/tools/agent');
-        return NextResponse.json(await updateAgentStatus(params.agentId, params.isActive, session_id || 'temp', auth.agentId!));
+        return NextResponse.json(await updateAgentStatus(
+          params.agentId,
+          params.isActive,
+          session_id || 'temp',
+          auth.agentId!,
+          auth.permissions,
+        ));
+
+      case 'rotate_agent_key':
+        const { rotateAgentCredential } = await import('../../../lib/mcp/tools/agent');
+        return NextResponse.json(await rotateAgentCredential(
+          params.agentId,
+          params.apiKeyTtlDays,
+          session_id || 'temp',
+          auth.agentId!,
+          auth.permissions,
+        ));
 
       default:
         return createHttpErrorResponse(
-          `Unknown tool: ${tool}. Available tools: search_products, assess_request, get_recommendations, add_to_cart, update_cart, remove_from_cart, get_cart, bulk_add_to_cart, clear_cart, place_order, get_order_status, get_shipping_options, validate_payment, create_agent, list_agents, get_agent_details, update_agent_status`,
+          `Unknown tool: ${tool}. Available tools: search_products, assess_request, get_recommendations, add_to_cart, update_cart, remove_from_cart, get_cart, bulk_add_to_cart, clear_cart, create_payment_intent, place_order, get_order_status, get_shipping_options, validate_payment, create_agent, list_agents, get_agent_details, update_agent_status, rotate_agent_key`,
           400
         );
     }

--- a/app/api/mcp/schema/route.ts
+++ b/app/api/mcp/schema/route.ts
@@ -3,13 +3,13 @@ import { NextRequest, NextResponse } from 'next/server';
 export async function GET(request: NextRequest) {
   // MCP Server Schema Documentation
   const schema = {
-    name: "voltique-mcp-server",
+    name: "mercora-mcp-server",
     version: "1.0.0",
-    description: "Voltique MCP Server for multi-agent outdoor gear commerce",
+    description: "Mercora MCP server for agent-assisted commerce",
     capabilities: {
       tools: true,
       resources: false,
-      prompts: true
+      prompts: false
     },
     tools: [
       {
@@ -25,8 +25,8 @@ export async function GET(request: NextRequest) {
                 category: { type: "string" },
                 priceMin: { type: "number" },
                 priceMax: { type: "number" },
-                limit: { type: "number", default: 10 },
-                sortBy: { type: "string", enum: ["price", "rating", "popularity"] }
+                limit: { type: "number", minimum: 1, maximum: 100, default: 10 },
+                sortBy: { type: "string", enum: ["price"] }
               }
             },
             session_id: { type: "string", description: "Agent session ID" }
@@ -43,7 +43,7 @@ export async function GET(request: NextRequest) {
             requirements: {
               type: "object",
               properties: {
-                items: { type: "array", items: { type: "string" } },
+                items: { type: "array", minItems: 1, maxItems: 20, items: { type: "string" } },
                 budget: { type: "number" },
                 timeline: { type: "string" },
                 location: { type: "string" }
@@ -159,41 +159,44 @@ export async function GET(request: NextRequest) {
         }
       },
       {
-        name: "place_order",
-        description: "Place order with agent context and budget validation",
+        name: "create_payment_intent",
+        description: "Create a server-priced pending order and bound Stripe PaymentIntent",
         inputSchema: {
           type: "object",
           properties: {
             shippingAddress: {
               type: "object",
               properties: {
-                street: { type: "string" },
-                street2: { type: "string" },
+                line1: { type: "string" },
+                line2: { type: "string" },
                 city: { type: "string" },
-                state: { type: "string" },
+                region: { type: "string" },
                 postal_code: { type: "string" },
-                country: { type: "string", default: "US" }
+                country: { type: "string", default: "US" },
+                recipient: { type: "string" },
+                email: { type: "string" }
               },
-              required: ["street", "city", "state", "postal_code"]
+              required: ["line1", "city", "region", "postal_code"]
             },
-            billingAddress: { 
-              type: "object",
-              description: "Optional, defaults to shipping address"
-            },
-            paymentMethod: { 
-              type: "string", 
-              default: "agent-processed",
-              description: "Payment method identifier"
-            },
-            shippingOption: { 
-              type: "string", 
-              default: "standard",
-              enum: ["standard", "expedited", "overnight"]
-            },
-            specialInstructions: { type: "string" },
+            shippingMethodId: { type: "string" },
+            discountCodes: { type: "array", items: { type: "string" } },
+            giftCardToken: { type: "string" },
             session_id: { type: "string" }
           },
-          required: ["shippingAddress", "session_id"]
+          required: ["shippingAddress", "shippingMethodId", "session_id"]
+        }
+      },
+      {
+        name: "place_order",
+        description: "Finalize a server-created pending order after verified payment",
+        inputSchema: {
+          type: "object",
+          properties: {
+            orderId: { type: "string" },
+            paymentIntentId: { type: "string" },
+            session_id: { type: "string" }
+          },
+          required: ["orderId", "paymentIntentId", "session_id"]
         }
       },
       {
@@ -216,32 +219,18 @@ export async function GET(request: NextRequest) {
             address: {
               type: "object",
               properties: {
-                street: { type: "string" },
-                street2: { type: "string" },
+                line1: { type: "string" },
+                line2: { type: "string" },
                 city: { type: "string" },
-                state: { type: "string" },
+                region: { type: "string" },
                 postal_code: { type: "string" },
                 country: { type: "string", default: "US" }
               },
-              required: ["street", "city", "state", "postal_code"]
-            },
-            cart: {
-              type: "array",
-              description: "Optional cart items (uses session cart if not provided)",
-              items: {
-                type: "object",
-                properties: {
-                  productId: { type: "number" },
-                  variantId: { type: "number" },
-                  quantity: { type: "number" },
-                  name: { type: "string" },
-                  price: { type: "number" }
-                }
-              }
+              required: ["line1", "city", "region", "postal_code"]
             },
             session_id: { type: "string" }
           },
-          required: ["address"]
+          required: ["address", "session_id"]
         }
       },
       {
@@ -252,41 +241,23 @@ export async function GET(request: NextRequest) {
           properties: {
             payment_method: {
               type: "string",
-              enum: ["agent_processed", "credit_card", "paypal", "bank_transfer"],
+              enum: ["stripe"],
               description: "Payment method to validate"
             },
             billing_address: {
               type: "object",
               properties: {
-                street: { type: "string" },
-                street2: { type: "string" },
+                line1: { type: "string" },
+                line2: { type: "string" },
                 city: { type: "string" },
-                state: { type: "string" },
+                region: { type: "string" },
                 postal_code: { type: "string" },
                 country: { type: "string", default: "US" }
               }
             },
-            cart: {
-              type: "array",
-              description: "Optional cart items (uses session cart if not provided)",
-              items: {
-                type: "object",
-                properties: {
-                  productId: { type: "number" },
-                  variantId: { type: "number" },
-                  quantity: { type: "number" },
-                  name: { type: "string" },
-                  price: { type: "number" }
-                }
-              }
-            },
-            total_amount: { 
-              type: "number",
-              description: "Total amount to validate payment for"
-            },
             session_id: { type: "string" }
           },
-          required: ["payment_method", "total_amount"]
+          required: ["payment_method", "session_id"]
         }
       },
       {
@@ -320,14 +291,34 @@ export async function GET(request: NextRequest) {
               type: "number",
               description: "Operations per hour limit (default: 10)"
             },
+            apiKeyTtlDays: {
+              type: "number",
+              minimum: 1,
+              maximum: 365,
+              default: 90,
+              description: "Credential lifetime in days"
+            },
             session_id: { type: "string" }
           },
           required: ["agentId", "name"]
         }
       },
       {
+        name: "rotate_agent_key",
+        description: "Rotate an agent API key and return the replacement once",
+        inputSchema: {
+          type: "object",
+          properties: {
+            agentId: { type: "string" },
+            apiKeyTtlDays: { type: "number", minimum: 1, maximum: 365 },
+            session_id: { type: "string" }
+          },
+          required: ["agentId"]
+        }
+      },
+      {
         name: "list_agents",
-        description: "List all MCP agents with stats and pagination",
+        description: "List MCP agents with bounded pagination",
         inputSchema: {
           type: "object",
           properties: {
@@ -374,13 +365,13 @@ export async function GET(request: NextRequest) {
             },
             session_id: { type: "string" }
           },
-          required: ["agentId", "isActive"]
+          required: ["agentId"]
         }
       }
     ],
     authentication: {
       type: "api_key",
-      description: "Agent API key required in X-Agent-API-Key header",
+      description: "Agent API key required in X-Agent-API-Key or Authorization: Bearer header",
       rate_limits: {
         requests_per_minute: 100,
         orders_per_hour: 10
@@ -391,7 +382,7 @@ export async function GET(request: NextRequest) {
       schema: {
         type: "object",
         properties: {
-          agentId: { type: "string", required: true },
+          agentId: { type: "string", description: "Ignored and replaced by authenticated identity" },
           userId: { type: "string" },
           userPreferences: {
             type: "object",
@@ -444,13 +435,14 @@ export async function GET(request: NextRequest) {
     },
     examples: {
       multi_agent_workflow: [
-        "1. assess_request - Determine what items Voltique can fulfill",
-        "2. bulk_add_to_cart - Add all Voltique items efficiently", 
+        "1. assess_request - Determine what items this store can fulfill",
+        "2. bulk_add_to_cart - Add purchasable items efficiently",
         "3. get_cart - Validate totals against budget",
         "4. get_shipping_options - Compare shipping methods and costs",
-        "5. validate_payment - Verify payment method and calculate fees",
-        "6. place_order - Complete purchase with user address",
-        "7. get_order_status - Monitor delivery progress"
+        "5. create_payment_intent - Create the authoritative quote and pending order",
+        "6. Complete the returned Stripe PaymentIntent",
+        "7. place_order - Verify payment and finalize the order",
+        "8. get_order_status - Monitor order progress"
       ]
     }
   };

--- a/app/api/mcp/sessions/[sessionId]/route.ts
+++ b/app/api/mcp/sessions/[sessionId]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getSession, updateSession, deleteSession } from '../../../../../lib/mcp/session';
 import { authenticateAgent } from '../../../../../lib/mcp/auth';
+import { parseAgentContext } from '../../../../../lib/mcp/context';
 import { MCPToolResponse, AgentSession } from '../../../../../lib/mcp/types';
 
 export async function GET(
@@ -109,8 +110,28 @@ export async function PUT(
       }, { status: 403 });
     }
 
-    const updateData = await request.json() as any;
-    const success = await updateSession(sessionId, updateData);
+    // Session carts are changed only through scoped cart tools, which reload
+    // canonical catalog data. This endpoint updates bounded context only.
+    if (!request.headers.get('X-Agent-Context')) {
+      return NextResponse.json({
+        success: false,
+        error: {
+          code: 'INVALID_REQUEST',
+          message: 'X-Agent-Context is required for session updates'
+        }
+      }, { status: 400 });
+    }
+    const agentContext = parseAgentContext(request, auth.agentId);
+    if (!agentContext) {
+      return NextResponse.json({
+        success: false,
+        error: {
+          code: 'INVALID_REQUEST',
+          message: 'X-Agent-Context is invalid'
+        }
+      }, { status: 400 });
+    }
+    const success = await updateSession(sessionId, { userContext: agentContext });
     
     if (!success) {
       throw new Error('Failed to update session');

--- a/app/api/mcp/sessions/route.ts
+++ b/app/api/mcp/sessions/route.ts
@@ -16,7 +16,7 @@ export async function POST(request: NextRequest) {
   }
 
   try {
-    const agentContext = parseAgentContext(request);
+    const agentContext = parseAgentContext(request, auth.agentId);
     const session = await createSession(auth.agentId!, agentContext || undefined);
     
     const response: MCPToolResponse<AgentSession> = {

--- a/app/api/mcp/tools/agents/[agentId]/route.ts
+++ b/app/api/mcp/tools/agents/[agentId]/route.ts
@@ -1,6 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { authenticateAgent } from '../../../../../../lib/mcp/auth';
-import { getAgentDetails, updateAgentStatus } from '../../../../../../lib/mcp/tools/agent';
+import { authenticateAgent, hasAgentManagementPermission } from '../../../../../../lib/mcp/auth';
+import { getAgentDetails, rotateAgentCredential, updateAgentStatus } from '../../../../../../lib/mcp/tools/agent';
+
+const forbiddenResponse = {
+  success: false,
+  error: {
+    code: 'FORBIDDEN',
+    message: 'Agent management requires admin or agents:manage permission',
+  },
+} as const;
 
 export async function GET(
   request: NextRequest,
@@ -13,6 +21,10 @@ export async function GET(
       success: false,
       error: auth.error
     }, { status: 401 });
+  }
+
+  if (!hasAgentManagementPermission(auth.permissions)) {
+    return NextResponse.json(forbiddenResponse, { status: 403 });
   }
 
   try {
@@ -48,27 +60,43 @@ export async function PATCH(
     }, { status: 401 });
   }
 
+  if (!hasAgentManagementPermission(auth.permissions)) {
+    return NextResponse.json(forbiddenResponse, { status: 403 });
+  }
+
   try {
     const { agentId } = await params;
     const body = await request.json() as any;
     
-    // Currently only support status updates
+    const sessionId = body.session_id || 'temp';
+
+    if (body.rotateApiKey === true) {
+      const result = await rotateAgentCredential(
+        agentId,
+        body.apiKeyTtlDays,
+        sessionId,
+        auth.agentId!,
+        auth.permissions,
+      );
+      return NextResponse.json(result);
+    }
+
     if (typeof body.isActive !== 'boolean') {
       return NextResponse.json({
         success: false,
         error: {
           code: 'INVALID_REQUEST',
-          message: 'isActive boolean field is required'
+          message: 'isActive boolean or rotateApiKey=true is required'
         }
       }, { status: 400 });
     }
     
-    const sessionId = body.session_id || 'temp';
     const result = await updateAgentStatus(
       agentId,
       body.isActive,
       sessionId,
-      auth.agentId!
+      auth.agentId!,
+      auth.permissions,
     );
     
     return NextResponse.json(result);

--- a/app/api/mcp/tools/agents/create/route.ts
+++ b/app/api/mcp/tools/agents/create/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { authenticateAgent } from '../../../../../../lib/mcp/auth';
-import { parseAgentContext } from '../../../../../../lib/mcp/context';
+import { authenticateAgent, hasAgentManagementPermission } from '../../../../../../lib/mcp/auth';
 import { createAgent } from '../../../../../../lib/mcp/tools/agent';
 
 export async function POST(request: NextRequest) {
@@ -13,9 +12,18 @@ export async function POST(request: NextRequest) {
     }, { status: 401 });
   }
 
+  if (!hasAgentManagementPermission(auth.permissions)) {
+    return NextResponse.json({
+      success: false,
+      error: {
+        code: 'FORBIDDEN',
+        message: 'Agent management requires admin or agents:manage permission',
+      },
+    }, { status: 403 });
+  }
+
   try {
     const body = await request.json() as any;
-    const agentContext = parseAgentContext(request);
     
     // Validate required fields
     if (!body.agentId) {
@@ -44,11 +52,12 @@ export async function POST(request: NextRequest) {
       description: body.description,
       permissions: body.permissions,
       rateLimitRpm: body.rateLimitRpm,
-      rateLimitOph: body.rateLimitOph
+      rateLimitOph: body.rateLimitOph,
+      apiKeyTtlDays: body.apiKeyTtlDays,
     };
 
     const sessionId = body.session_id || 'temp';
-    const result = await createAgent(createRequest, sessionId, auth.agentId!);
+    const result = await createAgent(createRequest, sessionId, auth.agentId!, auth.permissions);
     
     return NextResponse.json(result);
   } catch (error) {

--- a/app/api/mcp/tools/agents/list/route.ts
+++ b/app/api/mcp/tools/agents/list/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { authenticateAgent } from '../../../../../../lib/mcp/auth';
+import { authenticateAgent, hasAgentManagementPermission } from '../../../../../../lib/mcp/auth';
 import { listAgents } from '../../../../../../lib/mcp/tools/agent';
 
 export async function GET(request: NextRequest) {
@@ -12,6 +12,16 @@ export async function GET(request: NextRequest) {
     }, { status: 401 });
   }
 
+  if (!hasAgentManagementPermission(auth.permissions)) {
+    return NextResponse.json({
+      success: false,
+      error: {
+        code: 'FORBIDDEN',
+        message: 'Agent management requires admin or agents:manage permission',
+      },
+    }, { status: 403 });
+  }
+
   try {
     const { searchParams } = request.nextUrl;
     const page = parseInt(searchParams.get('page') || '1');
@@ -19,7 +29,7 @@ export async function GET(request: NextRequest) {
     const sessionId = searchParams.get('session_id') || 'temp';
     
     // Validate pagination parameters
-    if (page < 1) {
+    if (!Number.isSafeInteger(page) || page < 1) {
       return NextResponse.json({
         success: false,
         error: {
@@ -29,7 +39,7 @@ export async function GET(request: NextRequest) {
       }, { status: 400 });
     }
     
-    if (limit < 1 || limit > 100) {
+    if (!Number.isSafeInteger(limit) || limit < 1 || limit > 100) {
       return NextResponse.json({
         success: false,
         error: {

--- a/app/api/mcp/tools/assess/route.ts
+++ b/app/api/mcp/tools/assess/route.ts
@@ -16,7 +16,7 @@ export async function POST(request: NextRequest) {
 
   try {
     const body = await request.json() as any;
-    const agentContext = parseAgentContext(request);
+    const agentContext = parseAgentContext(request, auth.agentId);
     
     const assessRequest: AssessRequest = {
       ...body,

--- a/app/api/mcp/tools/cart/add/route.ts
+++ b/app/api/mcp/tools/cart/add/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { authenticateAgent } from '../../../../../../lib/mcp/auth';
+import { authenticateAgent, hasPermission, requiredScopeForTool } from '../../../../../../lib/mcp/auth';
 import { parseAgentContext } from '../../../../../../lib/mcp/context';
 import { addToCart } from '../../../../../../lib/mcp/tools/cart';
 import { CartRequest } from '../../../../../../lib/mcp/types';
@@ -14,9 +14,14 @@ export async function POST(request: NextRequest) {
     }, { status: 401 });
   }
 
+  const requiredScope = requiredScopeForTool('add_to_cart')!;
+  if (!hasPermission(auth.permissions, requiredScope)) {
+    return NextResponse.json({ success: false, error: { code: 'FORBIDDEN', message: 'This tool requires write:cart permission' } }, { status: 403 });
+  }
+
   try {
     const body = await request.json() as any;
-    const agentContext = parseAgentContext(request);
+    const agentContext = parseAgentContext(request, auth.agentId);
     
     const cartRequest: CartRequest & { sessionId: string } = {
       ...body,
@@ -24,7 +29,7 @@ export async function POST(request: NextRequest) {
     };
 
     const sessionId = body.session_id || 'temp';
-    const result = await addToCart(cartRequest, sessionId);
+    const result = await addToCart(cartRequest, sessionId, auth.agentId!);
     
     return NextResponse.json(result);
   } catch (error) {

--- a/app/api/mcp/tools/cart/bulk-add/route.ts
+++ b/app/api/mcp/tools/cart/bulk-add/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { authenticateAgent } from '../../../../../../lib/mcp/auth';
+import { authenticateAgent, hasPermission, requiredScopeForTool } from '../../../../../../lib/mcp/auth';
 import { parseAgentContext } from '../../../../../../lib/mcp/context';
 import { bulkAddToCart } from '../../../../../../lib/mcp/tools/cart';
 import { CartRequest } from '../../../../../../lib/mcp/types';
@@ -14,9 +14,14 @@ export async function POST(request: NextRequest) {
     }, { status: 401 });
   }
 
+  const requiredScope = requiredScopeForTool('bulk_add_to_cart')!;
+  if (!hasPermission(auth.permissions, requiredScope)) {
+    return NextResponse.json({ success: false, error: { code: 'FORBIDDEN', message: 'This tool requires write:cart permission' } }, { status: 403 });
+  }
+
   try {
     const body = await request.json() as any;
-    const agentContext = parseAgentContext(request);
+    const agentContext = parseAgentContext(request, auth.agentId);
     
     if (!body.items || !Array.isArray(body.items)) {
       return NextResponse.json({
@@ -35,7 +40,7 @@ export async function POST(request: NextRequest) {
     };
 
     const sessionId = body.session_id || 'temp';
-    const result = await bulkAddToCart(bulkRequest, sessionId);
+    const result = await bulkAddToCart(bulkRequest, sessionId, auth.agentId!);
     
     return NextResponse.json(result);
   } catch (error) {

--- a/app/api/mcp/tools/cart/clear/route.ts
+++ b/app/api/mcp/tools/cart/clear/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { authenticateAgent } from '../../../../../../lib/mcp/auth';
+import { authenticateAgent, hasPermission, requiredScopeForTool } from '../../../../../../lib/mcp/auth';
 import { clearCart } from '../../../../../../lib/mcp/tools/cart';
 
 export async function POST(request: NextRequest) {
@@ -10,6 +10,11 @@ export async function POST(request: NextRequest) {
       success: false,
       error: auth.error
     }, { status: 401 });
+  }
+
+  const requiredScope = requiredScopeForTool('clear_cart')!;
+  if (!hasPermission(auth.permissions, requiredScope)) {
+    return NextResponse.json({ success: false, error: { code: 'FORBIDDEN', message: 'This tool requires write:cart permission' } }, { status: 403 });
   }
 
   try {

--- a/app/api/mcp/tools/cart/remove/route.ts
+++ b/app/api/mcp/tools/cart/remove/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { authenticateAgent } from '../../../../../../lib/mcp/auth';
+import { authenticateAgent, hasPermission, requiredScopeForTool } from '../../../../../../lib/mcp/auth';
 import { parseAgentContext } from '../../../../../../lib/mcp/context';
 import { removeFromCart } from '../../../../../../lib/mcp/tools/cart';
 import { CartRequest } from '../../../../../../lib/mcp/types';
@@ -14,9 +14,14 @@ export async function POST(request: NextRequest) {
     }, { status: 401 });
   }
 
+  const requiredScope = requiredScopeForTool('remove_from_cart')!;
+  if (!hasPermission(auth.permissions, requiredScope)) {
+    return NextResponse.json({ success: false, error: { code: 'FORBIDDEN', message: 'This tool requires write:cart permission' } }, { status: 403 });
+  }
+
   try {
     const body = await request.json() as any;
-    const agentContext = parseAgentContext(request);
+    const agentContext = parseAgentContext(request, auth.agentId);
     
     const cartRequest: CartRequest & { sessionId: string } = {
       ...body,
@@ -24,7 +29,7 @@ export async function POST(request: NextRequest) {
     };
 
     const sessionId = body.session_id || 'temp';
-    const result = await removeFromCart(cartRequest, sessionId);
+    const result = await removeFromCart(cartRequest, sessionId, auth.agentId!);
     
     return NextResponse.json(result);
   } catch (error) {

--- a/app/api/mcp/tools/cart/update/route.ts
+++ b/app/api/mcp/tools/cart/update/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { authenticateAgent } from '../../../../../../lib/mcp/auth';
+import { authenticateAgent, hasPermission, requiredScopeForTool } from '../../../../../../lib/mcp/auth';
 import { parseAgentContext } from '../../../../../../lib/mcp/context';
 import { updateCart } from '../../../../../../lib/mcp/tools/cart';
 import { CartRequest } from '../../../../../../lib/mcp/types';
@@ -14,9 +14,14 @@ export async function POST(request: NextRequest) {
     }, { status: 401 });
   }
 
+  const requiredScope = requiredScopeForTool('update_cart')!;
+  if (!hasPermission(auth.permissions, requiredScope)) {
+    return NextResponse.json({ success: false, error: { code: 'FORBIDDEN', message: 'This tool requires write:cart permission' } }, { status: 403 });
+  }
+
   try {
     const body = await request.json() as any;
-    const agentContext = parseAgentContext(request);
+    const agentContext = parseAgentContext(request, auth.agentId);
     
     const cartRequest: CartRequest & { sessionId: string } = {
       ...body,
@@ -24,7 +29,7 @@ export async function POST(request: NextRequest) {
     };
 
     const sessionId = body.session_id || 'temp';
-    const result = await updateCart(cartRequest, sessionId);
+    const result = await updateCart(cartRequest, sessionId, auth.agentId!);
     
     return NextResponse.json(result);
   } catch (error) {

--- a/app/api/mcp/tools/order/place/route.ts
+++ b/app/api/mcp/tools/order/place/route.ts
@@ -1,11 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { authenticateAgent } from '../../../../../../lib/mcp/auth';
+import { authenticateAgent, hasPermission, requiredScopeForTool } from '../../../../../../lib/mcp/auth';
 import { parseAgentContext } from '../../../../../../lib/mcp/context';
 import { placeOrder } from '../../../../../../lib/mcp/tools/order';
 import { OrderRequest } from '../../../../../../lib/mcp/types';
 
 export async function POST(request: NextRequest) {
-  const auth = await authenticateAgent(request);
+  const auth = await authenticateAgent(request, { isOrderOp: true });
   
   if (!auth.success) {
     return NextResponse.json({
@@ -14,9 +14,17 @@ export async function POST(request: NextRequest) {
     }, { status: 401 });
   }
 
+  const requiredScope = requiredScopeForTool('place_order')!;
+  if (!hasPermission(auth.permissions, requiredScope)) {
+    return NextResponse.json({
+      success: false,
+      error: { code: 'FORBIDDEN', message: 'This tool requires place:orders permission' },
+    }, { status: 403 });
+  }
+
   try {
     const body = await request.json() as any;
-    const agentContext = parseAgentContext(request);
+    const agentContext = parseAgentContext(request, auth.agentId);
     
     const orderRequest: OrderRequest = {
       ...body,
@@ -24,7 +32,7 @@ export async function POST(request: NextRequest) {
     };
 
     const sessionId = body.session_id || 'temp';
-    const result = await placeOrder(orderRequest, sessionId);
+    const result = await placeOrder(orderRequest, sessionId, auth.agentId!);
     
     return NextResponse.json(result);
   } catch (error) {

--- a/app/api/mcp/tools/order/track/route.ts
+++ b/app/api/mcp/tools/order/track/route.ts
@@ -1,142 +1,90 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { authenticateAgent } from '../../../../../../lib/mcp/auth';
-import { MCPToolResponse } from '../../../../../../lib/mcp/types';
+import { getOrderStatus } from '../../../../../../lib/mcp/tools/order';
+import type { MCPToolResponse } from '../../../../../../lib/mcp/types';
 
 interface TrackingResponse {
   orderId: string;
   trackingNumber?: string;
   status: string;
-  location?: string;
   estimatedDelivery: string;
-  history: Array<{
-    date: string;
-    status: string;
-    location?: string;
-    description: string;
-  }>;
+  history: Array<never>;
+}
+
+async function projectOwnedOrder(
+  orderId: string,
+  agentId: string,
+): Promise<NextResponse> {
+  const result = await getOrderStatus(orderId, agentId);
+  if (!result.success) return NextResponse.json(result, { status: 404 });
+
+  const response: MCPToolResponse<TrackingResponse> = {
+    success: true,
+    data: {
+      orderId: result.data.orderId,
+      trackingNumber: result.data.tracking_number,
+      status: result.data.status,
+      estimatedDelivery: result.data.estimated_delivery,
+      // Carrier events ship with the fulfillment vertical slice. An empty
+      // history is truthful; generated locations and events are not.
+      history: [],
+    },
+    context: result.context,
+    metadata: {
+      ...result.metadata,
+      next_actions: result.data.tracking_number
+        ? ['Use the configured carrier tracking experience']
+        : ['Check back after the order ships'],
+    },
+  };
+  return NextResponse.json(response);
 }
 
 export async function GET(request: NextRequest) {
   const auth = await authenticateAgent(request);
-  
   if (!auth.success) {
-    return NextResponse.json({
-      success: false,
-      error: auth.error
-    }, { status: 401 });
+    return NextResponse.json({ success: false, error: auth.error }, { status: 401 });
   }
 
-  try {
-    const orderId = request.nextUrl.searchParams.get('orderId');
-    const trackingNumber = request.nextUrl.searchParams.get('trackingNumber');
-    
-    if (!orderId && !trackingNumber) {
-      return NextResponse.json({
-        success: false,
-        error: {
-          code: 'MISSING_IDENTIFIER',
-          message: 'orderId or trackingNumber parameter is required'
-        }
-      }, { status: 400 });
-    }
-
-    // Mock tracking data - in production, integrate with shipping provider
-    const trackingData: TrackingResponse = {
-      orderId: orderId || 'unknown',
-      trackingNumber: trackingNumber || `VT${Date.now()}`,
-      status: 'in_transit',
-      location: 'Oakland, CA',
-      estimatedDelivery: '2 business days',
-      history: [
-        {
-          date: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString(),
-          status: 'order_confirmed',
-          description: 'Order confirmed and processing'
-        },
-        {
-          date: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000).toISOString(),
-          status: 'shipped',
-          location: 'Warehouse, CA',
-          description: 'Package shipped from warehouse'
-        },
-        {
-          date: new Date().toISOString(),
-          status: 'in_transit',
-          location: 'Oakland, CA',
-          description: 'Package in transit to destination'
-        }
-      ]
-    };
-
-    const response: MCPToolResponse<TrackingResponse> = {
-      success: true,
-      data: trackingData,
-      context: {
-        session_id: 'tracking',
-        agent_id: auth.agentId!,
-        processing_time_ms: Date.now() - Date.now()
-      },
-      metadata: {
-        can_fulfill_percentage: 100,
-        estimated_satisfaction: 95,
-        next_actions: ['Monitor delivery progress', 'Prepare for package arrival']
-      }
-    };
-    
-    return NextResponse.json(response);
-  } catch (error) {
+  const orderId = request.nextUrl.searchParams.get('orderId');
+  if (!orderId) {
     return NextResponse.json({
       success: false,
       error: {
-        code: 'TRACKING_ERROR',
-        message: 'Failed to get tracking information',
-        details: error instanceof Error ? error.message : 'Unknown error'
-      }
-    }, { status: 500 });
+        code: 'MISSING_ORDER_ID',
+        message: 'orderId is required; tracking-number lookup awaits the fulfillment data model',
+      },
+    }, { status: 400 });
   }
+  return projectOwnedOrder(orderId, auth.agentId!);
 }
 
 export async function POST(request: NextRequest) {
-  // Alternative POST method for tracking lookup
   const auth = await authenticateAgent(request);
-  
   if (!auth.success) {
-    return NextResponse.json({
-      success: false,
-      error: auth.error
-    }, { status: 401 });
+    return NextResponse.json({ success: false, error: auth.error }, { status: 401 });
   }
 
+  let body: unknown;
   try {
-    const body = await request.json() as any;
-    const { orderId, trackingNumber } = body;
-    
-    if (!orderId && !trackingNumber) {
-      return NextResponse.json({
-        success: false,
-        error: {
-          code: 'MISSING_IDENTIFIER',
-          message: 'orderId or trackingNumber is required'
-        }
-      }, { status: 400 });
-    }
-
-    // Use the same logic as GET method
-    const url = new URL(request.url);
-    if (orderId) url.searchParams.set('orderId', orderId);
-    if (trackingNumber) url.searchParams.set('trackingNumber', trackingNumber);
-    
-    const modifiedRequest = new NextRequest(url, { method: 'GET', headers: request.headers });
-    return GET(modifiedRequest);
-    
-  } catch (error) {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({
+      success: false,
+      error: { code: 'INVALID_REQUEST', message: 'Invalid JSON body' },
+    }, { status: 400 });
+  }
+  const orderId = body && typeof body === 'object' && !Array.isArray(body)
+    ? (body as Record<string, unknown>).orderId
+    : undefined;
+  if (typeof orderId !== 'string' || !orderId) {
     return NextResponse.json({
       success: false,
       error: {
-        code: 'TRACKING_ERROR',
-        message: 'Failed to get tracking information',
-        details: error instanceof Error ? error.message : 'Unknown error'
-      }
-    }, { status: 500 });
+        code: 'MISSING_ORDER_ID',
+        message: 'orderId is required; tracking-number lookup awaits the fulfillment data model',
+      },
+    }, { status: 400 });
   }
+  return projectOwnedOrder(orderId, auth.agentId!);
 }

--- a/app/api/mcp/tools/payment/create-intent/route.ts
+++ b/app/api/mcp/tools/payment/create-intent/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  authenticateAgent,
+  hasPermission,
+  requiredScopeForTool,
+} from '../../../../../../lib/mcp/auth';
+import { createAgentPaymentIntent } from '../../../../../../lib/mcp/tools/payment';
+
+export async function POST(request: NextRequest) {
+  const auth = await authenticateAgent(request);
+  if (!auth.success) {
+    return NextResponse.json({ success: false, error: auth.error }, { status: 401 });
+  }
+
+  const requiredScope = requiredScopeForTool('create_payment_intent')!;
+  if (!hasPermission(auth.permissions, requiredScope)) {
+    return NextResponse.json({
+      success: false,
+      error: { code: 'FORBIDDEN', message: 'This tool requires place:orders permission' },
+    }, { status: 403 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ success: false, error: { code: 'INVALID_REQUEST', message: 'Invalid JSON body' } }, { status: 400 });
+  }
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    return NextResponse.json({ success: false, error: { code: 'INVALID_REQUEST', message: 'Invalid request body' } }, { status: 400 });
+  }
+  const input = body as Record<string, unknown>;
+  const sessionId = typeof input.session_id === 'string' ? input.session_id : '';
+  if (!sessionId) {
+    return NextResponse.json({ success: false, error: { code: 'INVALID_REQUEST', message: 'session_id is required' } }, { status: 400 });
+  }
+
+  const result = await createAgentPaymentIntent({
+    shippingAddress: input.shippingAddress,
+    shippingMethodId: typeof input.shippingMethodId === 'string' ? input.shippingMethodId : undefined,
+    shippingOption: typeof input.shippingOption === 'string' ? input.shippingOption : undefined,
+    discountCodes: Array.isArray(input.discountCodes)
+      ? input.discountCodes.filter((code): code is string => typeof code === 'string')
+      : undefined,
+    giftCardToken: typeof input.giftCardToken === 'string' ? input.giftCardToken : undefined,
+  }, sessionId, auth.agentId!);
+  return NextResponse.json(result, { status: result.success ? 200 : 400 });
+}

--- a/app/api/mcp/tools/payment/validate/route.ts
+++ b/app/api/mcp/tools/payment/validate/route.ts
@@ -2,7 +2,6 @@ import { NextRequest, NextResponse } from 'next/server';
 import { authenticateAgent } from '../../../../../../lib/mcp/auth';
 import { parseAgentContext } from '../../../../../../lib/mcp/context';
 import { validatePayment } from '../../../../../../lib/mcp/tools/payment';
-import { getSessionCart } from '../../../../../../lib/mcp/session';
 
 export async function POST(request: NextRequest) {
   const auth = await authenticateAgent(request);
@@ -16,7 +15,7 @@ export async function POST(request: NextRequest) {
 
   try {
     const body = await request.json() as any;
-    const agentContext = parseAgentContext(request);
+    const agentContext = parseAgentContext(request, auth.agentId);
     
     if (!body.payment_method) {
       return NextResponse.json({
@@ -28,29 +27,14 @@ export async function POST(request: NextRequest) {
       }, { status: 400 });
     }
     
-    if (!body.total_amount && body.total_amount !== 0) {
-      return NextResponse.json({
-        success: false,
-        error: {
-          code: 'INVALID_REQUEST',
-          message: 'total_amount is required'
-        }
-      }, { status: 400 });
-    }
-    
-    // Get cart from session if not provided
     const sessionId = body.session_id || 'temp';
-    const cart = body.cart || await getSessionCart(sessionId);
-    
     const paymentRequest = {
       payment_method: body.payment_method,
       billing_address: body.billing_address,
-      cart,
-      total_amount: body.total_amount,
       agent_context: agentContext || undefined
     };
 
-    const result = await validatePayment(paymentRequest, sessionId);
+    const result = await validatePayment(paymentRequest, sessionId, auth.agentId!);
     
     return NextResponse.json(result);
   } catch (error) {

--- a/app/api/mcp/tools/recommend/route.ts
+++ b/app/api/mcp/tools/recommend/route.ts
@@ -16,7 +16,7 @@ export async function POST(request: NextRequest) {
 
   try {
     const body = await request.json() as any;
-    const agentContext = parseAgentContext(request);
+    const agentContext = parseAgentContext(request, auth.agentId);
     
     const recommendRequest: RecommendRequest = {
       ...body,

--- a/app/api/mcp/tools/search/route.ts
+++ b/app/api/mcp/tools/search/route.ts
@@ -16,7 +16,7 @@ export async function POST(request: NextRequest) {
 
   try {
     const body = await request.json() as any;
-    const agentContext = parseAgentContext(request);
+    const agentContext = parseAgentContext(request, auth.agentId);
     
     const searchRequest: SearchRequest = {
       ...body,

--- a/app/api/mcp/tools/shipping/route.ts
+++ b/app/api/mcp/tools/shipping/route.ts
@@ -2,9 +2,6 @@ import { NextRequest, NextResponse } from 'next/server';
 import { authenticateAgent } from '../../../../../lib/mcp/auth';
 import { parseAgentContext } from '../../../../../lib/mcp/context';
 import { getShippingOptions } from '../../../../../lib/mcp/tools/shipping';
-import { getSessionCart } from '../../../../../lib/mcp/session';
-import type { CartItem } from '../../../../../lib/types/cartitem';
-import { Money } from '../../../../../lib/money';
 
 export async function POST(request: NextRequest) {
   const auth = await authenticateAgent(request);
@@ -18,7 +15,7 @@ export async function POST(request: NextRequest) {
 
   try {
     const body = await request.json() as any;
-    const agentContext = parseAgentContext(request);
+    const agentContext = parseAgentContext(request, auth.agentId);
     
     if (!body.address) {
       return NextResponse.json({
@@ -30,17 +27,13 @@ export async function POST(request: NextRequest) {
       }, { status: 400 });
     }
     
-    // Get cart from session if not provided
     const sessionId = body.session_id || 'temp';
-    const cart = body.cart ? parseWireCart(body.cart) : await getSessionCart(sessionId);
-    
     const shippingRequest = {
       address: body.address,
-      cart,
       agent_context: agentContext || undefined
     };
 
-    const result = await getShippingOptions(shippingRequest, sessionId);
+    const result = await getShippingOptions(shippingRequest, sessionId, auth.agentId!);
     
     return NextResponse.json(result);
   } catch (error) {
@@ -53,30 +46,4 @@ export async function POST(request: NextRequest) {
       }
     }, { status: 500 });
   }
-}
-
-function parseWireCart(value: unknown): CartItem[] {
-  if (!Array.isArray(value)) throw new Error('cart must be an array');
-  return value.map((item) => {
-    if (!item || typeof item !== 'object') throw new Error('cart item must be an object');
-    const candidate = item as Record<string, unknown>;
-    if (typeof candidate.productId !== 'string' || typeof candidate.variantId !== 'string' || typeof candidate.name !== 'string' ||
-      typeof candidate.quantity !== 'number' || !Number.isSafeInteger(candidate.quantity) || candidate.quantity < 1 ||
-      !candidate.price || typeof candidate.price !== 'object') {
-      throw new Error('cart item is invalid');
-    }
-    const price = candidate.price as Record<string, unknown>;
-    if (typeof price.amount !== 'number' || typeof price.currency !== 'string') throw new Error('cart item price is invalid');
-    const money = 'precision' in price
-      ? Money.fromMajor(price.amount, price.currency)
-      : Money.fromStored(price, price.currency);
-    return {
-      productId: candidate.productId,
-      variantId: candidate.variantId,
-      name: candidate.name,
-      quantity: candidate.quantity,
-      primaryImageUrl: typeof candidate.primaryImageUrl === 'string' ? candidate.primaryImageUrl : '',
-      price: money.toJSON(),
-    };
-  });
 }

--- a/data/d1/seed-dev.sql
+++ b/data/d1/seed-dev.sql
@@ -1,0 +1,41 @@
+-- Development-only MCP credential. Production and preview migration commands
+-- never execute this file.
+--
+-- Raw key for local testing: test-key-123
+-- SHA-256: 625faa3fbbc3d2bd9d6ee7678d04cc5339cb33dc68d9b58451853d60046e226a
+INSERT INTO mcp_agents (
+  agent_id,
+  name,
+  description,
+  api_key,
+  api_key_hash,
+  api_key_expires_at,
+  credential_version,
+  permissions,
+  rate_limit_rpm,
+  rate_limit_oph,
+  is_active
+) VALUES (
+  'test-agent',
+  'Test Agent',
+  'Development-only MCP test agent',
+  'retired:test-agent:dev-seed',
+  '625faa3fbbc3d2bd9d6ee7678d04cc5339cb33dc68d9b58451853d60046e226a',
+  datetime('now', '+365 days'),
+  2,
+  '["read:products", "write:cart", "place:orders"]',
+  1000,
+  100,
+  1
+)
+ON CONFLICT(agent_id) DO UPDATE SET
+  name = excluded.name,
+  description = excluded.description,
+  api_key = excluded.api_key,
+  api_key_hash = excluded.api_key_hash,
+  api_key_expires_at = excluded.api_key_expires_at,
+  credential_version = excluded.credential_version,
+  permissions = excluded.permissions,
+  rate_limit_rpm = excluded.rate_limit_rpm,
+  rate_limit_oph = excluded.rate_limit_oph,
+  is_active = excluded.is_active;

--- a/docs/mcp-server-specification.md
+++ b/docs/mcp-server-specification.md
@@ -1,640 +1,162 @@
-# Voltique MCP Server - Technical Specification
+# Mercora MCP commerce API
 
-> **✅ COMPLETED - Model Context Protocol Integration for Voltique AI Assistant**
-> 
-> **Production-ready multi-agent commerce server with 17 tools**
+Mercora exposes an authenticated HTTP API for agent-assisted catalog discovery,
+session carts, checkout, and order status. The API is store-neutral: catalog,
+shipping, pricing, tax, promotion, inventory, and payment behavior comes from
+the same configuration and services used by the storefront.
 
-## 🎯 Overview
+The tool schema is available from `GET /api/mcp/schema`. Authenticated clients
+can use either the individual REST routes under `/api/mcp` or the JSON tool
+dispatcher at `POST /api/mcp`.
 
-The Voltique MCP Server enables direct integration of Volt (our AI shopping assistant) with Model Context Protocol compatible clients like Claude Desktop, Cursor, VS Code, and other AI development tools. This revolutionary approach allows users to discover, research, and purchase outdoor gear without leaving their workflow.
+## Authentication and credentials
 
-## 🚀 Vision Statement
+Send an agent credential in one of these headers:
 
-**"Shop for outdoor gear as naturally as asking a question"**
-
-Transform eCommerce from a web-based activity to a conversational experience embedded directly in users' daily tools and workflows.
-
-## 🎪 Revolutionary Use Cases
-
-### 💻 **Developer Scenarios**
-
-#### **Scenario 1: Weekend Adventure Planning**
-```
-Developer (in Claude Desktop): "I'm coding late and just realized I need camping 
-gear for this weekend. What's essential for car camping in California?"
-
-Volt: "For California car camping, you'll need:
-- 3-season sleeping bag (nights can drop to 40°F)
-- Basic tent (weather is usually good)
-- Camp chair and table
-- Headlamp for setup
-
-I recommend the Coastal Track Pack sleeping bag ($179) and the Echo Sky Kit tent ($299). 
-Want me to add these to your cart?"
-
-Developer: "Add the sleeping bag, but suggest a cheaper tent option"
-
-Volt: "Added sleeping bag! For budget tents, the Ember Crest Pack is $189 and 
-perfect for California car camping. Add it too?"
-
-Developer: "Yes, and checkout with my default shipping"
-
-Volt: "Order placed! Total $403.42. Shipping Monday, arrives Wednesday. 
-Confirmation #VP-2025-098 sent to your email."
+```http
+X-Agent-API-Key: mcp_...
 ```
 
-#### **Scenario 2: Quick Gear Research**
-```
-Developer (in VS Code): "I need a technical comparison of lightweight 
-backpacking stoves under 4oz"
-
-Volt: "Here are the top ultralight stoves:
-
-1. **Arctic Pulse Stove** (3.2oz, $89)
-   - Titanium construction, integrated igniter
-   - 10,000 BTU, boils 16oz water in 3.5 minutes
-   - Works down to 15°F
-
-2. **Quantum Ash Burner** (3.8oz, $67)  
-   - Aluminum, piezo ignition
-   - 9,500 BTU, boils 16oz water in 4.1 minutes
-   - Works down to 20°F
-
-The Arctic Pulse is worth the extra $22 for better cold weather performance."
-
-Developer: "Add the Arctic Pulse to my wishlist for later"
-
-Volt: "Added to wishlist! You now have 4 items saved."
+```http
+Authorization: Bearer mcp_...
 ```
 
-### 🏢 **Professional Use Cases**
+Query-string credentials are not accepted. New credentials are generated with
+Web Crypto, stored only as SHA-256 digests, expire after 90 days by default,
+and are returned in plaintext only when created or rotated. A manager can
+choose a lifetime from 1 through 365 days.
 
-#### **Scenario 3: Corporate Team Building**
-```
-Manager (in Claude Desktop): "I need to order outdoor gear for a company 
-retreat - 15 people, 2-day camping trip in Colorado in September"
+Migration `0012_expand_mcp_agent_credentials.sql` uses an
+expand/rotate/contract transition:
 
-Volt: "For 15 people in Colorado September weather, here's what you need:
+1. Existing plaintext credentials remain usable initially.
+2. The first successful use stores the digest, retires the plaintext value,
+   and gives the credential a 30-day rotation window.
+3. Explicit rotation immediately replaces the credential and its expiry.
+4. The legacy column can be removed in a future contract migration after no
+   version-1 credentials remain.
 
-**Per Person:**
-- 3-season sleeping bag: $179 x 15 = $2,685
-- Backpack day pack: $79 x 15 = $1,185  
-- Headlamp: $45 x 15 = $675
+The public demo credential formerly installed by a migration is removed.
+`npm run dev` applies `data/d1/seed-dev.sql` to the local D1 database only; its
+known test credential is never installed by preview or production migrations.
 
-**Group Gear:**
-- 2 large tents (8-person): $399 x 2 = $798
-- Camp stoves: $89 x 3 = $267
-- Water filtration: $149 x 2 = $298
+### Permissions
 
-**Total Estimate: $5,908**
+Permissions are deny-by-default. `admin` and `*` satisfy all scopes.
 
-I can create a bulk order with 10% corporate discount. Want me to proceed?"
+| Permission | Allows |
+| --- | --- |
+| `write:cart` | Add, update, remove, bulk-add, or clear cart lines |
+| `place:orders` | Create a bound PaymentIntent and finalize an order |
+| `agents:manage` | Create, list, inspect, disable, and rotate agents |
 
-Manager: "Yes, but let me approve items over $300 individually"
+An `agents:manage` credential cannot delegate a permission it does not hold.
+Only `admin` or `*` may delegate arbitrary permissions.
 
-Volt: "Perfect! I'll add items under $300 to cart and flag the others for approval."
-```
+Per-agent requests-per-minute limits apply to every authenticated request. The
+orders-per-hour limit applies to `place_order`. D1 stores and resets both
+counters by fixed time window.
 
-### 🎯 **Power User Scenarios**
+## Identity and session ownership
 
-#### **Scenario 4: Gear Expert Research**
-```
-Gear Reviewer (in Cursor): "I'm writing a review of ultralight shelters. 
-Give me technical specs and user feedback for shelters under 2 lbs"
+The authenticated credential is the sole source of agent identity.
+`X-Agent-Context` may carry bounded user preferences, but a client-provided
+`agentId` is always replaced with the authenticated agent ID.
 
-Volt: "Here are the top ultralight shelters with detailed specs:
+Session IDs use cryptographically random UUIDs. Every cart, shipping, payment,
+and order mutation verifies that the session belongs to the authenticated
+agent before reading or changing it. Order lookup also verifies the agent ID;
+an order identifier alone is not authorization.
 
-**Stealth Brook Shelter** (1.8 lbs, $329)
-- 20D silnylon, single-wall design
-- 84" x 30" x 42" (L x W x H)
-- Customer feedback: 4.6/5 stars (127 reviews)
-- Pros: Excellent wind resistance, quick setup
-- Cons: Condensation in humid conditions
+Create a session with:
 
-**Nova Flame Tarp-Tent** (1.5 lbs, $289)
-- 15D Dyneema composite, trekking pole setup  
-- 90" x 45" x 44" sleeping area
-- Customer feedback: 4.8/5 stars (89 reviews)
-- Pros: Spacious, bombproof in storms
-- Cons: Requires trekking poles, learning curve
-
-Would you like detailed user reviews or technical drawings for your article?"
-```
-
-## 🔧 Technical Architecture
-
-### **🛠️ MCP Server Implementation**
-
-#### **Core Infrastructure**
-```typescript
-// MCP Server Entry Point
-const server = new MCPServer({
-  name: "voltique-mcp-server",
-  version: "1.0.0",
-  capabilities: {
-    tools: true,
-    resources: false,
-    prompts: true
-  }
-});
-
-// Authentication & Rate Limiting
-interface UserContext {
-  userId: string;
-  apiKey: string;
-  permissions: string[];
-  rateLimits: RateLimitConfig;
-}
+```http
+POST /api/mcp/sessions
+X-Agent-API-Key: mcp_...
 ```
 
-### **🔍 MCP Tools Specification**
+Use the returned `sessionId` for subsequent cart and checkout tools.
 
-#### **Product Discovery Tools**
-```typescript
-// Product search and discovery
-voltique_search_products(query: string, options?: {
-  category?: string;
-  priceMin?: number;
-  priceMax?: number;
-  limit?: number;
-  sortBy?: 'price' | 'rating' | 'popularity';
-});
+## Catalog and wire data
 
-voltique_get_product_details(productId: number): Promise<ProductDetails>;
+Discovery capabilities are derived from active catalog categories, product
+prices, shipping settings, and allowed countries. No demo-store categories,
+brands, product names, or fulfillment claims are compiled into MCP responses.
 
-voltique_compare_products(productIds: number[]): Promise<ComparisonMatrix>;
+Only active products and variants cross the public MCP boundary. Internal
+costs, inventory records, barcodes, integration references, extensions, and
+media-processing metadata are removed by the shared public product serializer.
 
-voltique_get_recommendations(context: {
-  currentProduct?: number;
-  userActivity?: string;
-  budget?: number;
-  useCase?: string;
-}): Promise<Product[]>;
+Money responses use the MACH decimal wire shape:
+
+```json
+{ "amount": 31.49, "currency": "USD", "precision": 2 }
 ```
 
-#### **Shopping Cart Management**
-```typescript
-// Cart operations
-voltique_add_to_cart(productId: number, quantity?: number): Promise<CartResponse>;
-
-voltique_view_cart(): Promise<CartSummary>;
-
-voltique_update_cart_item(productId: number, quantity: number): Promise<CartResponse>;
-
-voltique_remove_from_cart(productId: number): Promise<CartResponse>;
-
-voltique_clear_cart(): Promise<void>;
-
-voltique_estimate_totals(shippingAddress?: Address): Promise<OrderTotals>;
-```
-
-#### **Order Processing Tools**
-```typescript
-// Order management
-voltique_get_shipping_options(address: Address): Promise<ShippingOption[]>;
-
-voltique_apply_discount_code(code: string): Promise<DiscountResponse>;
-
-voltique_place_order(orderData: {
-  shippingAddress: Address;
-  billingAddress?: Address;
-  paymentMethod: PaymentMethod;
-  shippingOption: string;
-  specialInstructions?: string;
-}): Promise<OrderConfirmation>;
-
-voltique_track_order(orderId: string): Promise<OrderStatus>;
-
-voltique_cancel_order(orderId: string, reason?: string): Promise<CancellationResponse>;
-```
-
-#### **User Account Tools**
-```typescript
-// Account management
-voltique_get_user_profile(): Promise<UserProfile>;
-
-voltique_get_order_history(limit?: number): Promise<Order[]>;
-
-voltique_save_address(address: Address, label: string): Promise<void>;
-
-voltique_save_payment_method(paymentData: PaymentMethodData): Promise<void>;
-
-voltique_get_wishlist(): Promise<Product[]>;
-
-voltique_add_to_wishlist(productId: number): Promise<void>;
-
-voltique_create_price_alert(productId: number, targetPrice: number): Promise<void>;
-```
-
-#### **AI Conversation Tools**
-```typescript
-// Volt AI integration
-voltique_ask_volt(question: string, context?: {
-  conversationHistory?: Message[];
-  userPreferences?: UserPreferences;
-  currentCart?: CartItem[];
-}): Promise<VoltResponse>;
-
-voltique_get_gear_advice(activity: string, conditions: {
-  season?: string;
-  location?: string;
-  duration?: string;
-  experience?: string;
-}): Promise<GearRecommendations>;
-
-voltique_explain_product(productId: number, focus?: string): Promise<ProductExplanation>;
-```
-
-### **🔐 Security & Safety Features**
-
-#### **Authentication System**
-```typescript
-interface AuthConfig {
-  apiKey: string;           // Voltique API key
-  permissions: Permission[]; // Granular permissions
-  spending_limits: {
-    daily_max?: number;
-    monthly_max?: number;
-    single_order_max?: number;
-  };
-  confirmation_required: {
-    orders_over?: number;
-    new_addresses?: boolean;
-    new_payment_methods?: boolean;
-  };
-}
-```
-
-#### **Permission Levels**
-```typescript
-enum Permission {
-  READ_PRODUCTS = "read:products",
-  READ_ORDERS = "read:orders", 
-  WRITE_CART = "write:cart",
-  PLACE_ORDERS = "place:orders",
-  MANAGE_ACCOUNT = "manage:account",
-  ADMIN_ACCESS = "admin:access"
-}
-```
-
-#### **Safety Mechanisms**
-```typescript
-interface SafetyConfig {
-  // Confirmation requirements
-  require_confirmation_over: number;        // Dollar amount
-  require_explicit_shipping: boolean;       // Must specify address
-  require_payment_method_confirmation: boolean;
-  
-  // Rate limiting
-  max_orders_per_hour: number;
-  max_api_calls_per_minute: number;
-  
-  // Spending controls
-  daily_spending_limit?: number;
-  monthly_spending_limit?: number;
-  
-  // Address validation
-  require_validated_addresses: boolean;
-  allow_new_addresses: boolean;
-}
-```
-
-### **📊 Order Flow Architecture**
-
-#### **Simple Order Flow**
-```
-1. User: "Add a headlamp to my cart"
-2. voltique_search_products("headlamp") → Show options
-3. User: "Add the $45 one"
-4. voltique_add_to_cart(productId) → Cart updated
-5. User: "Checkout with my default address"
-6. voltique_place_order(defaultConfig) → Order placed
-```
-
-#### **Complex Order Flow with Confirmation**
-```
-1. User: "I need complete camping setup for 4 people, budget $2000"
-2. voltique_ask_volt() → AI generates gear list
-3. Multiple voltique_add_to_cart() calls → Build cart
-4. voltique_estimate_totals() → Show total ($1,847)
-5. User: "Looks good, but ship to my parents' house"
-6. voltique_get_shipping_options(parentsAddress) → Show options
-7. User confirmation required (order > $1000)
-8. voltique_place_order() → Order placed with confirmation
-```
-
-## 🚀 Implementation Roadmap
-
-### **Phase 1: Foundation (Week 1-2)**
-- Basic MCP server setup and authentication
-- Core product search and discovery tools
-- Volt AI conversation integration
-- Basic cart management (add, view, remove)
-
-### **Phase 2: Shopping (Week 3-4)**
-- Complete cart management with updates
-- Shipping calculations and options
-- Order placement with safety checks
-- Order tracking and status
-
-### **Phase 3: Advanced Features (Week 5-6)**
-- User account management
-- Wishlist and price alerts
-- Bulk operations for corporate users
-- Advanced AI gear consultation
-
-### **Phase 4: Enterprise (Week 7-8)**
-- Corporate account features
-- Advanced permissions and spending controls
-- Bulk ordering and approval workflows
-- Integration with corporate procurement systems
-
-## 📈 Business Impact
-
-### **Revenue Opportunities**
-- **New Sales Channel**: Zero-marketing-cost customer acquisition
-- **Higher Order Values**: AI recommendations increase basket size
-- **Increased Frequency**: Easier ordering drives more frequent purchases
-- **Corporate Sales**: B2B opportunities through corporate integrations
-
-### **Market Differentiation**
-- **First Mover**: No competitors offer MCP commerce integration
-- **Technical Leadership**: Position as most innovative outdoor retailer
-- **Developer Community**: Build loyalty among technical users
-- **Viral Marketing**: Developers naturally share innovative tools
-
-### **Customer Experience**
-- **Zero Context Switching**: Shop without leaving workflow
-- **Natural Language**: Conversational shopping experience  
-- **Instant Expertise**: Access to Volt's outdoor knowledge
-- **Seamless Integration**: Part of existing tool ecosystem
-
-## 🎯 Success Metrics
-
-### **Adoption Metrics**
-- Number of active MCP users
-- Daily/monthly MCP sessions
-- MCP server installations
-
-### **Commerce Metrics**
-- Orders placed via MCP
-- Average order value through MCP
-- Conversion rate from MCP chat to purchase
-- Revenue attribution to MCP channel
-
-### **Engagement Metrics**
-- Messages per session
-- Session duration
-- User retention rate
-- Feature usage patterns
-
-## 🛠️ Technical Requirements
-
-### **Dependencies**
-- Model Context Protocol SDK
-- Existing Voltique APIs (agent-chat, products, orders)
-- Clerk authentication system
-- Stripe payment processing
-
-### **Infrastructure**
-- Cloudflare Workers for MCP server hosting
-- D1 database for MCP session storage
-- R2 for any MCP-specific assets
-- Existing Voltique infrastructure
-
-### **Performance Targets**
-- Sub-500ms response time for product searches
-- Sub-2s response time for AI conversations
-- 99.9% uptime for MCP server
-- Support for 1000+ concurrent MCP sessions
-
----
-
-## 🤖 Multi-Agent Commerce Architecture
-
-### **Agent Context & User Identity**
-
-**Design Philosophy**: Users don't need authentication, but agents provide rich user context for personalized commerce.
-
-```typescript
-interface AgentContext {
-  agentId: string;           // Unique agent identifier
-  userId?: string;           // User's identifier (optional)
-  userPreferences?: {        // User context from agent
-    budget?: number;
-    brands?: string[];
-    activities?: string[];
-    location?: string;
-    experience_level?: string;
-  };
-  session_context?: string;  // Agent's understanding of user needs
-}
-```
-
-### **Multi-Site Order Coordination**
-
-**Vision**: Personal shopping agents coordinate orders across specialized retailers (Voltique for camping gear, others for rations/skis).
-
-```typescript
-// Cross-site coordination tools
-voltique_get_capabilities(): Promise<{
-  categories: string[];
-  price_ranges: Record<string, {min: number, max: number}>;
-  shipping_regions: string[];
-  specialties: string[];
-}>;
-
-voltique_assess_request(requirements: {
-  items: string[];
-  budget: number;
-  timeline: string;
-  location: string;
-}): Promise<{
-  can_fulfill: string[];         // Items Voltique can provide
-  cannot_fulfill: string[];      // Items to source elsewhere
-  recommendations: Product[];    // What we recommend
-  estimated_cost: number;
-  estimated_delivery: string;
-}>;
-```
-
-### **Enhanced Tool Response Format**
-
-```typescript
-interface MCPToolResponse<T> {
-  success: boolean;
-  data: T;
-  context: {
-    session_id: string;
-    agent_id: string;
-    processing_time_ms: number;
-  };
-  recommendations?: {
-    alternative_sites?: string[];    // Suggest other sites for unfulfilled needs
-    bundling_opportunities?: string[];
-    cost_optimization?: string[];
-  };
-  metadata: {
-    can_fulfill_percentage: number;  // How much of request we can handle
-    estimated_satisfaction: number;  // How well we match user needs
-    next_actions?: string[];         // Suggested next steps
-  };
-}
-```
-
-## 🏗️ Implementation Architecture
-
-### **Code Structure**
-
-```
-app/api/mcp/                    # MCP Server endpoints
-├── route.ts                    # Main MCP server discovery/capabilities
-├── tools/
-│   ├── search/route.ts         # Product search with agent context
-│   ├── assess/route.ts         # Fulfillment assessment
-│   ├── recommend/route.ts      # AI recommendations
-│   ├── cart/
-│   │   ├── add/route.ts        # Add to agent cart
-│   │   ├── update/route.ts     # Update cart quantities
-│   │   ├── remove/route.ts     # Remove from cart
-│   │   └── estimate/route.ts   # Get totals/shipping
-│   └── order/
-│       ├── place/route.ts      # Place order with agent context
-│       ├── status/route.ts     # Order status lookup
-│       └── track/route.ts      # Shipment tracking
-└── sessions/
-    ├── route.ts                # Create/list sessions
-    └── [sessionId]/route.ts    # Get/update/delete session
-
-lib/mcp/                        # MCP-specific logic
-├── types.ts                    # MCP request/response types
-├── auth.ts                     # Agent authentication
-├── context.ts                  # Agent context parsing
-├── session.ts                  # Session management
-├── tools/                      # Tool implementations
-│   ├── search.ts              
-│   ├── assess.ts              
-│   ├── recommend.ts           
-│   ├── cart.ts                
-│   └── order.ts               
-└── server.ts                   # Core MCP server logic
-
-lib/db/schema/
-└── mcp.ts                      # MCP session/agent tables
-```
-
-### **Cloudflare Workers Adaptations**
-
-**Transport Layer**: HTTP REST instead of WebSocket
-```typescript
-// HTTP-based MCP server for Cloudflare Workers
-app.post('/api/mcp/tools/:toolName', async (request) => {
-  const context = parseAgentContext(request.headers);
-  const result = await executeTool(toolName, request.body, context);
-  return Response.json(result);
-});
-```
-
-**Response Chunking** for 128KB limit:
-```typescript
-interface ChunkedResponse {
-  chunk: number;
-  total_chunks: number;
-  data: any[];
-  next_token?: string;
-}
-```
-
-**Session State** via Cloudflare D1:
-```typescript
-interface AgentSession {
-  sessionId: string;
-  agentId: string;
-  userContext: AgentContext;
-  cart: CartItem[];
-  created_at: string;
-  expires_at: string;
-}
-```
-
-### **Authentication Architecture**
-
-**Hybrid Approach**: No user auth required, agent API keys for rate limiting
-
-```typescript
-interface MCPAuthConfig {
-  require_user_auth: false;
-  
-  agent_auth: {
-    method: 'api_key';
-    header: 'X-Agent-API-Key';
-    rate_limits: {
-      requests_per_minute: 100;
-      orders_per_hour: 10;
-    };
-  };
-  
-  user_context_validation: {
-    required_fields: [];
-    optional_fields: ['budget', 'preferences', 'location'];
-    max_context_size: 1024; // bytes
-  };
-}
-```
-
-## 🎯 Implementation Decisions (Recommendations)
-
-### **✅ Recommended Decisions**
-
-1. **Transport**: HTTP REST API (Option B) - Simpler than JSON-RPC, Cloudflare Workers compatible
-2. **Authentication**: API Keys - Required for rate limiting and agent identification  
-3. **Context**: Rich Context - Enables personalized multi-site coordination
-4. **State**: Cloudflare D1 - Leverages existing infrastructure, persistent sessions
-5. **Caching**: Product + Agent-specific - Best performance for repeated queries
-6. **Error Handling**: Graceful degradation with fallbacks - Maintains agent workflow reliability
-
-### **✅ IMPLEMENTATION COMPLETED**
-
-#### **✅ Phase 1: MCP Foundation** 
-- ✅ **HTTP-based MCP server** - `/api/mcp` endpoint with tool routing
-- ✅ **Agent context parsing** - `parseAgentContext()` with user preferences
-- ✅ **Session management** - D1-based sessions with cart persistence  
-- ✅ **Authentication** - API key system with rate limiting
-- ✅ **Basic tools**: `search_products`, `assess_request`, `get_recommendations`
-
-#### **✅ Phase 2: Commerce Core**  
-- ✅ **Cart management** - Full CRUD with bulk operations (`add_to_cart`, `bulk_add_to_cart`, `update_cart`, `remove_from_cart`, `clear_cart`, `get_cart`)
-- ✅ **Order placement** - Complete order flow with `place_order`
-- ✅ **Enhanced recommendations** - Context-aware product suggestions
-- ✅ **Order tracking** - `get_order_status` with delivery updates
-
-#### **✅ Phase 3: Multi-Agent Features**
-- ✅ **Cross-site coordination** - `assess_request` determines fulfillment capability
-- ✅ **Agent rate limiting** - Per-agent RPM/OPH limits with D1 tracking
-- ✅ **Context validation** - User preference processing and budget validation
-- ✅ **Shipping & Payment** - `get_shipping_options`, `validate_payment` tools
-
-#### **✅ Phase 4: Production Readiness**
-- ✅ **Error handling** - Comprehensive error system with retry guidance
-- ✅ **Agent management** - `create_agent`, `list_agents`, `get_agent_details`, `update_agent_status`
-- ✅ **Documentation** - Auto-generated schema at `/api/mcp/schema`
-- ✅ **Discovery** - HTML meta tags, robots.txt, sitemap integration
-
-### **🚀 PRODUCTION DEPLOYMENT STATUS**
-
-#### **✅ Completed Features (17 MCP Tools)**
-**Commerce Tools:** `search_products`, `assess_request`, `get_recommendations`  
-**Cart Management:** `add_to_cart`, `bulk_add_to_cart`, `update_cart`, `remove_from_cart`, `clear_cart`, `get_cart`  
-**Order Processing:** `get_shipping_options`, `validate_payment`, `place_order`, `get_order_status`  
-**Agent Administration:** `create_agent`, `list_agents`, `get_agent_details`, `update_agent_status`
-
-#### **🌐 Server Endpoints**
-- **Main Server**: `https://voltique.russellkmoore.me/api/mcp`
-- **Schema Docs**: `https://voltique.russellkmoore.me/api/mcp/schema`  
-- **Discovery**: HTML meta tags, robots.txt allowlist, sitemap integration
-
----
-
-**This MCP server represents a paradigm shift in eCommerce - from destination shopping to embedded, conversational commerce. By integrating shopping directly into users' daily workflows, we transform Voltique from a website into an essential tool.**
-
-**Updated**: Enhanced with multi-agent commerce architecture and Cloudflare Workers implementation planning.
+Persisted commerce values remain integer minor units. Shipping and billing
+addresses accept either legacy flat names such as `street`, `state`, and
+`postalCode` or MACH names such as `line1`, `region`, and `postal_code`; they
+are normalized before pricing or persistence.
+
+## Commerce workflow
+
+The safe purchase sequence is:
+
+1. Create a session.
+2. Search the active catalog and add product/variant IDs to the session cart.
+3. Request shipping options for that owned session and address.
+4. Call `create_payment_intent` with the session, shipping address, configured
+   shipping method, and optional discount or gift-card input.
+5. Complete the returned Stripe PaymentIntent using its client secret.
+6. Call `place_order` with the returned `orderId` and `paymentIntentId`.
+7. Poll `get_order_status` with the order ID when needed.
+
+`create_payment_intent` does not trust cart names or prices. It reloads each
+product and variant, validates inventory, applies configured shipping,
+promotions, gift cards, and tax through the shared checkout pricing service,
+then creates both:
+
+- a Stripe PaymentIntent whose amount, currency, order ID, agent ID, and
+  session ID are bound in metadata; and
+- a durable pending order containing the exact canonical quote and line
+  allocations.
+
+If Stripe returns a mismatched amount or currency, or pending-order persistence
+fails, Mercora cancels the PaymentIntent. `place_order` verifies that the
+pending order, PaymentIntent, agent, and session all match before invoking the
+shared idempotent payment finalizer. That finalizer verifies captured payment
+with Stripe and runs the same durable inventory and post-payment effects as the
+storefront.
+
+Client-supplied totals, display names, prices, cart objects, and paid flags are
+never authoritative.
+
+## Tool summary
+
+| Area | Tools |
+| --- | --- |
+| Discovery | `search_products`, `assess_request`, `get_recommendations` |
+| Cart | `add_to_cart`, `update_cart`, `remove_from_cart`, `get_cart`, `bulk_add_to_cart`, `clear_cart` |
+| Checkout | `get_shipping_options`, `validate_payment`, `create_payment_intent`, `place_order` |
+| Orders | `get_order_status` |
+| Agents | `create_agent`, `list_agents`, `get_agent_details`, `update_agent_status`, `rotate_agent_key` |
+
+Shipment-event-backed tracking remains part of Mercora's planned fulfillment
+vertical slice. Until then, order status exposes only fields backed by the
+current order record and does not fabricate carrier events.
+
+## Rotation operations
+
+Managers can rotate an agent credential through either interface:
+
+- `PATCH /api/mcp/tools/agents/{agentId}` with
+  `{ "rotateApiKey": true, "apiKeyTtlDays": 90 }`; or
+- the dispatcher tool `rotate_agent_key` with `agentId` and optional
+  `apiKeyTtlDays`.
+
+Store the returned key immediately. Rotation invalidates the previous key and
+the plaintext replacement cannot be recovered from the database.
+
+Before removing legacy credential support, operators should confirm that no
+active row remains at credential version 1 and that all required clients have
+received rotated credentials.

--- a/lib/db/schema/mcp.ts
+++ b/lib/db/schema/mcp.ts
@@ -17,7 +17,12 @@ export const mcpAgents = sqliteTable('mcp_agents', {
   agentId: text('agent_id').primaryKey(),
   name: text('name'),
   description: text('description'),
-  apiKey: text('api_key').unique().notNull(),
+  // Transitional expand/rotate/contract credential shape. `legacyApiKey`
+  // remains until every deployed database has rotated its old plaintext rows.
+  legacyApiKey: text('api_key').unique().notNull(),
+  apiKeyHash: text('api_key_hash').unique(),
+  apiKeyExpiresAt: text('api_key_expires_at'),
+  credentialVersion: integer('credential_version').default(1).notNull(),
   permissions: text('permissions'), // JSON string array
   rateLimitRpm: integer('rate_limit_rpm').default(100),
   rateLimitOph: integer('rate_limit_oph').default(10),

--- a/lib/mcp/auth.ts
+++ b/lib/mcp/auth.ts
@@ -1,190 +1,366 @@
 import { NextRequest } from 'next/server';
+import { and, eq, gte, isNull, or, sql } from 'drizzle-orm';
+import { sha256Hex } from '../auth/crypto';
 import { getDbAsync } from '../db';
 import { mcpAgents, mcpRateLimits } from '../db/schema/mcp';
-import { eq, and, gte, sql } from 'drizzle-orm';
 import { MCPError } from './types';
-import { AuthenticationError, RateLimitError, DatabaseError } from './error-handler';
+
+const AGENT_MANAGEMENT_PERMISSIONS = ['admin', '*', 'agents:manage'];
+const SUPERUSER_PERMISSIONS = ['admin', '*'];
+const DEFAULT_KEY_TTL_DAYS = 90;
+const LEGACY_KEY_GRACE_DAYS = 30;
+
+export const COMMERCE_SCOPES = {
+  WRITE_CART: 'write:cart',
+  PLACE_ORDERS: 'place:orders',
+} as const;
+
+export const COMMERCE_TOOL_SCOPES: Record<string, string> = {
+  add_to_cart: COMMERCE_SCOPES.WRITE_CART,
+  update_cart: COMMERCE_SCOPES.WRITE_CART,
+  remove_from_cart: COMMERCE_SCOPES.WRITE_CART,
+  bulk_add_to_cart: COMMERCE_SCOPES.WRITE_CART,
+  clear_cart: COMMERCE_SCOPES.WRITE_CART,
+  place_order: COMMERCE_SCOPES.PLACE_ORDERS,
+  create_payment_intent: COMMERCE_SCOPES.PLACE_ORDERS,
+};
 
 export interface AgentAuthResult {
   success: boolean;
   agentId?: string;
+  permissions?: string[];
   error?: MCPError['error'];
 }
 
-export async function authenticateAgent(request: NextRequest): Promise<AgentAuthResult> {
-  const apiKey = request.headers.get('X-Agent-API-Key') || 
-                 request.headers.get('Authorization')?.replace('Bearer ', '') ||
-                 request.nextUrl.searchParams.get('api_key');
+export type McpDatabase = Awaited<ReturnType<typeof getDbAsync>>;
+
+export function hasAgentManagementPermission(permissions: string[] | undefined): boolean {
+  return permissions?.some((permission) => AGENT_MANAGEMENT_PERMISSIONS.includes(permission)) ?? false;
+}
+
+export function hasPermission(permissions: string[] | undefined, required: string): boolean {
+  return permissions?.some(
+    (permission) => permission === required || SUPERUSER_PERMISSIONS.includes(permission),
+  ) ?? false;
+}
+
+export function requiredScopeForTool(toolName: string): string | undefined {
+  return COMMERCE_TOOL_SCOPES[toolName];
+}
+
+export function extractAgentApiKey(request: NextRequest): string | null {
+  const directKey = request.headers.get('X-Agent-API-Key')?.trim();
+  if (directKey) return directKey;
+
+  const authorization = request.headers.get('Authorization')?.trim();
+  const bearer = authorization?.match(/^Bearer\s+(\S+)$/i);
+  return bearer?.[1] ?? null;
+}
+
+function parsePermissions(value: string | null): string[] {
+  try {
+    const parsed: unknown = JSON.parse(value || '[]');
+    return Array.isArray(parsed)
+      ? parsed.filter((permission): permission is string => typeof permission === 'string')
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+function expiryFromNow(days: number): string {
+  const expiresAt = new Date();
+  expiresAt.setUTCDate(expiresAt.getUTCDate() + days);
+  return expiresAt.toISOString();
+}
+
+function normalizeTtlDays(days: number | undefined): number {
+  if (days === undefined) return DEFAULT_KEY_TTL_DAYS;
+  if (!Number.isSafeInteger(days) || days < 1 || days > 365) {
+    throw new Error('API key lifetime must be an integer between 1 and 365 days');
+  }
+  return days;
+}
+
+function retiredLegacyValue(agentId: string): string {
+  return `retired:${agentId}:${crypto.randomUUID()}`;
+}
+
+export async function authenticateAgent(
+  request: NextRequest,
+  opts: { isOrderOp?: boolean; database?: McpDatabase } = {},
+): Promise<AgentAuthResult> {
+  const apiKey = extractAgentApiKey(request);
 
   if (!apiKey) {
     return {
       success: false,
       error: {
         code: 'MISSING_API_KEY',
-        message: 'Agent API key required in X-Agent-API-Key header, Authorization header, or api_key query parameter'
-      }
+        message: 'Agent API key required in X-Agent-API-Key or Authorization header',
+      },
     };
   }
 
   try {
-    const db = await getDbAsync();
-    const agent = await db.select()
+    const db = opts.database ?? await getDbAsync();
+    const apiKeyHash = await sha256Hex(apiKey);
+    const agents = await db.select()
       .from(mcpAgents)
       .where(and(
-        eq(mcpAgents.apiKey, apiKey),
-        eq(mcpAgents.isActive, true)
+        eq(mcpAgents.isActive, true),
+        or(
+          eq(mcpAgents.apiKeyHash, apiKeyHash),
+          and(
+            isNull(mcpAgents.apiKeyHash),
+            eq(mcpAgents.legacyApiKey, apiKey),
+          ),
+        ),
       ))
       .limit(1);
 
-    if (agent.length === 0) {
+    const agent = agents[0];
+    if (!agent) {
       return {
         success: false,
-        error: {
-          code: 'INVALID_API_KEY',
-          message: 'Invalid or inactive agent API key'
-        }
+        error: { code: 'INVALID_API_KEY', message: 'Invalid or inactive agent API key' },
       };
     }
 
-    const agentData = agent[0];
-
-    // Check rate limits
-    const rateLimitCheck = await checkRateLimit(agentData.agentId, agentData.rateLimitRpm || 100, agentData.rateLimitOph || 10);
-    if (!rateLimitCheck.success) {
-      return rateLimitCheck;
+    const now = new Date();
+    const expiresAt = agent.apiKeyExpiresAt ? new Date(agent.apiKeyExpiresAt) : null;
+    if (expiresAt && (!Number.isFinite(expiresAt.getTime()) || expiresAt <= now)) {
+      return {
+        success: false,
+        error: { code: 'API_KEY_EXPIRED', message: 'Agent API key has expired' },
+      };
     }
 
-    // Update last used timestamp
+    // Transitional dual-read: a successful legacy authentication upgrades the
+    // row in place, retires the plaintext value, and grants a bounded rotation
+    // window. The conditional update makes concurrent upgrades converge.
+    if (!agent.apiKeyHash && agent.legacyApiKey === apiKey) {
+      await db.update(mcpAgents)
+        .set({
+          apiKeyHash,
+          legacyApiKey: retiredLegacyValue(agent.agentId),
+          apiKeyExpiresAt: agent.apiKeyExpiresAt || expiryFromNow(LEGACY_KEY_GRACE_DAYS),
+          credentialVersion: 2,
+        })
+        .where(and(
+          eq(mcpAgents.agentId, agent.agentId),
+          isNull(mcpAgents.apiKeyHash),
+          eq(mcpAgents.legacyApiKey, apiKey),
+        ));
+    }
+
+    const rateLimit = await checkRateLimit(
+      agent.agentId,
+      agent.rateLimitRpm ?? 100,
+      agent.rateLimitOph ?? 10,
+      opts.isOrderOp ?? false,
+      db,
+    );
+    if (!rateLimit.success) return rateLimit;
+
     await db.update(mcpAgents)
-      .set({ lastUsed: new Date().toISOString() })
-      .where(eq(mcpAgents.agentId, agentData.agentId));
+      .set({ lastUsed: now.toISOString() })
+      .where(eq(mcpAgents.agentId, agent.agentId));
 
     return {
       success: true,
-      agentId: agentData.agentId
+      agentId: agent.agentId,
+      permissions: parsePermissions(agent.permissions),
     };
   } catch (error) {
+    console.error('MCP authentication failed', error);
     return {
       success: false,
-      error: {
-        code: 'AUTH_ERROR',
-        message: 'Authentication failed',
-        details: error instanceof Error ? error.message : 'Unknown error'
-      }
+      error: { code: 'AUTH_ERROR', message: 'Authentication failed' },
     };
   }
 }
 
-async function checkRateLimit(agentId: string, rpmLimit: number, ophLimit: number): Promise<AgentAuthResult> {
-  const now = new Date();
-  const minuteStart = new Date(now.getFullYear(), now.getMonth(), now.getDate(), now.getHours(), now.getMinutes());
-  const hourStart = new Date(now.getFullYear(), now.getMonth(), now.getDate(), now.getHours());
+export function getRateLimitWindowStarts(now: Date = new Date()): {
+  minuteStart: string;
+  hourStart: string;
+} {
+  const minuteStart = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate(),
+    now.getHours(),
+    now.getMinutes(),
+  );
+  const hourStart = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate(),
+    now.getHours(),
+  );
+  return { minuteStart: minuteStart.toISOString(), hourStart: hourStart.toISOString() };
+}
+
+export async function checkRateLimit(
+  agentId: string,
+  rpmLimit: number,
+  ophLimit: number,
+  isOrderOp = false,
+  database?: McpDatabase,
+): Promise<AgentAuthResult> {
+  const { minuteStart, hourStart } = getRateLimitWindowStarts();
 
   try {
-    const db = await getDbAsync();
-    
-    // Check minute rate limit
+    const db = database ?? await getDbAsync();
     const minuteUsage = await db.select()
       .from(mcpRateLimits)
       .where(and(
         eq(mcpRateLimits.agentId, agentId),
         eq(mcpRateLimits.window, 'minute'),
-        gte(mcpRateLimits.windowStart, minuteStart.toISOString())
+        gte(mcpRateLimits.windowStart, minuteStart),
       ))
       .limit(1);
 
-    if (minuteUsage.length > 0 && (minuteUsage[0]?.count || 0) >= rpmLimit) {
+    if ((minuteUsage[0]?.count || 0) >= rpmLimit) {
       return {
         success: false,
         error: {
           code: 'RATE_LIMIT_EXCEEDED',
-          message: `Rate limit exceeded: ${rpmLimit} requests per minute`
-        }
+          message: `Rate limit exceeded: ${rpmLimit} requests per minute`,
+        },
       };
     }
 
-    // Check hour rate limit for orders (if this is an order endpoint)
-    const hourUsage = await db.select()
-      .from(mcpRateLimits)
-      .where(and(
-        eq(mcpRateLimits.agentId, agentId),
-        eq(mcpRateLimits.window, 'hour'),
-        gte(mcpRateLimits.windowStart, hourStart.toISOString())
-      ))
-      .limit(1);
+    if (isOrderOp) {
+      const hourUsage = await db.select()
+        .from(mcpRateLimits)
+        .where(and(
+          eq(mcpRateLimits.agentId, agentId),
+          eq(mcpRateLimits.window, 'hour'),
+          gte(mcpRateLimits.windowStart, hourStart),
+        ))
+        .limit(1);
 
-    if (hourUsage.length > 0 && (hourUsage[0]?.count || 0) >= ophLimit) {
-      return {
-        success: false,
-        error: {
-          code: 'RATE_LIMIT_EXCEEDED',
-          message: `Rate limit exceeded: ${ophLimit} operations per hour`
-        }
-      };
+      if ((hourUsage[0]?.count || 0) >= ophLimit) {
+        return {
+          success: false,
+          error: {
+            code: 'RATE_LIMIT_EXCEEDED',
+            message: `Rate limit exceeded: ${ophLimit} operations per hour`,
+          },
+        };
+      }
     }
 
-    // Update rate limit counters
-    await updateRateLimit(agentId, 'minute', minuteStart.toISOString());
-    
+    if (isOrderOp) {
+      await db.batch([
+        buildRateLimitUpsert(db, agentId, 'minute', minuteStart),
+        buildRateLimitUpsert(db, agentId, 'hour', hourStart),
+      ]);
+    } else {
+      await db.batch([buildRateLimitUpsert(db, agentId, 'minute', minuteStart)]);
+    }
+
     return { success: true, agentId };
   } catch (error) {
+    console.error('MCP rate-limit check failed', error);
     return {
       success: false,
-      error: {
-        code: 'RATE_LIMIT_ERROR',
-        message: 'Failed to check rate limits',
-        details: error instanceof Error ? error.message : 'Unknown error'
-      }
+      error: { code: 'RATE_LIMIT_ERROR', message: 'Failed to check rate limits' },
     };
   }
 }
 
-async function updateRateLimit(agentId: string, window: string, windowStart: string): Promise<void> {
-  const db = await getDbAsync();
-  
-  // Upsert rate limit record
-  await db.insert(mcpRateLimits)
-    .values({
-      agentId,
-      window,
-      count: 1,
-      windowStart
-    })
+function buildRateLimitUpsert(
+  db: Awaited<ReturnType<typeof getDbAsync>>,
+  agentId: string,
+  window: string,
+  windowStart: string,
+) {
+  return db.insert(mcpRateLimits)
+    .values({ agentId, window, count: 1, windowStart })
     .onConflictDoUpdate({
       target: [mcpRateLimits.agentId, mcpRateLimits.window],
       set: {
-        count: sql`count + 1`,
-        windowStart: windowStart
+        count: sql`CASE WHEN ${mcpRateLimits.windowStart} = ${windowStart} THEN ${mcpRateLimits.count} + 1 ELSE 1 END`,
+        windowStart,
       },
-      where: eq(mcpRateLimits.windowStart, windowStart)
     });
 }
 
-export async function createAgent(agentData: {
+export async function updateRateLimit(
+  agentId: string,
+  window: string,
+  windowStart: string,
+  database?: McpDatabase,
+): Promise<void> {
+  const db = database ?? await getDbAsync();
+  await buildRateLimitUpsert(db, agentId, window, windowStart);
+}
+
+export interface CreateAgentCredentialInput {
   agentId: string;
   name: string;
   description?: string;
   permissions?: string[];
   rateLimitRpm?: number;
   rateLimitOph?: number;
-}): Promise<{ apiKey: string }> {
+  apiKeyTtlDays?: number;
+}
+
+export interface IssuedAgentCredential {
+  apiKey: string;
+  expiresAt: string;
+}
+
+export async function createAgent(
+  agentData: CreateAgentCredentialInput,
+): Promise<IssuedAgentCredential> {
   const db = await getDbAsync();
   const apiKey = generateApiKey();
-  
+  const apiKeyHash = await sha256Hex(apiKey);
+  const expiresAt = expiryFromNow(normalizeTtlDays(agentData.apiKeyTtlDays));
+
   await db.insert(mcpAgents).values({
     agentId: agentData.agentId,
     name: agentData.name,
     description: agentData.description,
-    apiKey,
+    legacyApiKey: retiredLegacyValue(agentData.agentId),
+    apiKeyHash,
+    apiKeyExpiresAt: expiresAt,
+    credentialVersion: 2,
     permissions: JSON.stringify(agentData.permissions || []),
-    rateLimitRpm: agentData.rateLimitRpm || 100,
-    rateLimitOph: agentData.rateLimitOph || 10,
-    isActive: true
+    rateLimitRpm: agentData.rateLimitRpm ?? 100,
+    rateLimitOph: agentData.rateLimitOph ?? 10,
+    isActive: true,
   });
 
-  return { apiKey };
+  return { apiKey, expiresAt };
 }
 
-function generateApiKey(): string {
-  return `mcp_${Date.now()}_${Math.random().toString(36).substring(2, 15)}`;
+export async function rotateAgentApiKey(
+  agentId: string,
+  apiKeyTtlDays?: number,
+): Promise<IssuedAgentCredential> {
+  const db = await getDbAsync();
+  const apiKey = generateApiKey();
+  const apiKeyHash = await sha256Hex(apiKey);
+  const expiresAt = expiryFromNow(normalizeTtlDays(apiKeyTtlDays));
+
+  const updated = await db.update(mcpAgents)
+    .set({
+      legacyApiKey: retiredLegacyValue(agentId),
+      apiKeyHash,
+      apiKeyExpiresAt: expiresAt,
+      credentialVersion: sql`${mcpAgents.credentialVersion} + 1`,
+    })
+    .where(eq(mcpAgents.agentId, agentId))
+    .returning({ agentId: mcpAgents.agentId });
+
+  if (updated.length === 0) throw new Error('Agent not found');
+  return { apiKey, expiresAt };
+}
+
+export function generateApiKey(): string {
+  return `mcp_${crypto.randomUUID().replace(/-/g, '')}`;
 }

--- a/lib/mcp/catalog.ts
+++ b/lib/mcp/catalog.ts
@@ -1,0 +1,72 @@
+import { Money } from '../money';
+import { getCategoryDisplayName, listCategories } from '../models/mach/category';
+import { listProducts } from '../models/mach/products';
+import { allowedShippingCountries } from '../shipping/allowed-countries';
+import type { Product } from '../types';
+import { getSettings } from '../utils/settings';
+import type { CapabilitiesResponse } from './types';
+
+export function isPublicMcpProduct(product: Product): boolean {
+  return product.status === 'active';
+}
+
+const MERCHANDISING_CATEGORIES = new Set([
+  'featured',
+  'sale',
+  'on sale',
+  'new',
+  'new arrivals',
+  'bestsellers',
+  'best sellers',
+]);
+
+function variantPrices(product: Product): number[] {
+  return (product.variants ?? []).flatMap((variant) => {
+    try {
+      const amount = Money.fromStored(variant.price ?? 0).toMach().amount;
+      return amount > 0 ? [amount] : [];
+    } catch {
+      return [];
+    }
+  });
+}
+
+export async function getCatalogCapabilities(): Promise<CapabilitiesResponse> {
+  const [categories, products, shippingSettings] = await Promise.all([
+    listCategories(),
+    listProducts({ status: ['active'] }),
+    getSettings('shipping'),
+  ]);
+  const publicProducts = products.filter(isPublicMcpProduct);
+  const categoryNames = categories.flatMap((category) => {
+    const name = getCategoryDisplayName(category);
+    return name ? [name] : [];
+  });
+  const priceRanges: Record<string, { min: number; max: number }> = {};
+
+  for (const category of categories) {
+    const name = getCategoryDisplayName(category);
+    if (!name) continue;
+    const prices = publicProducts
+      .filter((product) => product.categories?.includes(category.id))
+      .flatMap(variantPrices);
+    if (prices.length) priceRanges[name] = { min: Math.min(...prices), max: Math.max(...prices) };
+  }
+
+  const specialties = categoryNames.filter(
+    (name) => !MERCHANDISING_CATEGORIES.has(name.toLowerCase()),
+  );
+  return {
+    categories: categoryNames,
+    price_ranges: priceRanges,
+    shipping_regions: allowedShippingCountries(shippingSettings),
+    specialties,
+  };
+}
+
+export function genericBundleSuggestions(distinctProducts: number): string[] {
+  if (distinctProducts < 1) return [];
+  return distinctProducts === 1
+    ? ['Browse related catalog items that complement this product.']
+    : ['Review the selected products together for complementary options.'];
+}

--- a/lib/mcp/checkout.ts
+++ b/lib/mcp/checkout.ts
@@ -1,0 +1,247 @@
+import { and, eq, sql } from 'drizzle-orm';
+import { getDbAsync } from '@/lib/db';
+import { orders } from '@/lib/db/schema/order';
+import { Money, toWireMoney } from '@/lib/money';
+import { hydrateOrder } from '@/lib/models/mach/orders';
+import { isBoundedString, isPlainRecord } from '@/lib/public-request-validation';
+import {
+  priceCheckout,
+  MAX_CHECKOUT_LINES,
+  type CheckoutQuote,
+} from '@/lib/services/checkout-pricing';
+import {
+  assertCheckoutInventoryAvailable,
+} from '@/lib/services/inventory-adjustments';
+import { cancelPaymentIntent, createPaymentIntent } from '@/lib/stripe';
+import type { Address, Order } from '@/lib/types';
+import type { AgentSession } from './types';
+
+export interface McpCheckoutRequest {
+  shippingAddress: unknown;
+  shippingMethodId?: string;
+  shippingOption?: string;
+  discountCodes?: string[];
+  giftCardToken?: string;
+}
+
+export interface McpCheckoutResult {
+  clientSecret: string;
+  paymentIntentId: string;
+  orderId: string;
+  amount: ReturnType<typeof toWireMoney>;
+  quote: CheckoutQuote;
+}
+
+export function normalizeMcpAddress(value: unknown): Address {
+  if (!isPlainRecord(value)) throw new Error('Shipping address is required');
+  const line1 = value.line1 ?? value.street;
+  const line2 = value.line2 ?? value.street2;
+  const region = value.region ?? value.state;
+  const postalCode = value.postal_code ?? value.postalCode;
+  const country = value.country ?? 'US';
+  const email = typeof value.email === 'string' ? value.email.trim() : undefined;
+
+  if (!(
+    isBoundedString(line1, 256) &&
+    isBoundedString(value.city, 128) &&
+    isBoundedString(region, 128) &&
+    isBoundedString(postalCode, 32) &&
+    isBoundedString(country, 2) && /^[A-Za-z]{2}$/.test(country) &&
+    (line2 === undefined || isBoundedString(line2, 256, { allowEmpty: true })) &&
+    (value.recipient === undefined || isBoundedString(value.recipient, 256, { allowEmpty: true })) &&
+    (email === undefined || email === '' || /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email))
+  )) {
+    throw new Error('Shipping address is invalid');
+  }
+
+  return {
+    line1,
+    ...(line2 !== undefined ? { line2 } : {}),
+    city: value.city,
+    region,
+    postal_code: postalCode,
+    country: country.toUpperCase(),
+    ...(value.recipient !== undefined ? { recipient: value.recipient } : {}),
+    ...(email ? { email } : {}),
+    type: 'shipping',
+    status: 'unverified',
+  };
+}
+
+function newMcpOrderId(agentId: string): string {
+  const owner = agentId.replace(/[^a-zA-Z0-9]/g, '').toUpperCase().slice(0, 32) || 'AGENT';
+  return `MCP-${owner}-${Date.now()}-${crypto.randomUUID().slice(0, 8).toUpperCase()}`;
+}
+
+export async function createMcpCheckout(args: {
+  agentId: string;
+  session: AgentSession;
+  input: McpCheckoutRequest;
+}): Promise<McpCheckoutResult> {
+  if (args.session.cart.length === 0) throw new Error('Cart is empty');
+  if (args.session.cart.length > MAX_CHECKOUT_LINES) {
+    throw new Error(`Cart has too many distinct items (max ${MAX_CHECKOUT_LINES})`);
+  }
+
+  const shippingAddress = normalizeMcpAddress(args.input.shippingAddress);
+  const shippingMethodId = args.input.shippingMethodId ?? args.input.shippingOption;
+  if (!isBoundedString(shippingMethodId, 128)) throw new Error('Shipping method is required');
+
+  const quote = await priceCheckout({
+    items: args.session.cart.map((item) => ({
+      productId: item.productId,
+      variantId: item.variantId,
+      quantity: item.quantity,
+    })),
+    shippingAddress,
+    shippingMethodId,
+    discountCodes: args.input.discountCodes,
+    giftCardToken: args.input.giftCardToken,
+  });
+  await assertCheckoutInventoryAvailable(quote.items);
+
+  const total = Money.fromStored(quote.total);
+  if (!total.gt(Money.zero(total.currency))) {
+    throw new Error('Checkout requires a positive payment amount');
+  }
+
+  const orderId = newMcpOrderId(args.agentId);
+  const paymentIntent = await createPaymentIntent({
+    amount: total.toMinorUnits(),
+    currency: total.currency.toLowerCase(),
+    automatic_payment_methods: { enabled: true },
+    metadata: {
+      orderId,
+      agentId: args.agentId,
+      sessionId: args.session.sessionId,
+      expectedAmount: String(total.toMinorUnits()),
+      currency: total.currency,
+    },
+    shipping: {
+      address: {
+        line1: String(shippingAddress.line1),
+        line2: shippingAddress.line2 ? String(shippingAddress.line2) : undefined,
+        city: String(shippingAddress.city),
+        state: shippingAddress.region,
+        postal_code: shippingAddress.postal_code,
+        country: shippingAddress.country,
+      },
+      name: shippingAddress.recipient || 'Customer',
+    },
+    description: `Order ${orderId}`,
+  });
+
+  const providerAmount = Number(paymentIntent.amount);
+  const providerCurrency = String(paymentIntent.currency || '').toUpperCase();
+  if (
+    !Number.isSafeInteger(providerAmount) ||
+    providerAmount !== total.toMinorUnits() ||
+    providerCurrency !== total.currency ||
+    !paymentIntent.client_secret
+  ) {
+    await cancelPaymentIntent(paymentIntent.id).catch((error) =>
+      console.error(`[mcp] Failed to cancel invalid PaymentIntent ${paymentIntent.id}:`, error)
+    );
+    throw new Error('Payment provider returned an invalid intent');
+  }
+
+  const catalogSubtotal = Money.fromStored(quote.subtotal);
+  const merchandiseDiscount = Money.fromStored(quote.merchandiseDiscount, quote.currency);
+  const baseShipping = Money.fromStored(quote.shipping, quote.currency);
+  const shippingDiscount = Money.fromStored(quote.shippingDiscount, quote.currency);
+  const extensions = {
+    agent_id: args.agentId,
+    mcp_session_id: args.session.sessionId,
+    email: shippingAddress.email,
+    payment_intent_id: paymentIntent.id,
+    checkout_catalog_subtotal: catalogSubtotal.toJSON(),
+    checkout_subtotal: catalogSubtotal.subtract(merchandiseDiscount).toJSON(),
+    checkout_discount: quote.discount,
+    checkout_merchandise_discount: quote.merchandiseDiscount,
+    checkout_shipping_before_discount: baseShipping.toJSON(),
+    checkout_shipping_discount: quote.shippingDiscount,
+    checkout_shipping: baseShipping.subtract(shippingDiscount).toJSON(),
+    checkout_tax: quote.tax,
+    checkout_shipping_tax: quote.shippingTax,
+    checkout_line_allocations: quote.lineAllocations,
+    checkout_tender: quote.tender,
+    checkout_tender_state: quote.tenderState,
+    checkout_total: Money.fromMinor(providerAmount, providerCurrency).toJSON(),
+    discount_codes: quote.discountCodes,
+    tax_source: quote.taxSource,
+  };
+
+  try {
+    const db = await getDbAsync();
+    await db.insert(orders).values({
+      id: orderId,
+      customer_id: null,
+      status: 'pending',
+      total_amount: Money.fromMinor(providerAmount, providerCurrency).toJSON(),
+      currency_code: providerCurrency,
+      shipping_address: shippingAddress,
+      billing_address: shippingAddress,
+      items: quote.items,
+      shipping_method: quote.shippingMethod.label,
+      payment_method: 'stripe',
+      payment_status: 'pending',
+      external_references: { payment_intent_id: paymentIntent.id },
+      extensions,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    });
+  } catch (error) {
+    await cancelPaymentIntent(paymentIntent.id).catch((cancelError) =>
+      console.error(`[mcp] Failed to cancel orphaned PaymentIntent ${paymentIntent.id}:`, cancelError)
+    );
+    throw error;
+  }
+
+  return {
+    clientSecret: paymentIntent.client_secret,
+    paymentIntentId: paymentIntent.id,
+    orderId,
+    amount: toWireMoney(Money.fromMinor(providerAmount, providerCurrency).toJSON()),
+    quote,
+  };
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  if (!value) return {};
+  if (typeof value === 'string') {
+    try { return asRecord(JSON.parse(value)); } catch { return {}; }
+  }
+  return typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+}
+
+export async function getOwnedMcpOrder(orderId: string, agentId: string): Promise<Order | null> {
+  const db = await getDbAsync();
+  const [record] = await db.select().from(orders).where(eq(orders.id, orderId)).limit(1);
+  if (!record) return null;
+  const extensions = asRecord(record.extensions);
+  if (extensions.agent_id !== agentId) return null;
+  return hydrateOrder(record);
+}
+
+export async function getOwnedMcpOrderBinding(args: {
+  orderId: string;
+  paymentIntentId: string;
+  agentId: string;
+  sessionId: string;
+}): Promise<Order | null> {
+  const db = await getDbAsync();
+  const [record] = await db.select().from(orders).where(and(
+    eq(orders.id, args.orderId),
+    sql`json_extract(${orders.external_references}, '$.payment_intent_id') = ${args.paymentIntentId}`,
+  )).limit(1);
+  if (!record) return null;
+  const extensions = asRecord(record.extensions);
+  if (
+    extensions.agent_id !== args.agentId ||
+    extensions.mcp_session_id !== args.sessionId ||
+    extensions.payment_intent_id !== args.paymentIntentId
+  ) return null;
+  return hydrateOrder(record);
+}

--- a/lib/mcp/context.ts
+++ b/lib/mcp/context.ts
@@ -1,11 +1,14 @@
 import { NextRequest } from 'next/server';
 import { AgentContext } from './types';
 
-export function parseAgentContext(request: NextRequest): AgentContext | null {
+export function parseAgentContext(
+  request: NextRequest,
+  authenticatedAgentId?: string,
+): AgentContext | null {
   try {
     const contextHeader = request.headers.get('X-Agent-Context');
     if (!contextHeader) {
-      return null;
+      return authenticatedAgentId ? { agentId: authenticatedAgentId } : null;
     }
 
     const context: AgentContext = JSON.parse(contextHeader);
@@ -26,6 +29,12 @@ export function parseAgentContext(request: NextRequest): AgentContext | null {
       throw new Error(`Agent context too large: ${contextSize} bytes (max 1024)`);
     }
 
+    // X-Agent-Context is client-controlled. Authentication, not this header,
+    // owns identity attribution.
+    if (authenticatedAgentId) {
+      context.agentId = authenticatedAgentId;
+    }
+
     return context;
   } catch (error) {
     console.error('Failed to parse agent context:', error);
@@ -36,24 +45,40 @@ export function parseAgentContext(request: NextRequest): AgentContext | null {
 function validateUserPreferences(preferences: AgentContext['userPreferences']): void {
   if (!preferences) return;
 
-  if (preferences.budget && (typeof preferences.budget !== 'number' || preferences.budget < 0)) {
-    throw new Error('budget must be a positive number');
+  if (
+    preferences.budget !== undefined &&
+    (typeof preferences.budget !== 'number' || !Number.isFinite(preferences.budget) || preferences.budget < 0)
+  ) {
+    throw new Error('budget must be a non-negative finite number');
   }
 
-  if (preferences.brands && !Array.isArray(preferences.brands)) {
-    throw new Error('brands must be an array of strings');
+  if (preferences.brands) {
+    validateStringList(preferences.brands, 'brands');
   }
 
-  if (preferences.activities && !Array.isArray(preferences.activities)) {
-    throw new Error('activities must be an array of strings');
+  if (preferences.activities) {
+    validateStringList(preferences.activities, 'activities');
   }
 
-  if (preferences.location && typeof preferences.location !== 'string') {
-    throw new Error('location must be a string');
+  if (preferences.location && (typeof preferences.location !== 'string' || preferences.location.length > 256)) {
+    throw new Error('location must be a string of at most 256 characters');
   }
 
-  if (preferences.experience_level && typeof preferences.experience_level !== 'string') {
-    throw new Error('experience_level must be a string');
+  if (
+    preferences.experience_level &&
+    (typeof preferences.experience_level !== 'string' || preferences.experience_level.length > 64)
+  ) {
+    throw new Error('experience_level must be a string of at most 64 characters');
+  }
+}
+
+function validateStringList(value: unknown, name: string): asserts value is string[] {
+  if (
+    !Array.isArray(value) ||
+    value.length > 50 ||
+    value.some((entry) => typeof entry !== 'string' || entry.length < 1 || entry.length > 128)
+  ) {
+    throw new Error(`${name} must contain at most 50 non-empty strings of at most 128 characters`);
   }
 }
 
@@ -74,5 +99,5 @@ export function enhanceUserContext(agentContext: AgentContext | null, existingUs
 }
 
 export function createAgentSessionId(agentId: string): string {
-  return `${agentId}_${Date.now()}_${Math.random().toString(36).substring(2, 8)}`;
+  return `${agentId}_${crypto.randomUUID()}`;
 }

--- a/lib/mcp/session.ts
+++ b/lib/mcp/session.ts
@@ -130,6 +130,36 @@ export async function getSessionCart(sessionId: string): Promise<CartItem[]> {
   return session?.cart || [];
 }
 
+export type SessionOwnershipResult =
+  | { ok: true; session: AgentSession }
+  | {
+      ok: false;
+      code: 'SESSION_NOT_FOUND' | 'SESSION_ACCESS_DENIED';
+      message: string;
+    };
+
+export async function requireOwnedSession(
+  sessionId: string,
+  agentId: string,
+): Promise<SessionOwnershipResult> {
+  const session = await getSession(sessionId);
+  if (!session) {
+    return {
+      ok: false,
+      code: 'SESSION_NOT_FOUND',
+      message: 'Session not found or expired',
+    };
+  }
+  if (session.agentId !== agentId) {
+    return {
+      ok: false,
+      code: 'SESSION_ACCESS_DENIED',
+      message: 'Agent does not own this session',
+    };
+  }
+  return { ok: true, session };
+}
+
 export async function updateSessionCart(sessionId: string, cart: CartItem[]): Promise<boolean> {
   return updateSession(sessionId, { cart });
 }

--- a/lib/mcp/tools/agent.ts
+++ b/lib/mcp/tools/agent.ts
@@ -2,7 +2,7 @@ import { getDbAsync } from '../../db';
 import { mcpAgents, mcpSessions } from '../../db/schema/mcp';
 import { eq, desc, count, and, gte } from 'drizzle-orm';
 import { MCPToolResponse } from '../types';
-import { createAgent as createAgentAuth } from '../auth';
+import { createAgent as createAgentAuth, hasPermission, rotateAgentApiKey } from '../auth';
 import { AuthenticationError, ValidationError, ResourceNotFoundError, DatabaseError, createErrorResponse } from '../error-handler';
 
 export interface AgentInfo {
@@ -15,6 +15,8 @@ export interface AgentInfo {
   isActive: boolean;
   createdAt: string;
   lastUsed?: string;
+  apiKeyExpiresAt?: string;
+  credentialVersion: number;
 }
 
 export interface AgentStats {
@@ -31,11 +33,13 @@ export interface CreateAgentRequest {
   permissions?: string[];
   rateLimitRpm?: number;
   rateLimitOph?: number;
+  apiKeyTtlDays?: number;
 }
 
 export interface CreateAgentResponse {
   agent: AgentInfo;
   apiKey: string;
+  expiresAt: string;
   setup_instructions: string[];
 }
 
@@ -57,21 +61,85 @@ export interface AgentDetailsResponse {
   }>;
 }
 
+function safePermissions(value: string | null): string[] {
+  try {
+    const parsed: unknown = JSON.parse(value || '[]');
+    return Array.isArray(parsed)
+      ? parsed.filter((permission): permission is string => typeof permission === 'string')
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+function storedPermissions(value: string | null): string[] {
+  const parsed: unknown = JSON.parse(value || '[]');
+  if (!Array.isArray(parsed) || parsed.some((permission) => typeof permission !== 'string')) {
+    throw new Error('Agent has an invalid stored permission set');
+  }
+  return parsed;
+}
+
+export function canManageAgentPermissions(
+  managerPermissions: string[],
+  targetPermissions: string[],
+): boolean {
+  return targetPermissions.every((permission) => hasPermission(managerPermissions, permission));
+}
+
+function safeCartItemCount(value: string | null): number {
+  try {
+    const parsed: unknown = JSON.parse(value || '[]');
+    return Array.isArray(parsed) ? parsed.length : 0;
+  } catch {
+    return 0;
+  }
+}
+
 export async function createAgent(
   request: CreateAgentRequest,
   sessionId: string,
-  adminAgentId: string
+  adminAgentId: string,
+  adminPermissions: string[] = [],
 ): Promise<MCPToolResponse<CreateAgentResponse>> {
   const startTime = Date.now();
 
   try {
     // Validate input
-    if (!request.agentId || request.agentId.length < 3) {
-      throw ValidationError('agentId', 'Agent ID must be at least 3 characters long');
+    if (!request.agentId || !/^[A-Za-z0-9._-]{3,128}$/.test(request.agentId)) {
+      throw ValidationError('agentId', 'Agent ID must be 3-128 safe identifier characters');
     }
 
-    if (!request.name || request.name.length < 3) {
-      throw ValidationError('name', 'Agent name must be at least 3 characters long');
+    if (typeof request.name !== 'string' || request.name.length < 3 || request.name.length > 128) {
+      throw ValidationError('name', 'Agent name must be between 3 and 128 characters long');
+    }
+    if (
+      request.description !== undefined &&
+      (typeof request.description !== 'string' || request.description.length > 1_000)
+    ) {
+      throw ValidationError('description', 'Agent description must be a string of at most 1000 characters');
+    }
+
+    const requestedPermissions = request.permissions ?? [];
+    if (
+      !Array.isArray(requestedPermissions) ||
+      requestedPermissions.length > 50 ||
+      requestedPermissions.some((permission) =>
+        typeof permission !== 'string' || permission.length < 1 || permission.length > 128
+      )
+    ) {
+      throw ValidationError('permissions', 'Permissions must be at most 50 non-empty strings');
+    }
+    if (!canManageAgentPermissions(adminPermissions, requestedPermissions)) {
+      throw ValidationError('permissions', 'Cannot grant a permission the managing agent does not hold');
+    }
+    for (const [field, value] of [
+      ['rateLimitRpm', request.rateLimitRpm],
+      ['rateLimitOph', request.rateLimitOph],
+    ] as const) {
+      if (value !== undefined && (!Number.isSafeInteger(value) || value < 1 || value > 100_000)) {
+        throw ValidationError(field, `${field} must be an integer between 1 and 100000`);
+      }
     }
 
     // Check if agent already exists
@@ -86,13 +154,14 @@ export async function createAgent(
     }
 
     // Create the agent
-    const { apiKey } = await createAgentAuth({
+    const { apiKey, expiresAt } = await createAgentAuth({
       agentId: request.agentId,
       name: request.name,
       description: request.description,
-      permissions: request.permissions,
+      permissions: requestedPermissions,
       rateLimitRpm: request.rateLimitRpm,
-      rateLimitOph: request.rateLimitOph
+      rateLimitOph: request.rateLimitOph,
+      apiKeyTtlDays: request.apiKeyTtlDays,
     });
 
     // Get the created agent info
@@ -106,12 +175,14 @@ export async function createAgent(
       agentId: agentData.agentId,
       name: agentData.name || '',
       description: agentData.description || undefined,
-      permissions: JSON.parse(agentData.permissions || '[]'),
-      rateLimitRpm: agentData.rateLimitRpm || 100,
-      rateLimitOph: agentData.rateLimitOph || 10,
+      permissions: safePermissions(agentData.permissions),
+      rateLimitRpm: agentData.rateLimitRpm ?? 100,
+      rateLimitOph: agentData.rateLimitOph ?? 10,
       isActive: agentData.isActive || false,
       createdAt: agentData.createdAt || '',
-      lastUsed: agentData.lastUsed || undefined
+      lastUsed: agentData.lastUsed || undefined,
+      apiKeyExpiresAt: agentData.apiKeyExpiresAt || undefined,
+      credentialVersion: agentData.credentialVersion,
     };
 
     const processingTime = Date.now() - startTime;
@@ -121,6 +192,7 @@ export async function createAgent(
       data: {
         agent,
         apiKey,
+        expiresAt,
         setup_instructions: [
           'Store the API key securely - it will not be shown again',
           'Include the API key in X-Agent-API-Key header for all requests',
@@ -150,6 +222,7 @@ export async function createAgent(
       return createErrorResponse(new Error(`Validation error: ${(error as any).message}`), sessionId, adminAgentId, processingTime, {
         agent: {} as AgentInfo,
         apiKey: '',
+        expiresAt: '',
         setup_instructions: []
       });
     }
@@ -162,6 +235,7 @@ export async function createAgent(
       {
         agent: {} as AgentInfo,
         apiKey: '',
+        expiresAt: '',
         setup_instructions: []
       }
     );
@@ -177,6 +251,12 @@ export async function listAgents(
   const startTime = Date.now();
 
   try {
+    if (!Number.isSafeInteger(page) || page < 1) {
+      throw ValidationError('page', 'page must be a positive integer');
+    }
+    if (!Number.isSafeInteger(limit) || limit < 1 || limit > 100) {
+      throw ValidationError('limit', 'limit must be an integer between 1 and 100');
+    }
     const db = await getDbAsync();
     const offset = (page - 1) * limit;
 
@@ -192,24 +272,21 @@ export async function listAgents(
       .from(mcpAgents);
     const total = totalResult[0].count;
 
-    // Get stats for each agent
-    const agentsWithStats = await Promise.all(
-      agents.map(async (agent) => {
-        const stats = await getAgentStats(agent.agentId);
-        return {
-          agentId: agent.agentId,
-          name: agent.name || '',
-          description: agent.description || undefined,
-          permissions: JSON.parse(agent.permissions || '[]'),
-          rateLimitRpm: agent.rateLimitRpm || 100,
-          rateLimitOph: agent.rateLimitOph || 10,
-          isActive: agent.isActive || false,
-          createdAt: agent.createdAt || '',
-          lastUsed: agent.lastUsed || undefined,
-          stats
-        };
-      })
-    );
+    // Detailed stats remain available from get_agent_details. Keeping the
+    // paginated list to two aggregate queries avoids a D1 N+1 fan-out.
+    const agentsWithStats = agents.map((agent) => ({
+      agentId: agent.agentId,
+      name: agent.name || '',
+      description: agent.description || undefined,
+      permissions: safePermissions(agent.permissions),
+      rateLimitRpm: agent.rateLimitRpm ?? 100,
+      rateLimitOph: agent.rateLimitOph ?? 10,
+      isActive: agent.isActive ?? false,
+      createdAt: agent.createdAt || '',
+      lastUsed: agent.lastUsed || undefined,
+      apiKeyExpiresAt: agent.apiKeyExpiresAt || undefined,
+      credentialVersion: agent.credentialVersion,
+    }));
 
     const processingTime = Date.now() - startTime;
 
@@ -275,12 +352,14 @@ export async function getAgentDetails(
       agentId: agentData.agentId,
       name: agentData.name || '',
       description: agentData.description || undefined,
-      permissions: JSON.parse(agentData.permissions || '[]'),
-      rateLimitRpm: agentData.rateLimitRpm || 100,
-      rateLimitOph: agentData.rateLimitOph || 10,
+      permissions: safePermissions(agentData.permissions),
+      rateLimitRpm: agentData.rateLimitRpm ?? 100,
+      rateLimitOph: agentData.rateLimitOph ?? 10,
       isActive: agentData.isActive || false,
       createdAt: agentData.createdAt || '',
-      lastUsed: agentData.lastUsed || undefined
+      lastUsed: agentData.lastUsed || undefined,
+      apiKeyExpiresAt: agentData.apiKeyExpiresAt || undefined,
+      credentialVersion: agentData.credentialVersion,
     };
 
     // Get detailed stats
@@ -302,7 +381,7 @@ export async function getAgentDetails(
       sessionId: session.sessionId,
       createdAt: session.createdAt || '',
       expiresAt: session.expiresAt,
-      itemsInCart: session.cart ? JSON.parse(session.cart).length : 0
+      itemsInCart: safeCartItemCount(session.cart)
     }));
 
     const processingTime = Date.now() - startTime;
@@ -358,7 +437,8 @@ export async function updateAgentStatus(
   agentId: string,
   isActive: boolean,
   sessionId: string,
-  adminAgentId: string
+  adminAgentId: string,
+  adminPermissions: string[] = [],
 ): Promise<MCPToolResponse<{ agent: AgentInfo; previous_status: boolean }>> {
   const startTime = Date.now();
 
@@ -373,6 +453,9 @@ export async function updateAgentStatus(
 
     if (agentResult.length === 0) {
       throw ResourceNotFoundError('Agent', agentId);
+    }
+    if (!canManageAgentPermissions(adminPermissions, storedPermissions(agentResult[0].permissions))) {
+      throw ValidationError('permissions', 'Cannot change an agent with permissions the managing agent does not hold');
     }
 
     const previousStatus = agentResult[0].isActive;
@@ -393,12 +476,14 @@ export async function updateAgentStatus(
       agentId: agentData.agentId,
       name: agentData.name || '',
       description: agentData.description || undefined,
-      permissions: JSON.parse(agentData.permissions || '[]'),
-      rateLimitRpm: agentData.rateLimitRpm || 100,
-      rateLimitOph: agentData.rateLimitOph || 10,
+      permissions: safePermissions(agentData.permissions),
+      rateLimitRpm: agentData.rateLimitRpm ?? 100,
+      rateLimitOph: agentData.rateLimitOph ?? 10,
       isActive: agentData.isActive || false,
       createdAt: agentData.createdAt || '',
-      lastUsed: agentData.lastUsed || undefined
+      lastUsed: agentData.lastUsed || undefined,
+      apiKeyExpiresAt: agentData.apiKeyExpiresAt || undefined,
+      credentialVersion: agentData.credentialVersion,
     };
 
     const processingTime = Date.now() - startTime;
@@ -435,6 +520,51 @@ export async function updateAgentStatus(
         agent: {} as AgentInfo,
         previous_status: false
       }
+    );
+  }
+}
+
+export async function rotateAgentCredential(
+  agentId: string,
+  apiKeyTtlDays: number | undefined,
+  sessionId: string,
+  adminAgentId: string,
+  adminPermissions: string[] = [],
+): Promise<MCPToolResponse<{ apiKey: string; expiresAt: string }>> {
+  const startTime = Date.now();
+
+  try {
+    const db = await getDbAsync();
+    const [target] = await db.select({ permissions: mcpAgents.permissions })
+      .from(mcpAgents)
+      .where(eq(mcpAgents.agentId, agentId))
+      .limit(1);
+    if (!target) throw ResourceNotFoundError('Agent', agentId);
+    if (!canManageAgentPermissions(adminPermissions, storedPermissions(target.permissions))) {
+      throw ValidationError('permissions', 'Cannot rotate an agent with permissions the managing agent does not hold');
+    }
+    const credential = await rotateAgentApiKey(agentId, apiKeyTtlDays);
+    return {
+      success: true,
+      data: credential,
+      context: {
+        session_id: sessionId,
+        agent_id: adminAgentId,
+        processing_time_ms: Date.now() - startTime,
+      },
+      metadata: {
+        can_fulfill_percentage: 100,
+        estimated_satisfaction: 95,
+        next_actions: ['Store the new API key securely; it will not be shown again'],
+      },
+    };
+  } catch (error) {
+    return createErrorResponse(
+      error instanceof Error ? error : new Error('Failed to rotate agent credential'),
+      sessionId,
+      adminAgentId,
+      Date.now() - startTime,
+      { apiKey: '', expiresAt: '' },
     );
   }
 }

--- a/lib/mcp/tools/assess.ts
+++ b/lib/mcp/tools/assess.ts
@@ -1,9 +1,9 @@
 import { searchProducts } from '../../models/mach/products';
-import { listCategories } from '../../models/mach/category';
 import { AssessRequest, AssessResponse, MCPToolResponse } from '../types';
 import { enhanceUserContext } from '../context';
 import { Money } from '../../money';
 import { toPublicProduct, toWireProduct } from '../../models/mach/product-serializer';
+import { isBoundedString, isPlainRecord } from '../../public-request-validation';
 
 export async function assessFulfillmentCapability(
   request: AssessRequest,
@@ -12,49 +12,48 @@ export async function assessFulfillmentCapability(
   const startTime = Date.now();
   
   try {
-    const requirements = request.requirements;
+    if (!isPlainRecord(request?.requirements)) throw new Error('requirements are required');
+    const rawItems = request.requirements.items;
+    if (
+      !Array.isArray(rawItems) ||
+      rawItems.length === 0 ||
+      rawItems.length > 20 ||
+      rawItems.some((item) => !isBoundedString(item, 256))
+    ) {
+      throw new Error('requirements.items must contain 1-20 non-empty strings');
+    }
+    if (
+      request.requirements.budget !== undefined &&
+      (!Number.isFinite(request.requirements.budget) || request.requirements.budget < 0)
+    ) {
+      throw new Error('requirements.budget must be a non-negative finite number');
+    }
+    if (
+      (request.requirements.timeline !== undefined &&
+        !isBoundedString(request.requirements.timeline, 256, { allowEmpty: true })) ||
+      (request.requirements.location !== undefined &&
+        !isBoundedString(request.requirements.location, 256, { allowEmpty: true }))
+    ) {
+      throw new Error('requirements timeline and location are too long');
+    }
+    const requirements = {
+      ...request.requirements,
+      items: rawItems.map((item) => item.trim()),
+    };
     const userContext = enhanceUserContext(request.agent_context || null);
     
-    // Get our categories and capabilities
-    const categories = await listCategories();
-    const categoryNames = categories.map(cat => typeof cat.name === 'string' ? cat.name.toLowerCase() : String(cat.name || '').toLowerCase());
-    
-    // Define Voltique's core specialties
-    const ourSpecialties = [
-      'camping', 'hiking', 'backpacking', 'outdoor', 'tent', 'sleeping bag',
-      'backpack', 'headlamp', 'stove', 'gear', 'adventure', 'trail', 'mountain'
-    ];
-    
     // Assess each requested item
-    const canFulfill: string[] = [];
-    const cannotFulfill: string[] = [];
-    const assessmentResults: Array<{item: string, confidence: number, products: any[]}> = [];
-    
-    for (const item of requirements.items) {
-      const itemLower = item.toLowerCase();
-      
-      // Check if item matches our specialties
-      const isOurSpecialty = ourSpecialties.some(specialty => 
-        itemLower.includes(specialty) || specialty.includes(itemLower)
-      );
-      
-      // Search for products matching this item
-      const searchResults = await searchProducts(item);
-      
-      const confidence = calculateConfidence(itemLower, searchResults, isOurSpecialty);
-      
-      assessmentResults.push({
-        item,
-        confidence,
-        products: searchResults
-      });
-      
-      if (confidence > 0.6 || searchResults.length > 0) {
-        canFulfill.push(item);
-      } else {
-        cannotFulfill.push(item);
-      }
-    }
+    const assessmentResults: Array<{item: string, confidence: number, products: any[]}> =
+      await Promise.all(requirements.items.map(async (item) => {
+        const products = await searchProducts(item);
+        return { item, confidence: calculateConfidence(products), products };
+      }));
+    const canFulfill = assessmentResults
+      .filter((result) => result.products.length > 0)
+      .map((result) => result.item);
+    const cannotFulfill = assessmentResults
+      .filter((result) => result.products.length === 0)
+      .map((result) => result.item);
     
     // Generate recommendations from items we can fulfill
     const recommendations = assessmentResults
@@ -110,7 +109,9 @@ export async function assessFulfillmentCapability(
       success: false,
       data: {
         can_fulfill: [],
-        cannot_fulfill: request.requirements?.items || [],
+        cannot_fulfill: Array.isArray(request?.requirements?.items)
+          ? request.requirements.items.filter((item): item is string => typeof item === 'string').slice(0, 20)
+          : [],
         recommendations: [],
         estimated_cost: 0,
         estimated_delivery: 'Unknown'
@@ -129,21 +130,12 @@ export async function assessFulfillmentCapability(
   }
 }
 
-function calculateConfidence(item: string, products: any[], isOurSpecialty: boolean): number {
+function calculateConfidence(products: any[]): number {
   let confidence = 0;
   
   // Base confidence from search results
   if (products.length > 0) confidence += 0.4;
   if (products.length > 2) confidence += 0.2;
-  
-  // Boost for our specialties
-  if (isOurSpecialty) confidence += 0.3;
-  
-  // Reduce confidence for items we typically don't carry
-  const nonOutdoorItems = ['ration', 'food', 'ski', 'snow', 'electronic', 'book'];
-  if (nonOutdoorItems.some(non => item.includes(non))) {
-    confidence -= 0.3;
-  }
   
   return Math.max(0, Math.min(1, confidence));
 }
@@ -162,38 +154,13 @@ function calculateDeliveryEstimate(location?: string, timeline?: string): string
 }
 
 function generateAlternativeSiteRecommendations(cannotFulfill: string[]): string[] {
-  const suggestions: string[] = [];
-  
-  cannotFulfill.forEach(item => {
-    const itemLower = item.toLowerCase();
-    
-    if (itemLower.includes('food') || itemLower.includes('ration') || itemLower.includes('meal')) {
-      suggestions.push('Mountain House or Backpacker\'s Pantry for freeze-dried meals');
-    }
-    
-    if (itemLower.includes('ski') || itemLower.includes('snow')) {
-      suggestions.push('Backcountry.com or REI for specialized snow sports equipment');
-    }
-    
-    if (itemLower.includes('electronic') || itemLower.includes('gps')) {
-      suggestions.push('Garmin or outdoor electronics specialists');
-    }
-  });
-  
-  return [...new Set(suggestions)]; // Remove duplicates
+  return cannotFulfill.length ? ['Search another catalog for unavailable items'] : [];
 }
 
 function generateBundlingOpportunities(results: Array<{item: string, products: any[]}>): string[] {
-  const opportunities: string[] = [];
-  
-  const hasSheltier = results.some(r => r.item.toLowerCase().includes('tent') || r.item.toLowerCase().includes('shelter'));
-  const hasSleep = results.some(r => r.item.toLowerCase().includes('sleep') || r.item.toLowerCase().includes('bag'));
-  
-  if (hasSheltier && hasSleep) {
-    opportunities.push('Camping comfort bundle: tent + sleeping system discount available');
-  }
-  
-  return opportunities;
+  return results.filter((result) => result.products.length > 0).length > 1
+    ? ['Review matching products together for complementary options']
+    : [];
 }
 
 function generateCostOptimizations(results: Array<{item: string, products: any[]}>, budget?: number): string[] {
@@ -214,11 +181,12 @@ function generateCostOptimizations(results: Array<{item: string, products: any[]
 }
 
 function calculateSatisfaction(results: Array<{confidence: number}>, userContext: any): number {
+  if (results.length === 0) return 0;
   const avgConfidence = results.reduce((sum, r) => sum + r.confidence, 0) / results.length;
   
   // Boost satisfaction if we match user preferences
   let satisfactionBoost = 0;
-  if (userContext.activities?.includes('camping')) satisfactionBoost += 10;
+  if (userContext.activities?.length) satisfactionBoost += 10;
   if (userContext.experienceLevel === 'expert') satisfactionBoost += 5;
   
   return Math.min(100, (avgConfidence * 80) + satisfactionBoost);
@@ -237,7 +205,7 @@ function generateNextActions(canFulfill: string[], cannotFulfill: string[], fulf
   }
   
   if (fulfillmentPercentage > 80) {
-    actions.push('Proceed with Voltique order');
+    actions.push('Proceed with this store order');
   } else {
     actions.push('Consider splitting order across multiple retailers');
   }

--- a/lib/mcp/tools/cart.ts
+++ b/lib/mcp/tools/cart.ts
@@ -1,28 +1,66 @@
-import { getSession, updateSessionCart, getSessionCart } from '../session';
+import { requireOwnedSession, updateSessionCart } from '../session';
 import { getProductBySlug } from '../../models/mach/products';
 import { CartRequest, CartResponse, MCPToolResponse, WireCartItem } from '../types';
 import { CartItem } from '../../types/cartitem';
 import { Money, cartSubtotal } from '../../money';
+import { genericBundleSuggestions, isPublicMcpProduct } from '../catalog';
+import { MAX_CHECKOUT_LINES } from '../../services/checkout-pricing';
+
+const ZERO_ESTIMATED_TOTAL = Money.zero('USD').toMach();
+
+function validatedQuantity(value: unknown, fallback = 1): number {
+  const quantity = value === undefined ? fallback : value;
+  if (!Number.isSafeInteger(quantity) || Number(quantity) < 1 || Number(quantity) > 1_000) {
+    throw new Error('Quantity must be an integer between 1 and 1000');
+  }
+  return Number(quantity);
+}
+
+function cartOwnershipError(
+  ownership: { code: 'SESSION_NOT_FOUND' | 'SESSION_ACCESS_DENIED'; message: string },
+  sessionId: string,
+  agentId: string,
+  processingTime: number,
+): MCPToolResponse<CartResponse> {
+  return {
+    success: false,
+    data: { cart: [], total_items: 0, estimated_total: ZERO_ESTIMATED_TOTAL },
+    context: { session_id: sessionId, agent_id: agentId, processing_time_ms: processingTime },
+    error: { code: ownership.code, message: ownership.message },
+    metadata: {
+      can_fulfill_percentage: 0,
+      estimated_satisfaction: 0,
+      next_actions: ownership.code === 'SESSION_NOT_FOUND'
+        ? ['Create a new session', 'Verify session ID']
+        : ['Use a session created by this agent'],
+    },
+  };
+}
 
 export async function addToCart(
   request: CartRequest & { sessionId: string },
-  sessionId: string
+  sessionId: string,
+  agentId: string,
 ): Promise<MCPToolResponse<CartResponse>> {
   const startTime = Date.now();
   
   try {
-    // Get current cart
-    const currentCart = await getSessionCart(sessionId);
+    const ownership = await requireOwnedSession(sessionId, agentId);
+    if (!ownership.ok) {
+      return cartOwnershipError(ownership, sessionId, agentId, Date.now() - startTime);
+    }
+    const currentCart = ownership.session.cart;
+    const quantity = validatedQuantity(request.quantity);
     
     // Get product details
     const product = await getProductBySlug(request.productId.toString());
-    if (!product) {
+    if (!product || !isPublicMcpProduct(product)) {
       throw new Error('Product not found');
     }
 
     // Find the specific variant
     const variant = product.variants?.find(v => String(v.id) === String(request.variantId));
-    if (!variant) {
+    if (!variant || (variant.status != null && variant.status !== 'active')) {
       throw new Error('Product variant not found');
     }
 
@@ -33,13 +71,18 @@ export async function addToCart(
     if (existingItemIndex >= 0) {
       // Update quantity of existing item
       updatedCart = [...currentCart];
-      updatedCart[existingItemIndex].quantity += request.quantity || 1;
+      updatedCart[existingItemIndex].quantity = validatedQuantity(
+        updatedCart[existingItemIndex].quantity + quantity,
+      );
     } else {
+      if (currentCart.length >= MAX_CHECKOUT_LINES) {
+        throw new Error(`Cart cannot exceed ${MAX_CHECKOUT_LINES} distinct items`);
+      }
       // Add new item to cart
       const newItem: CartItem = {
         productId: String(product.id!),
         variantId: String(request.variantId),
-        quantity: request.quantity || 1,
+        quantity,
         name: typeof product.name === 'string' ? product.name : String(product.name || ''),
         price: Money.fromStored(variant.price).toJSON(),
         primaryImageUrl: (product as any).image_url || ''
@@ -52,7 +95,7 @@ export async function addToCart(
     
     // Calculate totals
     const totalItems = updatedCart.reduce((sum, item) => sum + item.quantity, 0);
-    const estimatedTotal = cartSubtotal(updatedCart).toMach().amount;
+    const estimatedTotal = cartSubtotal(updatedCart).toMach();
     
     const processingTime = Date.now() - startTime;
     
@@ -65,7 +108,7 @@ export async function addToCart(
       },
       context: {
         session_id: sessionId,
-        agent_id: request.agent_context?.agentId || 'unknown',
+        agent_id: agentId,
         processing_time_ms: processingTime
       },
       recommendations: {
@@ -83,10 +126,10 @@ export async function addToCart(
     
     return {
       success: false,
-      data: { cart: [], total_items: 0, estimated_total: 0 },
+      data: { cart: [], total_items: 0, estimated_total: ZERO_ESTIMATED_TOTAL },
       context: {
         session_id: sessionId,
-        agent_id: request.agent_context?.agentId || 'unknown',
+        agent_id: agentId,
         processing_time_ms: processingTime
       },
       metadata: {
@@ -100,26 +143,39 @@ export async function addToCart(
 
 export async function bulkAddToCart(
   request: { items: CartRequest[]; sessionId: string; agent_context?: any },
-  sessionId: string
+  sessionId: string,
+  agentId: string,
 ): Promise<MCPToolResponse<CartResponse>> {
   const startTime = Date.now();
   
   try {
-    let currentCart = await getSessionCart(sessionId);
+    const ownership = await requireOwnedSession(sessionId, agentId);
+    if (!ownership.ok) {
+      return cartOwnershipError(ownership, sessionId, agentId, Date.now() - startTime);
+    }
+    if (
+      !Array.isArray(request.items) ||
+      request.items.length === 0 ||
+      request.items.length > MAX_CHECKOUT_LINES
+    ) {
+      throw new Error(`Bulk request must contain between 1 and ${MAX_CHECKOUT_LINES} items`);
+    }
+    let currentCart = ownership.session.cart;
     let addedItems = 0;
     let failedItems: string[] = [];
     
     // Process each item
     for (const item of request.items) {
       try {
+        const quantity = validatedQuantity(item.quantity);
         const product = await getProductBySlug(item.productId.toString());
-        if (!product) {
+        if (!product || !isPublicMcpProduct(product)) {
           failedItems.push(`Product ${item.productId} not found`);
           continue;
         }
 
         const variant = product.variants?.find(v => String(v.id) === String(item.variantId));
-        if (!variant) {
+        if (!variant || (variant.status != null && variant.status !== 'active')) {
           failedItems.push(`Variant ${item.variantId} not found for product ${item.productId}`);
           continue;
         }
@@ -129,13 +185,19 @@ export async function bulkAddToCart(
         
         if (existingItemIndex >= 0) {
           // Update quantity of existing item
-          currentCart[existingItemIndex].quantity += item.quantity || 1;
+          currentCart[existingItemIndex].quantity = validatedQuantity(
+            currentCart[existingItemIndex].quantity + quantity,
+          );
         } else {
+          if (currentCart.length >= MAX_CHECKOUT_LINES) {
+            failedItems.push(`Cart cannot exceed ${MAX_CHECKOUT_LINES} distinct items`);
+            continue;
+          }
           // Add new item to cart
           const newItem: CartItem = {
             productId: String(product.id!),
             variantId: String(item.variantId),
-            quantity: item.quantity || 1,
+            quantity,
             name: typeof product.name === 'string' ? product.name : String(product.name || ''),
             price: Money.fromStored(variant.price).toJSON(),
             primaryImageUrl: (product as any).image_url || ''
@@ -154,7 +216,7 @@ export async function bulkAddToCart(
     
     // Calculate totals
     const totalItems = currentCart.reduce((sum, item) => sum + item.quantity, 0);
-    const estimatedTotal = cartSubtotal(currentCart).toMach().amount;
+    const estimatedTotal = cartSubtotal(currentCart).toMach();
     
     const processingTime = Date.now() - startTime;
     const successRate = addedItems / request.items.length;
@@ -168,7 +230,7 @@ export async function bulkAddToCart(
       },
       context: {
         session_id: sessionId,
-        agent_id: request.agent_context?.agentId || 'unknown',
+        agent_id: agentId,
         processing_time_ms: processingTime
       },
       recommendations: failedItems.length > 0 ? {
@@ -191,10 +253,10 @@ export async function bulkAddToCart(
     
     return {
       success: false,
-      data: { cart: [], total_items: 0, estimated_total: 0 },
+      data: { cart: [], total_items: 0, estimated_total: ZERO_ESTIMATED_TOTAL },
       context: {
         session_id: sessionId,
-        agent_id: request.agent_context?.agentId || 'unknown',
+        agent_id: agentId,
         processing_time_ms: processingTime
       },
       metadata: {
@@ -213,6 +275,10 @@ export async function clearCart(
   const startTime = Date.now();
   
   try {
+    const ownership = await requireOwnedSession(sessionId, agentId);
+    if (!ownership.ok) {
+      return cartOwnershipError(ownership, sessionId, agentId, Date.now() - startTime);
+    }
     await updateSessionCart(sessionId, []);
     
     const processingTime = Date.now() - startTime;
@@ -222,7 +288,7 @@ export async function clearCart(
       data: {
         cart: [],
         total_items: 0,
-        estimated_total: 0
+        estimated_total: ZERO_ESTIMATED_TOTAL
       },
       context: {
         session_id: sessionId,
@@ -240,7 +306,7 @@ export async function clearCart(
     
     return {
       success: false,
-      data: { cart: [], total_items: 0, estimated_total: 0 },
+      data: { cart: [], total_items: 0, estimated_total: ZERO_ESTIMATED_TOTAL },
       context: {
         session_id: sessionId,
         agent_id: agentId,
@@ -257,12 +323,17 @@ export async function clearCart(
 
 export async function updateCart(
   request: CartRequest & { sessionId: string },
-  sessionId: string
+  sessionId: string,
+  agentId: string,
 ): Promise<MCPToolResponse<CartResponse>> {
   const startTime = Date.now();
   
   try {
-    const currentCart = await getSessionCart(sessionId);
+    const ownership = await requireOwnedSession(sessionId, agentId);
+    if (!ownership.ok) {
+      return cartOwnershipError(ownership, sessionId, agentId, Date.now() - startTime);
+    }
+    const currentCart = ownership.session.cart;
     const itemIndex = currentCart.findIndex(item => String(item.variantId) === String(request.variantId));
     
     if (itemIndex === -1) {
@@ -271,18 +342,16 @@ export async function updateCart(
     
     let updatedCart = [...currentCart];
     
-    if (request.quantity && request.quantity > 0) {
-      // Update quantity
-      updatedCart[itemIndex].quantity = request.quantity;
-    } else {
-      // Remove item if quantity is 0 or not provided
+    if (request.quantity === 0) {
       updatedCart.splice(itemIndex, 1);
+    } else {
+      updatedCart[itemIndex].quantity = validatedQuantity(request.quantity, 0);
     }
     
     await updateSessionCart(sessionId, updatedCart);
     
     const totalItems = updatedCart.reduce((sum, item) => sum + item.quantity, 0);
-    const estimatedTotal = cartSubtotal(updatedCart).toMach().amount;
+    const estimatedTotal = cartSubtotal(updatedCart).toMach();
     
     const processingTime = Date.now() - startTime;
     
@@ -295,7 +364,7 @@ export async function updateCart(
       },
       context: {
         session_id: sessionId,
-        agent_id: request.agent_context?.agentId || 'unknown',
+        agent_id: agentId,
         processing_time_ms: processingTime
       },
       metadata: {
@@ -309,10 +378,10 @@ export async function updateCart(
     
     return {
       success: false,
-      data: { cart: [], total_items: 0, estimated_total: 0 },
+      data: { cart: [], total_items: 0, estimated_total: ZERO_ESTIMATED_TOTAL },
       context: {
         session_id: sessionId,
-        agent_id: request.agent_context?.agentId || 'unknown',
+        agent_id: agentId,
         processing_time_ms: processingTime
       },
       metadata: {
@@ -326,9 +395,10 @@ export async function updateCart(
 
 export async function removeFromCart(
   request: CartRequest & { sessionId: string },
-  sessionId: string
+  sessionId: string,
+  agentId: string,
 ): Promise<MCPToolResponse<CartResponse>> {
-  return updateCart({ ...request, quantity: 0 }, sessionId);
+  return updateCart({ ...request, quantity: 0 }, sessionId, agentId);
 }
 
 export async function getCartEstimate(
@@ -338,9 +408,13 @@ export async function getCartEstimate(
   const startTime = Date.now();
   
   try {
-    const cart = await getSessionCart(sessionId);
+    const ownership = await requireOwnedSession(sessionId, agentId);
+    if (!ownership.ok) {
+      return cartOwnershipError(ownership, sessionId, agentId, Date.now() - startTime);
+    }
+    const cart = ownership.session.cart;
     const totalItems = cart.reduce((sum, item) => sum + item.quantity, 0);
-    const estimatedTotal = cartSubtotal(cart).toMach().amount;
+    const estimatedTotal = cartSubtotal(cart).toMach();
     
     const processingTime = Date.now() - startTime;
     
@@ -367,7 +441,7 @@ export async function getCartEstimate(
     
     return {
       success: false,
-      data: { cart: [], total_items: 0, estimated_total: 0 },
+      data: { cart: [], total_items: 0, estimated_total: ZERO_ESTIMATED_TOTAL },
       context: {
         session_id: sessionId,
         agent_id: agentId,
@@ -383,21 +457,7 @@ export async function getCartEstimate(
 }
 
 function generateCartBundlingOpportunities(cart: CartItem[]): string[] {
-  const opportunities: string[] = [];
-  
-  const hasTent = cart.some(item => item.name.toLowerCase().includes('tent'));
-  const hasSleeping = cart.some(item => item.name.toLowerCase().includes('sleeping') || item.name.toLowerCase().includes('bag'));
-  const hasBackpack = cart.some(item => item.name.toLowerCase().includes('pack'));
-  
-  if (hasTent && hasSleeping) {
-    opportunities.push('Complete camping system: add camp stove for full setup');
-  }
-  
-  if (hasBackpack && !hasSleeping) {
-    opportunities.push('Backpacking essential missing: consider adding sleeping system');
-  }
-  
-  return opportunities;
+  return genericBundleSuggestions(new Set(cart.map((item) => item.productId)).size);
 }
 
 function toWireCart(cart: CartItem[]): WireCartItem[] {
@@ -412,10 +472,10 @@ function generateCartOptimizations(cart: CartItem[], budget?: number): string[] 
   
   if (total > budget) {
     optimizations.push(`Cart total $${total} exceeds budget $${budget}`);
-    optimizations.push('Consider reducing quantities or choosing base models');
+    optimizations.push('Consider reducing quantities or choosing lower-priced variants');
   } else if (total < budget * 0.9) {
-    optimizations.push(`Budget allows for $${budget - total} in additional gear`);
-    optimizations.push('Consider premium upgrades within remaining budget');
+    optimizations.push(`Budget allows for $${budget - total} in additional products`);
+    optimizations.push('Consider additional catalog items within the remaining budget');
   }
   
   return optimizations;

--- a/lib/mcp/tools/order.ts
+++ b/lib/mcp/tools/order.ts
@@ -1,287 +1,226 @@
-import { createOrder } from '../../models/mach/orders';
-import { getSessionCart } from '../session';
-import { OrderRequest, OrderResponse, MCPToolResponse } from '../types';
-import { enhanceUserContext } from '../context';
-import { MACHAddress as Address } from '../../types/mach/Address';
-import { CartItem } from '../../types/cartitem';
-import { Money, cartSubtotal } from '../../money';
+import { toWireMoney } from '../../money';
+import {
+  finalizeOrderPayment,
+  PaymentVerificationError,
+} from '../../services/order-finalization';
+import type { MACHAddress as Address } from '../../types/mach/Address';
+import {
+  getOwnedMcpOrder,
+  getOwnedMcpOrderBinding,
+} from '../checkout';
+import { requireOwnedSession } from '../session';
+import type { MCPToolResponse, OrderRequest, OrderResponse } from '../types';
+
+const ZERO_TOTAL = toWireMoney(0);
+
+function orderFailure(
+  sessionId: string,
+  agentId: string,
+  startTime: number,
+  code: string,
+  message: string,
+  nextActions: string[],
+): MCPToolResponse<OrderResponse> {
+  return {
+    success: false,
+    data: { orderId: '', status: 'failed', total: ZERO_TOTAL, estimated_delivery: '' },
+    context: {
+      session_id: sessionId,
+      agent_id: agentId,
+      processing_time_ms: Date.now() - startTime,
+    },
+    error: { code, message },
+    metadata: {
+      can_fulfill_percentage: 0,
+      estimated_satisfaction: 0,
+      next_actions: nextActions,
+    },
+  };
+}
 
 export async function placeOrder(
   request: OrderRequest,
-  sessionId: string
+  sessionId: string,
+  agentId: string,
 ): Promise<MCPToolResponse<OrderResponse>> {
   const startTime = Date.now();
-  
-  try {
-    // Get current cart from session
-    const cart = await getSessionCart(sessionId);
-    
-    if (cart.length === 0) {
-      return {
-        success: false,
-        data: {
-          orderId: '',
-          status: 'failed',
-          total: 0,
-          estimated_delivery: ''
-        },
-        context: {
-          session_id: sessionId,
-          agent_id: request.agent_context?.agentId || 'unknown',
-          processing_time_ms: Date.now() - startTime
-        },
-        metadata: {
-          can_fulfill_percentage: 0,
-          estimated_satisfaction: 0,
-          next_actions: ['Add items to cart before placing order']
-        }
-      };
-    }
+  if (request.agent_context) request.agent_context.agentId = agentId;
 
-    // Enhanced user context for order
-    const userContext = enhanceUserContext(request.agent_context || null);
-    
-    // Calculate order totals
-    const subtotal = cartSubtotal(cart);
-    const shipping = calculateShipping(request.shippingAddress, subtotal);
-    const tax = calculateTax(subtotal, request.shippingAddress);
-    const total = subtotal.add(shipping).add(tax);
-
-    // Validate order limits if agent has budget constraints
-    if (userContext.budget && total.gt(Money.fromMajor(userContext.budget, total.currency))) {
-      return {
-        success: false,
-        data: {
-          orderId: '',
-          status: 'budget_exceeded',
-          total: total.toMach().amount,
-          estimated_delivery: ''
-        },
-        context: {
-          session_id: sessionId,
-          agent_id: request.agent_context?.agentId || 'unknown',
-          processing_time_ms: Date.now() - startTime
-        },
-        recommendations: {
-          cost_optimization: [
-            `Order total ${total.format()} exceeds budget $${userContext.budget}`,
-            'Consider removing items or choosing base models'
-          ]
-        },
-        metadata: {
-          can_fulfill_percentage: 100,
-          estimated_satisfaction: 30,
-          next_actions: ['Reduce cart total', 'Remove expensive items', 'Choose alternative products']
-        }
-      };
-    }
-
-    // Create order using existing order system
-    const orderData = {
-      user_id: userContext.userId || request.agent_context?.agentId || 'agent-order',
-      total_amount: total.toJSON(),
-      status: 'confirmed' as const,
-      shipping_address: request.shippingAddress,
-      billing_address: request.billingAddress || request.shippingAddress,
-      items: cart.map(item => ({
-        product_id: item.productId,
-        variant_id: item.variantId,
-        sku: item.variantId || `${item.productId}-default`,
-        quantity: item.quantity,
-        unit_price: Money.fromStored(item.price).toJSON(),
-        total_price: Money.fromStored(item.price).times(item.quantity).toJSON(),
-        product_name: item.name
-      })),
-      shipping_method: request.shippingOption || 'standard',
-      payment_method: request.paymentMethod || 'agent-processed',
-      special_instructions: request.specialInstructions,
-      // Agent-specific fields
-      agent_id: request.agent_context?.agentId,
-      agent_context: request.agent_context ? JSON.stringify(request.agent_context) : undefined,
-      currency_code: 'USD'
-    };
-
-    const order = await createOrder(orderData);
-    
-    // Calculate estimated delivery
-    const estimatedDelivery = calculateEstimatedDelivery(
-      request.shippingAddress,
-      request.shippingOption || 'standard'
+  const ownership = await requireOwnedSession(sessionId, agentId);
+  if (!ownership.ok) {
+    return orderFailure(
+      sessionId,
+      agentId,
+      startTime,
+      ownership.code,
+      ownership.message,
+      ownership.code === 'SESSION_NOT_FOUND'
+        ? ['Create a new session', 'Verify session ID']
+        : ['Use a session created by this agent'],
     );
+  }
 
-    // Generate order confirmation
-    const response: OrderResponse = {
-      orderId: order.id!.toString(),
-      status: order.status,
-      total: Money.fromStored(order.total_amount).toMach().amount,
-      tracking_number: order.tracking_number || undefined,
-      estimated_delivery: estimatedDelivery
-    };
+  const { orderId, paymentIntentId } = request;
+  if (
+    typeof orderId !== 'string' ||
+    !/^MCP-[A-Z0-9]+-\d+-[A-F0-9]{8}$/.test(orderId) ||
+    typeof paymentIntentId !== 'string' ||
+    !/^pi_[A-Za-z0-9_]+$/.test(paymentIntentId)
+  ) {
+    return orderFailure(
+      sessionId,
+      agentId,
+      startTime,
+      'PAYMENT_REQUIRED',
+      'A valid orderId and paymentIntentId from create_payment_intent are required.',
+      ['Call create_payment_intent', 'Complete payment', 'Retry place_order'],
+    );
+  }
 
-    const processingTime = Date.now() - startTime;
+  const pending = await getOwnedMcpOrderBinding({
+    orderId,
+    paymentIntentId,
+    agentId,
+    sessionId,
+  });
+  if (!pending) {
+    return orderFailure(
+      sessionId,
+      agentId,
+      startTime,
+      'PAYMENT_NOT_BOUND',
+      'The pending order and PaymentIntent are not bound to this agent and session.',
+      ['Create a new PaymentIntent for this session'],
+    );
+  }
 
+  try {
+    const result = await finalizeOrderPayment({
+      orderId,
+      paymentIntentId,
+      enforceOwnership: false,
+      sendEmail: true,
+    });
+    const order = result.order;
     return {
       success: true,
-      data: response,
+      data: {
+        orderId: order.id!,
+        status: order.status,
+        total: toWireMoney(order.total_amount, order.currency_code),
+        tracking_number: order.tracking_number,
+        estimated_delivery: calculateEstimatedDelivery(
+          order.shipping_address,
+          order.shipping_method || 'standard',
+        ),
+      },
       context: {
         session_id: sessionId,
-        agent_id: request.agent_context?.agentId || 'unknown',
-        processing_time_ms: processingTime
-      },
-      recommendations: {
-        bundling_opportunities: generatePostOrderRecommendations(cart),
-        cost_optimization: [`Order saved ${Money.fromMajor(userContext.budget || total.toMach().amount).subtract(total).format()} vs budget`]
+        agent_id: agentId,
+        processing_time_ms: Date.now() - startTime,
       },
       metadata: {
         can_fulfill_percentage: 100,
         estimated_satisfaction: 95,
-        next_actions: ['Track order status', 'Save order confirmation', 'Plan future purchases']
-      }
+        next_actions: ['Save the order confirmation', 'Use get_order_status for updates'],
+      },
     };
-
   } catch (error) {
-    const processingTime = Date.now() - startTime;
-    
-    return {
-      success: false,
-      data: {
-        orderId: '',
-        status: 'failed',
-        total: 0,
-        estimated_delivery: ''
-      },
-      context: {
-        session_id: sessionId,
-        agent_id: request.agent_context?.agentId || 'unknown',
-        processing_time_ms: processingTime
-      },
-      metadata: {
-        can_fulfill_percentage: 0,
-        estimated_satisfaction: 0,
-        next_actions: ['Check order details', 'Verify payment method', 'Retry order placement']
-      }
-    };
+    if (error instanceof PaymentVerificationError) {
+      return orderFailure(
+        sessionId,
+        agentId,
+        startTime,
+        'PAYMENT_VERIFICATION_FAILED',
+        'Payment has not been verified for this order.',
+        ['Complete payment', 'Retry place_order'],
+      );
+    }
+    console.error(`[mcp] Failed to finalize order ${orderId}:`, error);
+    return orderFailure(
+      sessionId,
+      agentId,
+      startTime,
+      'ORDER_FINALIZATION_FAILED',
+      'The order could not be finalized.',
+      ['Retry place_order; finalization is idempotent'],
+    );
   }
 }
 
 export async function getOrderStatus(
   orderId: string,
-  agentId: string
+  agentId: string,
 ): Promise<MCPToolResponse<OrderResponse>> {
   const startTime = Date.now();
-  
-  try {
-    // In a real implementation, you'd fetch from orders table
-    // For now, return a mock response
-    const response: OrderResponse = {
-      orderId,
-      status: 'confirmed',
-      total: 299.99,
-      tracking_number: `VT${Date.now()}`,
-      estimated_delivery: '3-5 business days'
-    };
+  const order = await getOwnedMcpOrder(orderId, agentId);
 
-    return {
-      success: true,
-      data: response,
-      context: {
-        session_id: 'status-check',
-        agent_id: agentId,
-        processing_time_ms: Date.now() - startTime
-      },
-      metadata: {
-        can_fulfill_percentage: 100,
-        estimated_satisfaction: 90,
-        next_actions: ['Track shipment', 'Contact customer service if needed']
-      }
-    };
-  } catch (error) {
-    return {
-      success: false,
-      data: {
-        orderId: '',
-        status: 'error',
-        total: 0,
-        estimated_delivery: ''
-      },
-      context: {
-        session_id: 'status-check',
-        agent_id: agentId,
-        processing_time_ms: Date.now() - startTime
-      },
-      metadata: {
-        can_fulfill_percentage: 0,
-        estimated_satisfaction: 0,
-        next_actions: ['Verify order ID', 'Contact support']
-      }
-    };
+  if (!order) {
+    return orderFailure(
+      'status-check',
+      agentId,
+      startTime,
+      'ORDER_NOT_FOUND',
+      'No order found for this agent with that ID.',
+      ['Verify the order ID', 'Place an order with place_order'],
+    );
   }
-}
 
-function calculateShipping(address: Address, subtotal: Money): Money {
-  // Free shipping over $100
-  if (subtotal.gte(Money.fromMajor(100, subtotal.currency))) return Money.zero(subtotal.currency);
-  
-  // Alaska/Hawaii surcharge
-  if (address.region === 'AK' || address.region === 'HI') {
-    return Money.fromMajor(19.99, subtotal.currency);
-  }
-  
-  // Standard shipping
-  return Money.fromMajor(9.99, subtotal.currency);
-}
-
-function calculateTax(subtotal: Money, address: Address): Money {
-  // Simple tax calculation - in production, use proper tax service
-  const taxRates: Record<string, number> = {
-    'CA': 0.0875, // California
-    'NY': 0.08,   // New York
-    'TX': 0.0625, // Texas
-    'FL': 0.06    // Florida
+  return {
+    success: true,
+    data: {
+      orderId: order.id!,
+      status: order.status,
+      total: toWireMoney(order.total_amount, order.currency_code),
+      tracking_number: order.tracking_number,
+      estimated_delivery: calculateEstimatedDelivery(
+        order.shipping_address,
+        order.shipping_method || 'standard',
+      ),
+    },
+    context: {
+      session_id: 'status-check',
+      agent_id: agentId,
+      processing_time_ms: Date.now() - startTime,
+    },
+    metadata: {
+      can_fulfill_percentage: 100,
+      estimated_satisfaction: 90,
+      next_actions: order.status === 'delivered'
+        ? ['Review the delivered order']
+        : ['Check back for status updates'],
+    },
   };
-  
-  const rate = taxRates[address.region || ''] || 0.05; // Default 5%
-  return subtotal.applyRate(rate);
 }
 
-function calculateEstimatedDelivery(address: Address, shippingOption: string): string {
+function calculateEstimatedDelivery(address: Address | undefined, shippingOption: string): string {
   if (shippingOption === 'expedited' || shippingOption === 'overnight') {
     return '1-2 business days';
   }
-  
-  if (address.region === 'AK' || address.region === 'HI') {
+  if (address?.region === 'AK' || address?.region === 'HI') {
     return '5-7 business days';
   }
-  
   return '3-5 business days';
 }
 
-function formatAddressForDB(address: Address): string {
-  return JSON.stringify({
-    street: address.line1,
-    street2: address.line2,
-    city: address.city,
-    state: address.region,
-    postal_code: address.postal_code,
-    country: address.country || 'US'
-  });
-}
-
-function generatePostOrderRecommendations(cart: CartItem[]): string[] {
-  const recommendations: string[] = [];
-  
-  const hasTent = cart.some(item => item.name.toLowerCase().includes('tent'));
-  const hasBackpack = cart.some(item => item.name.toLowerCase().includes('pack'));
-  
-  if (hasTent) {
-    recommendations.push('Consider tent footprint for ground protection');
-    recommendations.push('Add camping furniture for comfort');
+export function normalizeAddress(input: unknown): Address {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    return { line1: '', city: '', country: 'US' };
   }
-  
-  if (hasBackpack) {
-    recommendations.push('Rain cover recommended for pack protection');
-    recommendations.push('Hydration system for longer hikes');
-  }
-  
-  return recommendations;
+  const address = input as Record<string, unknown>;
+  return {
+    ...address,
+    line1: String(address.line1 ?? address.street ?? ''),
+    line2: address.line2 === undefined && address.street2 === undefined
+      ? undefined
+      : String(address.line2 ?? address.street2),
+    city: String(address.city ?? ''),
+    region: address.region === undefined && address.state === undefined
+      ? undefined
+      : String(address.region ?? address.state),
+    postal_code: address.postal_code === undefined && address.postalCode === undefined
+      ? undefined
+      : String(address.postal_code ?? address.postalCode),
+    country: String(address.country ?? 'US'),
+  } as Address;
 }

--- a/lib/mcp/tools/payment.ts
+++ b/lib/mcp/tools/payment.ts
@@ -1,320 +1,207 @@
-import { MCPToolResponse } from '../types';
-import { CartItem } from '../../types/cartitem';
+import { cartSubtotal, Money, toWireMoney, type MachMoney } from '../../money';
+import type { MACHAddress } from '../../types/mach/Address';
+import {
+  createMcpCheckout,
+  normalizeMcpAddress,
+  type McpCheckoutRequest,
+} from '../checkout';
+import { requireOwnedSession } from '../session';
+import type { MCPToolResponse } from '../types';
+
+export interface AgentPaymentIntentResponse {
+  clientSecret: string;
+  paymentIntentId: string;
+  orderId: string;
+  amount: MachMoney;
+  quote: {
+    items: Array<{
+      productId: string;
+      variantId?: string;
+      name: string;
+      quantity: number;
+      unitPrice: MachMoney;
+      lineTotal: MachMoney;
+    }>;
+    total: MachMoney;
+    currency: string;
+  };
+}
+
+const EMPTY_PAYMENT_INTENT: AgentPaymentIntentResponse = {
+  clientSecret: '',
+  paymentIntentId: '',
+  orderId: '',
+  amount: toWireMoney(0),
+  quote: { items: [], total: toWireMoney(0), currency: 'USD' },
+};
+
+export async function createAgentPaymentIntent(
+  request: McpCheckoutRequest,
+  sessionId: string,
+  agentId: string,
+): Promise<MCPToolResponse<AgentPaymentIntentResponse>> {
+  const startTime = Date.now();
+  const ownership = await requireOwnedSession(sessionId, agentId);
+  if (!ownership.ok) {
+    return {
+      success: false,
+      data: EMPTY_PAYMENT_INTENT,
+      context: { session_id: sessionId, agent_id: agentId, processing_time_ms: Date.now() - startTime },
+      error: { code: ownership.code, message: ownership.message },
+      metadata: { can_fulfill_percentage: 0, estimated_satisfaction: 0 },
+    };
+  }
+
+  try {
+    const checkout = await createMcpCheckout({ agentId, session: ownership.session, input: request });
+    return {
+      success: true,
+      data: {
+        clientSecret: checkout.clientSecret,
+        paymentIntentId: checkout.paymentIntentId,
+        orderId: checkout.orderId,
+        amount: checkout.amount,
+        quote: {
+          items: checkout.quote.items.map((item) => ({
+            productId: item.product_id,
+            variantId: item.variant_id,
+            name: item.product_name,
+            quantity: item.quantity,
+            unitPrice: toWireMoney(item.unit_price, checkout.quote.currency),
+            lineTotal: toWireMoney(item.total_price, checkout.quote.currency),
+          })),
+          total: checkout.amount,
+          currency: checkout.quote.currency,
+        },
+      },
+      context: { session_id: sessionId, agent_id: agentId, processing_time_ms: Date.now() - startTime },
+      metadata: {
+        can_fulfill_percentage: 100,
+        estimated_satisfaction: 90,
+        next_actions: ['Complete the PaymentIntent', 'Call place_order with orderId and paymentIntentId'],
+      },
+    };
+  } catch (error) {
+    console.error('[mcp] PaymentIntent creation failed:', error);
+    return {
+      success: false,
+      data: EMPTY_PAYMENT_INTENT,
+      context: { session_id: sessionId, agent_id: agentId, processing_time_ms: Date.now() - startTime },
+      error: { code: 'CHECKOUT_FAILED', message: 'Could not create an authoritative checkout' },
+      metadata: {
+        can_fulfill_percentage: 0,
+        estimated_satisfaction: 0,
+        next_actions: ['Verify the session cart and shipping details', 'Retry checkout'],
+      },
+    };
+  }
+}
 
 export interface PaymentMethod {
-  id: string;
-  type: 'credit_card' | 'paypal' | 'bank_transfer' | 'agent_processed';
+  id: 'stripe';
+  type: 'payment_intent';
   name: string;
   description: string;
-  processing_fee: number;
   available: boolean;
-  requirements?: string[];
 }
 
 export interface PaymentValidationRequest {
   payment_method: string;
-  billing_address?: {
-    street: string;
-    street2?: string;
-    city: string;
-    state: string;
-    postal_code: string;
-    country?: string;
-  };
-  cart: CartItem[];
-  total_amount: number;
-  agent_context?: any;
+  billing_address?: MACHAddress;
+  agent_context?: unknown;
 }
 
 export interface PaymentValidationResponse {
   valid: boolean;
   payment_methods: PaymentMethod[];
-  recommended_method: string;
-  processing_fee: number;
+  recommended_method: 'stripe';
+  processing_fee: MachMoney;
   estimated_processing_time: string;
   requirements_met: boolean;
   missing_requirements?: string[];
+  authoritative_total: MachMoney;
 }
 
 export async function validatePayment(
   request: PaymentValidationRequest,
-  sessionId: string
+  sessionId: string,
+  agentId: string,
 ): Promise<MCPToolResponse<PaymentValidationResponse>> {
   const startTime = Date.now();
-  
+  const ownership = await requireOwnedSession(sessionId, agentId);
+  if (!ownership.ok) {
+    return paymentValidationFailure(sessionId, agentId, startTime, ownership.code, ownership.message);
+  }
+
   try {
-    const { payment_method, billing_address, cart, total_amount } = request;
-    
-    // Get available payment methods
-    const paymentMethods = getAvailablePaymentMethods(total_amount, billing_address?.country || 'US');
-    
-    // Validate the specific payment method
-    const selectedMethod = paymentMethods.find(method => method.id === payment_method);
-    const isValid = selectedMethod ? selectedMethod.available : false;
-    
-    // Check requirements
-    const requirementCheck = checkPaymentRequirements(payment_method, billing_address, total_amount);
-    
-    // Calculate processing fee
-    const processingFee = selectedMethod ? selectedMethod.processing_fee : 0;
-    
-    // Determine recommended method
-    const recommendedMethod = getRecommendedPaymentMethod(paymentMethods, total_amount, request.agent_context);
-    
-    const processingTime = Date.now() - startTime;
-    
+    if (request.billing_address) normalizeMcpAddress(request.billing_address);
+    const subtotal = cartSubtotal(ownership.session.cart);
+    const missing: string[] = [];
+    if (request.payment_method !== 'stripe') missing.push("payment_method must be 'stripe'");
+    if (ownership.session.cart.length === 0) missing.push('Session cart is empty');
+    if (!subtotal.gt(Money.zero(subtotal.currency))) missing.push('Cart total must be positive');
+
+    const valid = missing.length === 0;
     return {
       success: true,
       data: {
-        valid: isValid && requirementCheck.met,
-        payment_methods: paymentMethods,
-        recommended_method: recommendedMethod.id,
-        processing_fee: processingFee,
-        estimated_processing_time: selectedMethod?.type === 'agent_processed' ? 'Instant' : '1-3 business days',
-        requirements_met: requirementCheck.met,
-        missing_requirements: requirementCheck.missing
+        valid,
+        payment_methods: [{
+          id: 'stripe',
+          type: 'payment_intent',
+          name: 'Stripe PaymentIntent',
+          description: 'Server-priced payment through the configured Stripe account',
+          available: true,
+        }],
+        recommended_method: 'stripe',
+        processing_fee: toWireMoney(0, subtotal.currency),
+        estimated_processing_time: 'Confirmed by PaymentIntent status',
+        requirements_met: valid,
+        missing_requirements: missing.length ? missing : undefined,
+        authoritative_total: subtotal.toMach(),
       },
-      context: {
-        session_id: sessionId,
-        agent_id: request.agent_context?.agentId || 'unknown',
-        processing_time_ms: processingTime
-      },
-      recommendations: {
-        cost_optimization: generatePaymentRecommendations(paymentMethods, total_amount, request.agent_context?.userPreferences?.budget),
-        alternative_sites: !isValid ? ['Consider alternative payment processors', 'Check agent payment capabilities'] : []
-      },
+      context: { session_id: sessionId, agent_id: agentId, processing_time_ms: Date.now() - startTime },
       metadata: {
-        can_fulfill_percentage: isValid ? 100 : 60,
-        estimated_satisfaction: calculatePaymentSatisfaction(isValid, paymentMethods, requirementCheck.met),
-        next_actions: generatePaymentActions(isValid, requirementCheck.met, requirementCheck.missing)
-      }
+        can_fulfill_percentage: valid ? 100 : 0,
+        estimated_satisfaction: valid ? 90 : 20,
+        next_actions: valid
+          ? ['Call create_payment_intent with shipping details']
+          : ['Resolve the missing payment requirements'],
+      },
     };
   } catch (error) {
-    const processingTime = Date.now() - startTime;
-    
-    return {
-      success: false,
-      data: {
-        valid: false,
-        payment_methods: [],
-        recommended_method: 'agent_processed',
-        processing_fee: 0,
-        estimated_processing_time: 'Unknown',
-        requirements_met: false,
-        missing_requirements: ['Payment validation failed']
-      },
-      context: {
-        session_id: sessionId,
-        agent_id: request.agent_context?.agentId || 'unknown',
-        processing_time_ms: processingTime
-      },
-      metadata: {
-        can_fulfill_percentage: 0,
-        estimated_satisfaction: 0,
-        next_actions: ['Verify payment information', 'Contact support', 'Try alternative payment method']
-      }
-    };
+    console.error('[mcp] Payment validation failed:', error);
+    return paymentValidationFailure(
+      sessionId,
+      agentId,
+      startTime,
+      'PAYMENT_VALIDATION_FAILED',
+      'Payment requirements could not be validated',
+    );
   }
 }
 
-function getAvailablePaymentMethods(amount: number, country: string): PaymentMethod[] {
-  const methods: PaymentMethod[] = [
-    {
-      id: 'agent_processed',
-      type: 'agent_processed',
-      name: 'Agent Processed Payment',
-      description: 'Payment handled by your personal shopping agent',
-      processing_fee: 0,
-      available: true,
-      requirements: ['Valid agent credentials', 'Pre-authorized payment method']
-    }
-  ];
-  
-  // Credit card processing (for direct payments)
-  if (amount >= 5 && amount <= 5000) {
-    methods.push({
-      id: 'credit_card',
-      type: 'credit_card',
-      name: 'Credit/Debit Card',
-      description: 'Direct card processing via Stripe',
-      processing_fee: Math.max(0.30, amount * 0.029), // Stripe-like fees
-      available: true,
-      requirements: ['Valid billing address', 'Card verification']
-    });
-  }
-  
-  // PayPal (US only for now)
-  if (country === 'US' && amount >= 1) {
-    methods.push({
-      id: 'paypal',
-      type: 'paypal',
-      name: 'PayPal',
-      description: 'PayPal checkout integration',
-      processing_fee: amount * 0.0349, // PayPal merchant fees
-      available: true,
-      requirements: ['PayPal account', 'Email verification']
-    });
-  }
-  
-  // Bank transfer for larger amounts
-  if (amount >= 100) {
-    methods.push({
-      id: 'bank_transfer',
-      type: 'bank_transfer',
-      name: 'Bank Transfer (ACH)',
-      description: 'Direct bank account transfer',
-      processing_fee: 0.50,
-      available: country === 'US',
-      requirements: ['Valid bank account', 'Identity verification', '3-5 business days processing time']
-    });
-  }
-  
-  return methods;
-}
-
-function checkPaymentRequirements(
-  paymentMethod: string,
-  billingAddress?: any,
-  amount?: number
-): { met: boolean; missing: string[] } {
-  const missing: string[] = [];
-  
-  switch (paymentMethod) {
-    case 'credit_card':
-      if (!billingAddress) {
-        missing.push('Billing address required for credit card payments');
-      }
-      if (amount && amount < 5) {
-        missing.push('Minimum $5.00 required for credit card payments');
-      }
-      if (amount && amount > 5000) {
-        missing.push('Credit card payments limited to $5,000 per transaction');
-      }
-      break;
-      
-    case 'paypal':
-      if (!billingAddress?.country || billingAddress.country !== 'US') {
-        missing.push('PayPal currently only available for US customers');
-      }
-      break;
-      
-    case 'bank_transfer':
-      if (amount && amount < 100) {
-        missing.push('Minimum $100.00 required for bank transfer');
-      }
-      if (!billingAddress?.country || billingAddress.country !== 'US') {
-        missing.push('ACH transfers only available for US bank accounts');
-      }
-      break;
-      
-    case 'agent_processed':
-      // Agent processed payments have minimal requirements
-      break;
-      
-    default:
-      missing.push(`Unknown payment method: ${paymentMethod}`);
-  }
-  
+function paymentValidationFailure(
+  sessionId: string,
+  agentId: string,
+  startTime: number,
+  code: string,
+  message: string,
+): MCPToolResponse<PaymentValidationResponse> {
   return {
-    met: missing.length === 0,
-    missing
+    success: false,
+    data: {
+      valid: false,
+      payment_methods: [],
+      recommended_method: 'stripe',
+      processing_fee: toWireMoney(0),
+      estimated_processing_time: 'Unknown',
+      requirements_met: false,
+      missing_requirements: [message],
+      authoritative_total: toWireMoney(0),
+    },
+    context: { session_id: sessionId, agent_id: agentId, processing_time_ms: Date.now() - startTime },
+    error: { code, message },
+    metadata: { can_fulfill_percentage: 0, estimated_satisfaction: 0 },
   };
-}
-
-function getRecommendedPaymentMethod(
-  methods: PaymentMethod[],
-  amount: number,
-  agentContext?: any
-): PaymentMethod {
-  // Always prefer agent processed for seamless agent experience
-  const agentProcessed = methods.find(m => m.id === 'agent_processed');
-  if (agentProcessed?.available) {
-    return agentProcessed;
-  }
-  
-  // For small amounts, prefer credit card
-  if (amount < 50) {
-    const creditCard = methods.find(m => m.id === 'credit_card' && m.available);
-    if (creditCard) return creditCard;
-  }
-  
-  // For larger amounts, consider bank transfer to save on fees
-  if (amount > 200) {
-    const bankTransfer = methods.find(m => m.id === 'bank_transfer' && m.available);
-    if (bankTransfer) return bankTransfer;
-  }
-  
-  // Default to first available method
-  return methods.find(m => m.available) || methods[0];
-}
-
-function generatePaymentRecommendations(methods: PaymentMethod[], amount: number, budget?: number): string[] {
-  const recommendations: string[] = [];
-  
-  // Fee optimization
-  const lowestFeeMethod = methods
-    .filter(m => m.available)
-    .reduce((prev, curr) => prev.processing_fee < curr.processing_fee ? prev : curr);
-    
-  if (lowestFeeMethod.processing_fee > 0) {
-    recommendations.push(`Save on fees: ${lowestFeeMethod.name} has lowest processing cost ($${lowestFeeMethod.processing_fee.toFixed(2)})`);
-  }
-  
-  // Budget considerations
-  if (budget) {
-    const totalWithFee = amount + lowestFeeMethod.processing_fee;
-    if (totalWithFee > budget) {
-      recommendations.push(`Payment fees will exceed budget by $${(totalWithFee - budget).toFixed(2)}`);
-    }
-  }
-  
-  // Speed recommendations
-  const agentMethod = methods.find(m => m.id === 'agent_processed' && m.available);
-  if (agentMethod) {
-    recommendations.push('For fastest processing, use agent-handled payment');
-  }
-  
-  return recommendations;
-}
-
-function calculatePaymentSatisfaction(isValid: boolean, methods: PaymentMethod[], requirementsMet: boolean): number {
-  let satisfaction = 60; // Base satisfaction
-  
-  if (isValid && requirementsMet) {
-    satisfaction += 30;
-  }
-  
-  // Bonus for having multiple payment options
-  const availableMethods = methods.filter(m => m.available).length;
-  satisfaction += Math.min(10, availableMethods * 2);
-  
-  // Bonus for agent processed availability
-  if (methods.some(m => m.id === 'agent_processed' && m.available)) {
-    satisfaction += 10;
-  }
-  
-  return Math.min(100, satisfaction);
-}
-
-function generatePaymentActions(isValid: boolean, requirementsMet: boolean, missingRequirements?: string[]): string[] {
-  const actions: string[] = [];
-  
-  if (!isValid) {
-    actions.push('Select valid payment method');
-    actions.push('Check available payment options');
-  }
-  
-  if (!requirementsMet && missingRequirements) {
-    actions.push('Complete missing payment requirements');
-    missingRequirements.forEach(req => {
-      actions.push(`Address: ${req}`);
-    });
-  }
-  
-  if (isValid && requirementsMet) {
-    actions.push('Proceed with payment processing');
-    actions.push('Review order total and fees');
-  }
-  
-  return actions;
 }

--- a/lib/mcp/tools/recommend.ts
+++ b/lib/mcp/tools/recommend.ts
@@ -4,6 +4,8 @@ import { enhanceUserContext } from '../context';
 import { Product } from '../../types';
 import { Money } from '../../money';
 import { toPublicProduct, toWireProduct, type WireProduct } from '../../models/mach/product-serializer';
+import { genericBundleSuggestions } from '../catalog';
+import { isBoundedString, isPlainRecord } from '../../public-request-validation';
 
 export async function getRecommendations(
   request: RecommendRequest,
@@ -12,7 +14,16 @@ export async function getRecommendations(
   const startTime = Date.now();
   
   try {
-    const { context } = request;
+    const context = isPlainRecord(request?.context) ? request.context : {};
+    if (
+      (context.useCase !== undefined && !isBoundedString(context.useCase, 256)) ||
+      (context.userActivity !== undefined && !isBoundedString(context.userActivity, 256)) ||
+      (context.budget !== undefined &&
+        (typeof context.budget !== 'number' || !Number.isFinite(context.budget) || context.budget < 0)) ||
+      (context.currentProduct !== undefined && !Number.isSafeInteger(context.currentProduct))
+    ) {
+      throw new Error('Recommendation context is invalid');
+    }
     const userContext = enhanceUserContext(request.agent_context || null);
     
     let recommendations: Product[] = [];
@@ -102,41 +113,16 @@ export async function getRecommendations(
 }
 
 async function getUseCaseRecommendations(useCase: string, userContext: any): Promise<Product[]> {
-  const useCaseLower = useCase.toLowerCase();
-  
-  if (useCaseLower.includes('camping') || useCaseLower.includes('camp')) {
-    return await searchProducts('camping tent sleeping bag');
-  }
-  
-  if (useCaseLower.includes('hiking') || useCaseLower.includes('trail')) {
-    return await searchProducts('hiking backpack boots');
-  }
-  
-  if (useCaseLower.includes('backpack')) {
-    return await searchProducts('backpacking ultralight');
-  }
-  
-  // Default to general outdoor gear
-  return await searchProducts('outdoor adventure gear');
+  return searchProducts(useCase);
 }
 
 async function getActivityRecommendations(activity: string, userContext: any): Promise<Product[]> {
-  // Map activities to product searches
-  const activityMap: Record<string, string> = {
-    'weekend_camping': 'car camping tent sleeping bag',
-    'backpacking': 'ultralight backpacking gear',
-    'day_hiking': 'day pack hiking boots',
-    'mountaineering': 'alpine climbing gear',
-    'winter_camping': 'winter tent sleeping system'
-  };
-  
-  const searchQuery = activityMap[activity] || activity;
-  return await searchProducts(searchQuery);
+  return searchProducts(activity.replace(/_/g, ' '));
 }
 
 async function getRelatedProductRecommendations(product: Product, userContext: any): Promise<Product[]> {
-  const category = (product as any).category_name || 'outdoor gear';
-  return await searchProducts(category);
+  const query = product.categories?.[0] || String(product.name || '');
+  return searchProducts(query);
 }
 
 async function getGeneralRecommendations(userContext: any): Promise<Product[]> {
@@ -146,8 +132,7 @@ async function getGeneralRecommendations(userContext: any): Promise<Product[]> {
     return await searchProducts(activity);
   }
   
-  // Default to popular outdoor essentials
-  return await searchProducts('popular outdoor gear essentials');
+  return searchProducts('');
 }
 
 function sortRecommendations(products: Product[], userContext: any): Product[] {
@@ -191,41 +176,11 @@ function sortRecommendations(products: Product[], userContext: any): Product[] {
 }
 
 function generateCrossSiteRecommendations(context: any, userContext: any): string[] {
-  const suggestions: string[] = [];
-  
-  if (context.useCase?.toLowerCase().includes('food') || context.userActivity?.includes('meal')) {
-    suggestions.push('Mountain House for freeze-dried meals and rations');
-    suggestions.push('REI for comprehensive outdoor food selection');
-  }
-  
-  if (context.useCase?.toLowerCase().includes('ski') || context.userActivity?.includes('winter')) {
-    suggestions.push('Backcountry.com for specialized winter sports equipment');
-    suggestions.push('Local ski shops for cross-country skiing gear');
-  }
-  
-  if (userContext.experienceLevel === 'expert') {
-    suggestions.push('Specialist manufacturers for high-end technical gear');
-  }
-  
-  return suggestions;
+  return [];
 }
 
 function generateBundlingRecommendations(products: Product[]): string[] {
-  const recommendations: string[] = [];
-  
-  const hasTent = products.some(p => (typeof p.name === 'string' ? p.name : String(p.name || '')).toLowerCase().includes('tent'));
-  const hasSleeping = products.some(p => (typeof p.name === 'string' ? p.name : String(p.name || '')).toLowerCase().includes('sleeping') || (typeof p.name === 'string' ? p.name : String(p.name || '')).toLowerCase().includes('bag'));
-  const hasBackpack = products.some(p => (typeof p.name === 'string' ? p.name : String(p.name || '')).toLowerCase().includes('pack') || (typeof p.name === 'string' ? p.name : String(p.name || '')).toLowerCase().includes('backpack'));
-  
-  if (hasTent && hasSleeping) {
-    recommendations.push('Complete shelter system: tent + sleeping setup bundle available');
-  }
-  
-  if (hasBackpack && hasSleeping) {
-    recommendations.push('Backpacking essentials: pack + sleeping system combo deals');
-  }
-  
-  return recommendations;
+  return genericBundleSuggestions(new Set(products.map((product) => product.id)).size);
 }
 
 function generateCostRecommendations(products: Product[], budget?: number): string[] {
@@ -238,11 +193,11 @@ function generateCostRecommendations(products: Product[], budget?: number): stri
   }, Money.zero()).toMach().amount;
   
   if (totalCost > budget * 1.2) {
-    recommendations.push('Consider base models to stay within budget');
+    recommendations.push('Consider lower-priced variants to stay within budget');
     recommendations.push('Look for seasonal sales on similar items');
   } else if (totalCost < budget * 0.8) {
     recommendations.push('Budget allows for premium upgrades');
-    recommendations.push('Consider adding complementary gear within budget');
+    recommendations.push('Consider adding complementary catalog items within budget');
   }
   
   return recommendations;

--- a/lib/mcp/tools/search.ts
+++ b/lib/mcp/tools/search.ts
@@ -1,38 +1,83 @@
 import { searchProducts } from '../../models/mach/products';
 import { SearchRequest, MCPToolResponse } from '../types';
 import { enhanceUserContext } from '../context';
-import { Product } from '../../types';
-import { toPublicProduct } from '../../models/mach/product-serializer';
+import { toPublicProduct, toWireProduct, type WireProduct } from '../../models/mach/product-serializer';
+import { isBoundedString, isPlainRecord } from '../../public-request-validation';
+import { Money } from '../../money';
 
 export async function searchProductsWithContext(
   request: SearchRequest,
   sessionId: string
-): Promise<MCPToolResponse<Product[]>> {
+): Promise<MCPToolResponse<WireProduct[]>> {
   const startTime = Date.now();
   
   try {
+    if (!isBoundedString(request?.query, 256)) {
+      throw new Error('Search query must be a non-empty string of at most 256 characters');
+    }
     // Enhance search with agent context
     const userContext = enhanceUserContext(request.agent_context || null);
     
-    // Apply budget filter if provided
+    if (request.options !== undefined && !isPlainRecord(request.options)) {
+      throw new Error('Search options must be an object');
+    }
     const options = { ...request.options };
-    if (userContext.budget) {
-      options.priceMax = Math.min(options.priceMax || userContext.budget, userContext.budget);
+    for (const [name, value] of [['priceMin', options.priceMin], ['priceMax', options.priceMax]] as const) {
+      if (value !== undefined && (!Number.isFinite(value) || value < 0)) {
+        throw new Error(`${name} must be a non-negative finite number`);
+      }
+    }
+    if (options.priceMin !== undefined && options.priceMax !== undefined && options.priceMin > options.priceMax) {
+      throw new Error('priceMin cannot exceed priceMax');
+    }
+    if (options.category !== undefined && !isBoundedString(options.category, 128)) {
+      throw new Error('category must be a non-empty string of at most 128 characters');
+    }
+    if (options.limit !== undefined && (!Number.isSafeInteger(options.limit) || options.limit < 1 || options.limit > 100)) {
+      throw new Error('limit must be an integer between 1 and 100');
+    }
+    if (options.sortBy !== undefined && options.sortBy !== 'price') {
+      throw new Error("sortBy currently supports only 'price'");
+    }
+    if (userContext.budget !== undefined) {
+      options.priceMax = Math.min(options.priceMax ?? userContext.budget, userContext.budget);
     }
 
     // Search products
     const products = await searchProducts(request.query);
     
     // Filter by user preferences if provided
-    let filteredProducts = products;
+    let filteredProducts = products.filter((product) => product.status === 'active');
+    if (options.category) {
+      const category = options.category.toLowerCase();
+      filteredProducts = filteredProducts.filter((product) =>
+        product.categories?.some((candidate) => candidate.toLowerCase() === category)
+      );
+    }
+    if (options.priceMin !== undefined || options.priceMax !== undefined) {
+      filteredProducts = filteredProducts.filter((product) => {
+        const price = lowestVariantPrice(product);
+        return price !== null &&
+          (options.priceMin === undefined || price >= options.priceMin) &&
+          (options.priceMax === undefined || price <= options.priceMax);
+      });
+    }
     if (userContext.preferredBrands?.length > 0) {
-      filteredProducts = products.filter(product => 
+      filteredProducts = filteredProducts.filter(product =>
         userContext.preferredBrands.some((brand: string) => 
+          (typeof product.brand === 'string' && product.brand.toLowerCase().includes(brand.toLowerCase())) ||
           (typeof product.name === 'string' ? product.name : String(product.name || '')).toLowerCase().includes(brand.toLowerCase()) ||
           (typeof product.description === 'string' ? product.description : String(product.description || '')).toLowerCase().includes(brand.toLowerCase())
         )
       );
     }
+    if (options.sortBy === 'price') {
+      filteredProducts.sort((a, b) =>
+        (lowestVariantPrice(a) ?? Number.POSITIVE_INFINITY) -
+        (lowestVariantPrice(b) ?? Number.POSITIVE_INFINITY)
+      );
+    }
+    filteredProducts = filteredProducts.slice(0, options.limit ?? 10);
 
     // Calculate fulfillment metrics
     const totalRequested = 1; // Single search query
@@ -41,22 +86,13 @@ export async function searchProductsWithContext(
 
     // Generate recommendations for items we can't fulfill well
     const recommendations: string[] = [];
-    if (fulfillmentPercentage < 80) {
-      if (request.query.toLowerCase().includes('ration') || request.query.toLowerCase().includes('food')) {
-        recommendations.push('Consider specialized outdoor food retailers for rations and meal planning');
-      }
-      if (request.query.toLowerCase().includes('ski') || request.query.toLowerCase().includes('snow')) {
-        recommendations.push('Check dedicated ski shops for cross-country skiing equipment');
-      }
-    }
+    if (fulfillmentPercentage < 80) recommendations.push('Try broader or category-level search terms');
 
     const processingTime = Date.now() - startTime;
 
     return {
       success: true,
-      data: filteredProducts
-        .filter(product => product.status === 'active')
-        .map(toPublicProduct),
+      data: filteredProducts.map((product) => toWireProduct(toPublicProduct(product))),
       context: {
         session_id: sessionId,
         agent_id: request.agent_context?.agentId || 'unknown',
@@ -89,4 +125,16 @@ export async function searchProductsWithContext(
       }
     };
   }
+}
+
+function lowestVariantPrice(product: Awaited<ReturnType<typeof searchProducts>>[number]): number | null {
+  const prices = (product.variants ?? []).flatMap((variant) => {
+    if (variant.status != null && variant.status !== 'active') return [];
+    try {
+      return [Money.fromStored(variant.price).toMach().amount];
+    } catch {
+      return [];
+    }
+  });
+  return prices.length > 0 ? prices.reduce((lowest, price) => Math.min(lowest, price)) : null;
 }

--- a/lib/mcp/tools/shipping.ts
+++ b/lib/mcp/tools/shipping.ts
@@ -1,287 +1,133 @@
-import { MCPToolResponse } from '../types';
-import { CartItem } from '../../types/cartitem';
-import { Money, cartSubtotal } from '../../money';
+import { cartSubtotal, Money, toWireMoney, type MachMoney } from '../../money';
+import {
+  allowedShippingCountries,
+  enabledShippingMethods,
+  freeShippingMethodIds,
+  freeShippingThreshold,
+} from '../../shipping/allowed-countries';
+import type { CartItem } from '../../types/cartitem';
+import type { MACHAddress } from '../../types/mach/Address';
+import { getSettings } from '../../utils/settings';
+import { normalizeMcpAddress } from '../checkout';
+import { requireOwnedSession } from '../session';
+import type { MCPToolResponse } from '../types';
 
 export interface ShippingOption {
   id: string;
   name: string;
-  description: string;
   estimated_days: string;
-  price: number;
-  carrier: string;
+  price: MachMoney;
 }
 
 export interface ShippingRequest {
-  address: {
-    street: string;
-    street2?: string;
-    city: string;
-    state: string;
-    postal_code: string;
-    country?: string;
-  };
+  address: MACHAddress;
   cart?: CartItem[];
-  agent_context?: any;
+  agent_context?: unknown;
 }
 
 export interface ShippingResponse {
   shipping_options: ShippingOption[];
   default_option: string;
-  total_weight?: number;
   restrictions?: string[];
 }
 
 export async function getShippingOptions(
   request: ShippingRequest,
-  sessionId: string
+  sessionId: string,
+  agentId: string,
 ): Promise<MCPToolResponse<ShippingResponse>> {
   const startTime = Date.now();
-  
+  const ownership = await requireOwnedSession(sessionId, agentId);
+  if (!ownership.ok) {
+    return failure(sessionId, agentId, startTime, ownership.code, ownership.message);
+  }
+
   try {
-    const { address, cart = [] } = request;
-    
-    // Calculate total weight and shipping cost factors
-    const totalWeight = cart.reduce((sum, item) => sum + (item.quantity * 2), 0); // Assume 2lbs per item average
-    const cartTotal = cartSubtotal(cart);
-    
-    // Determine shipping zone based on state
-    const zone = getShippingZone(address.state, address.country || 'US');
-    
-    // Generate shipping options based on zone and cart
-    const shippingOptions: ShippingOption[] = [];
-    
-    // Standard shipping
-    const standardCost = calculateStandardShipping(zone, totalWeight, cartTotal);
-    shippingOptions.push({
-      id: 'standard',
-      name: 'Standard Shipping',
-      description: 'USPS Ground - 5-7 business days',
-      estimated_days: '5-7 business days',
-      price: standardCost.toMach().amount,
-      carrier: 'USPS'
-    });
-    
-    // Expedited shipping
-    const expeditedCost = calculateExpeditedShipping(zone, totalWeight);
-    shippingOptions.push({
-      id: 'expedited',
-      name: 'Expedited Shipping',
-      description: 'UPS 2-Day - 2-3 business days',
-      estimated_days: '2-3 business days', 
-      price: expeditedCost.toMach().amount,
-      carrier: 'UPS'
-    });
-    
-    // Overnight shipping (only for continental US)
-    if (zone === 'continental') {
-      const overnightCost = calculateOvernightShipping(totalWeight);
-      shippingOptions.push({
-        id: 'overnight',
-        name: 'Overnight Shipping',
-        description: 'FedEx Next Day - 1 business day',
-        estimated_days: '1 business day',
-        price: overnightCost.toMach().amount,
-        carrier: 'FedEx'
-      });
+    const address = normalizeMcpAddress(request.address);
+    const [shippingSettings, storeSettings] = await Promise.all([
+      getSettings('shipping'),
+      getSettings('store'),
+    ]);
+    const country = address.country.toUpperCase();
+    if (!allowedShippingCountries(shippingSettings).includes(country)) {
+      return failure(
+        sessionId,
+        agentId,
+        startTime,
+        'DESTINATION_UNAVAILABLE',
+        'Shipping options are not available for this destination',
+      );
     }
-    
-    // Check for shipping restrictions
-    const restrictions = checkShippingRestrictions(address, cart);
-    
-    const processingTime = Date.now() - startTime;
-    
+
+    const subtotal = cartSubtotal(ownership.session.cart);
+    const threshold = freeShippingThreshold(storeSettings);
+    const freeMethods = freeShippingMethodIds(shippingSettings);
+    const shippingOptions = enabledShippingMethods(shippingSettings).flatMap((method) => {
+      if (
+        typeof method.id !== 'string' ||
+        typeof method.label !== 'string' ||
+        typeof method.cost !== 'number' ||
+        typeof method.estimatedDays !== 'number'
+      ) return [];
+      const cost = subtotal.gte(Money.fromMajor(threshold, subtotal.currency)) && freeMethods.includes(method.id)
+        ? Money.zero(subtotal.currency)
+        : Money.fromMajor(method.cost, subtotal.currency);
+      return [{
+        id: method.id,
+        name: method.label,
+        estimated_days: `${method.estimatedDays} business day${method.estimatedDays === 1 ? '' : 's'}`,
+        price: toWireMoney(cost.toJSON()),
+      }];
+    });
+
+    if (shippingOptions.length === 0) {
+      return failure(sessionId, agentId, startTime, 'NO_SHIPPING_METHODS', 'No shipping methods are enabled');
+    }
+
     return {
       success: true,
       data: {
         shipping_options: shippingOptions,
-        default_option: 'standard',
-        total_weight: totalWeight,
-        restrictions
+        default_option: shippingOptions[0].id,
+        restrictions: [],
       },
       context: {
         session_id: sessionId,
-        agent_id: request.agent_context?.agentId || 'unknown',
-        processing_time_ms: processingTime
-      },
-      recommendations: {
-        cost_optimization: generateShippingRecommendations(shippingOptions, cartTotal, request.agent_context?.userPreferences?.budget),
-        bundling_opportunities: cart.length > 0 ? ['Consider bulk orders to reduce per-item shipping cost'] : []
+        agent_id: agentId,
+        processing_time_ms: Date.now() - startTime,
       },
       metadata: {
-        can_fulfill_percentage: restrictions.length === 0 ? 100 : 75,
-        estimated_satisfaction: calculateShippingSatisfaction(shippingOptions, restrictions),
-        next_actions: restrictions.length > 0 ? 
-          ['Review shipping restrictions', 'Consider alternative items'] :
-          ['Select shipping option', 'Proceed to checkout']
-      }
+        can_fulfill_percentage: 100,
+        estimated_satisfaction: 90,
+        next_actions: ['Select a shipping method', 'Create the PaymentIntent'],
+      },
     };
   } catch (error) {
-    const processingTime = Date.now() - startTime;
-    
-    return {
-      success: false,
-      data: {
-        shipping_options: [],
-        default_option: 'standard',
-        restrictions: ['Unable to calculate shipping options']
-      },
-      context: {
-        session_id: sessionId,
-        agent_id: request.agent_context?.agentId || 'unknown',
-        processing_time_ms: processingTime
-      },
-      metadata: {
-        can_fulfill_percentage: 0,
-        estimated_satisfaction: 0,
-        next_actions: ['Verify shipping address', 'Check cart contents', 'Contact support']
-      }
-    };
+    console.error('[mcp] Shipping option calculation failed:', error);
+    return failure(sessionId, agentId, startTime, 'SHIPPING_UNAVAILABLE', 'Unable to calculate shipping options');
   }
 }
 
-function getShippingZone(state: string, country: string): string {
-  if (country !== 'US') {
-    return 'international';
-  }
-  
-  if (['AK', 'HI'].includes(state.toUpperCase())) {
-    return 'extended';
-  }
-  
-  return 'continental';
-}
-
-function calculateStandardShipping(zone: string, weight: number, cartTotal: Money): Money {
-  // Free shipping over $75
-  if (cartTotal.gte(Money.fromMajor(75, cartTotal.currency))) {
-    return Money.zero(cartTotal.currency);
-  }
-  
-  let baseCost = 0;
-  switch (zone) {
-    case 'continental':
-      baseCost = 8.99;
-      break;
-    case 'extended':
-      baseCost = 19.99;
-      break;
-    case 'international':
-      baseCost = 29.99;
-      break;
-  }
-  
-  // Add weight-based surcharge for heavy orders
-  if (weight > 10) {
-    baseCost += Math.ceil((weight - 10) / 5) * 5;
-  }
-  
-  return Money.fromMajor(baseCost, cartTotal.currency);
-}
-
-function calculateExpeditedShipping(zone: string, weight: number): Money {
-  let baseCost = 0;
-  switch (zone) {
-    case 'continental':
-      baseCost = 19.99;
-      break;
-    case 'extended':
-      baseCost = 39.99;
-      break;
-    case 'international':
-      baseCost = 59.99;
-      break;
-  }
-  
-  // Weight surcharge
-  if (weight > 5) {
-    baseCost += Math.ceil((weight - 5) / 3) * 8;
-  }
-  
-  return Money.fromMajor(baseCost);
-}
-
-function calculateOvernightShipping(weight: number): Money {
-  let baseCost = 39.99;
-  
-  // Higher weight surcharge for overnight
-  if (weight > 3) {
-    baseCost += Math.ceil((weight - 3) / 2) * 12;
-  }
-  
-  return Money.fromMajor(baseCost);
-}
-
-function checkShippingRestrictions(address: any, cart: CartItem[]): string[] {
-  const restrictions: string[] = [];
-  
-  // Check for hazardous materials (fuel canisters, etc.)
-  const hasHazmat = cart.some(item => 
-    item.name.toLowerCase().includes('fuel') || 
-    item.name.toLowerCase().includes('canister') ||
-    item.name.toLowerCase().includes('stove fuel')
-  );
-  
-  if (hasHazmat) {
-    restrictions.push('Fuel canisters require ground shipping only - expedited/overnight not available');
-  }
-  
-  // International shipping restrictions
-  if (address.country && address.country !== 'US') {
-    restrictions.push('International shipping may require additional customs documentation');
-    
-    // Specific restricted items for international
-    const hasElectronics = cart.some(item => 
-      item.name.toLowerCase().includes('headlamp') ||
-      item.name.toLowerCase().includes('lantern') ||
-      item.name.toLowerCase().includes('gps')
-    );
-    
-    if (hasElectronics) {
-      restrictions.push('Electronics may require additional customs declarations');
-    }
-  }
-  
-  return restrictions;
-}
-
-function generateShippingRecommendations(options: ShippingOption[], cartTotal: Money, budget?: number): string[] {
-  const recommendations: string[] = [];
-  
-  // Free shipping threshold
-  if (cartTotal.lt(Money.fromMajor(75)) && cartTotal.gte(Money.fromMajor(60))) {
-    recommendations.push(`Add ${Money.fromMajor(75).subtract(cartTotal).format()} to cart for free standard shipping`);
-  }
-  
-  // Budget-based recommendations
-  if (budget) {
-    const affordableOptions = options.filter(opt => opt.price <= budget * 0.1); // 10% of budget for shipping
-    if (affordableOptions.length > 0) {
-      const fastest = affordableOptions.reduce((prev, curr) => 
-        parseInt(prev.estimated_days) < parseInt(curr.estimated_days) ? prev : curr
-      );
-      recommendations.push(`Within shipping budget: ${fastest.name} recommended`);
-    } else {
-      recommendations.push('Consider standard shipping to stay within budget');
-    }
-  }
-  
-  return recommendations;
-}
-
-function calculateShippingSatisfaction(options: ShippingOption[], restrictions: string[]): number {
-  let satisfaction = 80; // Base satisfaction for having shipping options
-  
-  if (restrictions.length > 0) {
-    satisfaction -= restrictions.length * 10;
-  }
-  
-  if (options.length >= 3) {
-    satisfaction += 10; // Bonus for having multiple options
-  }
-  
-  if (options.some(opt => opt.price === 0)) {
-    satisfaction += 10; // Bonus for free shipping
-  }
-  
-  return Math.max(0, Math.min(100, satisfaction));
+function failure(
+  sessionId: string,
+  agentId: string,
+  startTime: number,
+  code: string,
+  message: string,
+): MCPToolResponse<ShippingResponse> {
+  return {
+    success: false,
+    data: { shipping_options: [], default_option: '', restrictions: [message] },
+    context: {
+      session_id: sessionId,
+      agent_id: agentId,
+      processing_time_ms: Date.now() - startTime,
+    },
+    error: { code, message },
+    metadata: {
+      can_fulfill_percentage: 0,
+      estimated_satisfaction: 0,
+      next_actions: ['Verify the shipping address and configured methods'],
+    },
+  };
 }

--- a/lib/mcp/types.ts
+++ b/lib/mcp/types.ts
@@ -66,7 +66,7 @@ export interface SearchRequest {
     priceMin?: number;
     priceMax?: number;
     limit?: number;
-    sortBy?: 'price' | 'rating' | 'popularity';
+    sortBy?: 'price';
   };
   agent_context?: AgentContext;
 }
@@ -82,7 +82,7 @@ export interface AssessRequest {
 }
 
 export interface RecommendRequest {
-  context: {
+  context?: {
     currentProduct?: number;
     userActivity?: string;
     budget?: number;
@@ -99,10 +99,12 @@ export interface CartRequest {
 }
 
 export interface OrderRequest {
-  shippingAddress: Address;
+  orderId: string;
+  paymentIntentId: string;
+  shippingAddress?: Address;
   billingAddress?: Address;
-  paymentMethod: string;
-  shippingOption: string;
+  paymentMethod?: string;
+  shippingOption?: string;
   specialInstructions?: string;
   agent_context?: AgentContext;
 }
@@ -126,13 +128,13 @@ export interface AssessResponse {
 export interface CartResponse {
   cart: WireCartItem[];
   total_items: number;
-  estimated_total: number;
+  estimated_total: MachMoney;
 }
 
 export interface OrderResponse {
   orderId: string;
   status: string;
-  total: number;
+  total: MachMoney;
   tracking_number?: string;
   estimated_delivery: string;
 }

--- a/migrations/0012_expand_mcp_agent_credentials.sql
+++ b/migrations/0012_expand_mcp_agent_credentials.sql
@@ -1,0 +1,20 @@
+-- Expand MCP credentials without invalidating existing agents.
+--
+-- Existing `api_key` rows remain readable during the rotation window. The
+-- application hashes and retires a legacy plaintext value after its next
+-- successful authentication or an explicit management rotation. A later
+-- contract migration may remove `api_key` only after operators confirm no
+-- credential_version=1 rows remain.
+ALTER TABLE mcp_agents ADD COLUMN api_key_hash TEXT;
+ALTER TABLE mcp_agents ADD COLUMN api_key_expires_at TEXT;
+ALTER TABLE mcp_agents ADD COLUMN credential_version INTEGER NOT NULL DEFAULT 1;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_mcp_agents_api_key_hash
+  ON mcp_agents(api_key_hash)
+  WHERE api_key_hash IS NOT NULL;
+
+-- Migration 0004 installed this public demo credential in every environment.
+-- Development restores it from data/d1/seed-dev.sql; deployed databases must
+-- never retain a credential whose raw value is committed to source control.
+DELETE FROM mcp_agents
+WHERE agent_id = 'test-agent' AND api_key = 'test-key-123';

--- a/scripts/db-local-ensure.mjs
+++ b/scripts/db-local-ensure.mjs
@@ -4,12 +4,22 @@ import { readFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { migrationArgs, parseWranglerConfig, resolveTarget } from "./lib/d1-migrate-plan.mjs";
 
+const DEV_SEED_FILE = "data/d1/seed-dev.sql";
+
 try {
   const config = parseWranglerConfig(readFileSync("wrangler.jsonc", "utf8"));
   const plan = resolveTarget(config, { target: "local" });
   console.log(`[db:local] Applying local migrations for ${plan.database}...`);
   const result = spawnSync("npx", ["wrangler", ...migrationArgs(plan, "apply")], { stdio: "inherit" });
-  process.exit(result.status ?? 1);
+  if ((result.status ?? 1) !== 0) process.exit(result.status ?? 1);
+
+  console.log(`[db:local] Applying development-only MCP seed from ${DEV_SEED_FILE}...`);
+  const seedResult = spawnSync(
+    "npx",
+    ["wrangler", "d1", "execute", plan.database, "--local", "--file", DEV_SEED_FILE],
+    { stdio: "inherit" },
+  );
+  process.exit(seedResult.status ?? 1);
 } catch (error) {
   console.error(`[db:local] ABORT: ${error.message}`);
   process.exit(1);

--- a/tests/integration/d1-harness.test.ts
+++ b/tests/integration/d1-harness.test.ts
@@ -24,6 +24,7 @@ describe('real D1 Workers harness', () => {
       '0009_add_order_effects.sql',
       '0010_add_inventory_adjustments.sql',
       '0011_add_external_refund_restock_setting.sql',
+      '0012_expand_mcp_agent_credentials.sql',
     ]);
   });
 

--- a/tests/integration/lib/mcp/credential-migration.test.ts
+++ b/tests/integration/lib/mcp/credential-migration.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { env } from 'cloudflare:workers';
+import { authenticateAgent } from '@/lib/mcp/auth';
+import { sha256Hex } from '@/lib/auth/crypto';
+import { applyTestMigrations } from '../../helpers/d1';
+import { drizzle } from 'drizzle-orm/d1';
+import * as schema from '@/lib/db/schema';
+
+beforeEach(async () => {
+  await applyTestMigrations();
+});
+
+function request(apiKey: string): import('next/server').NextRequest {
+  return new Request('https://mercora.test/api/mcp', {
+    headers: { 'X-Agent-API-Key': apiKey },
+  }) as import('next/server').NextRequest;
+}
+
+describe('MCP credential expansion on real D1', () => {
+  it('removes the public migration-seeded credential', async () => {
+    const seeded = await env.DB.prepare(
+      'SELECT agent_id FROM mcp_agents WHERE agent_id = ?'
+    ).bind('test-agent').first();
+    expect(seeded).toBeNull();
+  });
+
+  it('upgrades a legacy plaintext row after successful authentication', async () => {
+    await env.DB.prepare(`
+      INSERT INTO mcp_agents (
+        agent_id, name, api_key, permissions, rate_limit_rpm, rate_limit_oph,
+        is_active, credential_version
+      ) VALUES (?, ?, ?, ?, ?, ?, 1, 1)
+    `).bind(
+      'legacy-agent',
+      'Legacy Agent',
+      'legacy-secret',
+      '["read:products"]',
+      100,
+      10,
+    ).run();
+
+    const database = drizzle(env.DB, { schema });
+    const result = await authenticateAgent(request('legacy-secret'), { database });
+    expect(result).toMatchObject({ success: true, agentId: 'legacy-agent' });
+
+    const row = await env.DB.prepare(`
+      SELECT api_key, api_key_hash, api_key_expires_at, credential_version
+      FROM mcp_agents WHERE agent_id = ?
+    `).bind('legacy-agent').first<{
+      api_key: string;
+      api_key_hash: string;
+      api_key_expires_at: string;
+      credential_version: number;
+    }>();
+    expect(row?.api_key).toMatch(/^retired:legacy-agent:/);
+    expect(row?.api_key_hash).toBe(await sha256Hex('legacy-secret'));
+    expect(row?.api_key_expires_at).toBeTruthy();
+    expect(row?.credential_version).toBe(2);
+
+    await expect(authenticateAgent(request('legacy-secret'), { database })).resolves.toMatchObject({ success: true });
+  });
+
+  it('rejects an expired hashed credential', async () => {
+    await env.DB.prepare(`
+      INSERT INTO mcp_agents (
+        agent_id, name, api_key, api_key_hash, api_key_expires_at,
+        credential_version, permissions, is_active
+      ) VALUES (?, ?, ?, ?, ?, 2, '[]', 1)
+    `).bind(
+      'expired-agent',
+      'Expired Agent',
+      'retired:expired-agent:test',
+      await sha256Hex('expired-secret'),
+      '2000-01-01T00:00:00.000Z',
+    ).run();
+
+    const database = drizzle(env.DB, { schema });
+    const result = await authenticateAgent(request('expired-secret'), { database });
+    expect(result.error?.code).toBe('API_KEY_EXPIRED');
+  });
+
+  it('does not accept a stale plaintext value after a hash is installed', async () => {
+    await env.DB.prepare(`
+      INSERT INTO mcp_agents (
+        agent_id, name, api_key, api_key_hash, api_key_expires_at,
+        credential_version, permissions, is_active
+      ) VALUES (?, ?, ?, ?, ?, 2, '[]', 1)
+    `).bind(
+      'rotated-agent',
+      'Rotated Agent',
+      'stale-plaintext-secret',
+      await sha256Hex('current-secret'),
+      new Date(Date.now() + 60_000).toISOString(),
+    ).run();
+
+    const database = drizzle(env.DB, { schema });
+    await expect(authenticateAgent(request('current-secret'), { database }))
+      .resolves.toMatchObject({ success: true, agentId: 'rotated-agent' });
+    await expect(authenticateAgent(request('stale-plaintext-secret'), { database }))
+      .resolves.toMatchObject({ success: false, error: { code: 'INVALID_API_KEY' } });
+  });
+});

--- a/tests/integration/lib/mcp/rate-limit.test.ts
+++ b/tests/integration/lib/mcp/rate-limit.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { env } from 'cloudflare:workers';
+import { drizzle } from 'drizzle-orm/d1';
+import * as schema from '@/lib/db/schema';
+import { checkRateLimit, getRateLimitWindowStarts, updateRateLimit } from '@/lib/mcp/auth';
+import { applyTestMigrations } from '../../helpers/d1';
+
+beforeEach(async () => {
+  await applyTestMigrations();
+});
+
+async function rateRow(agentId: string, window: string) {
+  return env.DB.prepare(`
+    SELECT count, window_start FROM mcp_rate_limits
+    WHERE agent_id = ? AND window = ?
+  `).bind(agentId, window).first<{ count: number; window_start: string }>();
+}
+
+describe('MCP rate limits on real D1', () => {
+  it('does not consume the hourly order allowance for non-order tools', async () => {
+    const database = drizzle(env.DB, { schema });
+    for (let count = 0; count < 6; count += 1) {
+      expect((await checkRateLimit('reader', 100, 2, false, database)).success).toBe(true);
+    }
+    expect(await rateRow('reader', 'hour')).toBeNull();
+  });
+
+  it('blocks the first order operation above the hourly allowance', async () => {
+    const database = drizzle(env.DB, { schema });
+    expect((await checkRateLimit('buyer', 100, 2, true, database)).success).toBe(true);
+    expect((await checkRateLimit('buyer', 100, 2, true, database)).success).toBe(true);
+    const blocked = await checkRateLimit('buyer', 100, 2, true, database);
+    expect(blocked.error?.code).toBe('RATE_LIMIT_EXCEEDED');
+    expect((await rateRow('buyer', 'hour'))?.count).toBe(2);
+  });
+
+  it('enforces the minute allowance for every tool', async () => {
+    const database = drizzle(env.DB, { schema });
+    expect((await checkRateLimit('minute', 1, 100, false, database)).success).toBe(true);
+    expect((await checkRateLimit('minute', 1, 100, false, database)).error?.code)
+      .toBe('RATE_LIMIT_EXCEEDED');
+  });
+
+  it('resets a stale counter when its window advances', async () => {
+    const database = drizzle(env.DB, { schema });
+    await env.DB.prepare(`
+      INSERT INTO mcp_rate_limits (agent_id, window, count, window_start)
+      VALUES (?, 'hour', 99, ?)
+    `).bind('rollover', '2000-01-01T00:00:00.000Z').run();
+    const { hourStart } = getRateLimitWindowStarts();
+    await updateRateLimit('rollover', 'hour', hourStart, database);
+    const row = await rateRow('rollover', 'hour');
+    expect(row).toEqual({ count: 1, window_start: hourStart });
+  });
+});

--- a/tests/unit/app/api/mcp-authorization.test.ts
+++ b/tests/unit/app/api/mcp-authorization.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  authenticateAgent: vi.fn(),
+  createAgent: vi.fn(),
+  addToCart: vi.fn(),
+}));
+
+vi.mock('@/lib/mcp/auth', () => ({
+  authenticateAgent: mocks.authenticateAgent,
+  hasAgentManagementPermission: (permissions: string[] | undefined) =>
+    permissions?.some((permission) => ['admin', '*', 'agents:manage'].includes(permission)) ?? false,
+  hasPermission: (permissions: string[] | undefined, required: string) =>
+    permissions?.some((permission) => permission === required || permission === 'admin' || permission === '*') ?? false,
+  requiredScopeForTool: (tool: string) => ({
+    add_to_cart: 'write:cart',
+    create_payment_intent: 'place:orders',
+    place_order: 'place:orders',
+  } as Record<string, string>)[tool],
+}));
+vi.mock('@/lib/mcp/context', () => ({ parseAgentContext: vi.fn(() => null) }));
+vi.mock('@/lib/mcp/tools/agent', () => ({ createAgent: mocks.createAgent }));
+vi.mock('@/lib/mcp/tools/cart', () => ({ addToCart: mocks.addToCart }));
+vi.mock('@/lib/mcp/catalog', () => ({ getCatalogCapabilities: vi.fn() }));
+
+import { POST as dispatch } from '@/app/api/mcp/route';
+import { POST as createAgent } from '@/app/api/mcp/tools/agents/create/route';
+import { POST as addCart } from '@/app/api/mcp/tools/cart/add/route';
+
+function request(body: Record<string, unknown>) {
+  return {
+    json: vi.fn(async () => body),
+    headers: { get: vi.fn(() => null) },
+  } as unknown as import('next/server').NextRequest;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.authenticateAgent.mockResolvedValue({
+    success: true,
+    agentId: 'plain-agent',
+    permissions: ['read:products'],
+  });
+});
+
+describe('MCP authorization is enforced on every entry point', () => {
+  it('blocks agent management through the JSON dispatcher', async () => {
+    const response = await dispatch(request({ tool: 'create_agent', params: {} }));
+    expect(response.status).toBe(403);
+    expect(mocks.createAgent).not.toHaveBeenCalled();
+  });
+
+  it('blocks cart mutation through the JSON dispatcher without write:cart', async () => {
+    const response = await dispatch(request({ tool: 'add_to_cart', params: {}, session_id: 's' }));
+    expect(response.status).toBe(403);
+    expect(mocks.addToCart).not.toHaveBeenCalled();
+  });
+
+  it('blocks agent management through its REST route', async () => {
+    const response = await createAgent(request({ agentId: 'new', name: 'New Agent' }));
+    expect(response.status).toBe(403);
+    expect(mocks.createAgent).not.toHaveBeenCalled();
+  });
+
+  it('blocks cart mutation through its REST route without write:cart', async () => {
+    const response = await addCart(request({ productId: 1, variantId: 1, session_id: 's' }));
+    expect(response.status).toBe(403);
+    expect(mocks.addToCart).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/app/api/mcp-session-route.test.ts
+++ b/tests/unit/app/api/mcp-session-route.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  authenticateAgent: vi.fn(),
+  getSession: vi.fn(),
+  updateSession: vi.fn(),
+  parseAgentContext: vi.fn(),
+}));
+
+vi.mock('@/lib/mcp/auth', () => ({ authenticateAgent: mocks.authenticateAgent }));
+vi.mock('@/lib/mcp/session', () => ({
+  getSession: mocks.getSession,
+  updateSession: mocks.updateSession,
+  deleteSession: vi.fn(),
+}));
+vi.mock('@/lib/mcp/context', () => ({ parseAgentContext: mocks.parseAgentContext }));
+
+import { PUT } from '@/app/api/mcp/sessions/[sessionId]/route';
+
+function request(contextHeader: string | null) {
+  return {
+    headers: { get: (name: string) => name === 'X-Agent-Context' ? contextHeader : null },
+    json: vi.fn(async () => ({ cart: [{ price: 1 }] })),
+  } as unknown as import('next/server').NextRequest;
+}
+
+const session = {
+  sessionId: 'session-1',
+  agentId: 'agent-1',
+  userContext: { agentId: 'agent-1' },
+  cart: [],
+  created_at: new Date().toISOString(),
+  expires_at: new Date(Date.now() + 60_000).toISOString(),
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.authenticateAgent.mockResolvedValue({ success: true, agentId: 'agent-1', permissions: [] });
+  mocks.getSession.mockResolvedValue(session);
+  mocks.updateSession.mockResolvedValue(true);
+  mocks.parseAgentContext.mockReturnValue({
+    agentId: 'agent-1',
+    userPreferences: { budget: 50 },
+  });
+});
+
+describe('MCP session update boundary', () => {
+  it('rejects a generic update without validated agent context', async () => {
+    const response = await PUT(request(null), { params: Promise.resolve({ sessionId: 'session-1' }) });
+    expect(response.status).toBe(400);
+    expect(mocks.updateSession).not.toHaveBeenCalled();
+  });
+
+  it('updates only validated context and cannot overwrite the cart', async () => {
+    const req = request('{"agentId":"spoofed"}');
+    const response = await PUT(req, { params: Promise.resolve({ sessionId: 'session-1' }) });
+    expect(response.status).toBe(200);
+    expect(req.json).not.toHaveBeenCalled();
+    expect(mocks.updateSession).toHaveBeenCalledWith('session-1', {
+      userContext: { agentId: 'agent-1', userPreferences: { budget: 50 } },
+    });
+  });
+});

--- a/tests/unit/app/api/mcp-tracking-route.test.ts
+++ b/tests/unit/app/api/mcp-tracking-route.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  authenticateAgent: vi.fn(),
+  getOrderStatus: vi.fn(),
+}));
+
+vi.mock('@/lib/mcp/auth', () => ({ authenticateAgent: mocks.authenticateAgent }));
+vi.mock('@/lib/mcp/tools/order', () => ({ getOrderStatus: mocks.getOrderStatus }));
+
+import { GET, POST } from '@/app/api/mcp/tools/order/track/route';
+
+function getRequest(url: string) {
+  return {
+    nextUrl: new URL(url),
+    headers: new Headers(),
+  } as unknown as import('next/server').NextRequest;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.authenticateAgent.mockResolvedValue({ success: true, agentId: 'agent-1', permissions: [] });
+  mocks.getOrderStatus.mockResolvedValue({
+    success: true,
+    data: {
+      orderId: 'MCP-AGENT1-1-A1B2C3D4',
+      status: 'processing',
+      total: { amount: 25, currency: 'USD', precision: 2 },
+      estimated_delivery: '3-5 business days',
+    },
+    context: { session_id: 'status-check', agent_id: 'agent-1', processing_time_ms: 1 },
+    metadata: { can_fulfill_percentage: 100, estimated_satisfaction: 90 },
+  });
+});
+
+describe('MCP tracking route', () => {
+  it('projects the authenticated agent order without invented carrier history', async () => {
+    const response = await GET(getRequest(
+      'https://mercora.test/api/mcp/tools/order/track?orderId=MCP-AGENT1-1-A1B2C3D4',
+    ));
+    expect(response.status).toBe(200);
+    const body = await response.json() as { data: Record<string, unknown> };
+    expect(mocks.getOrderStatus).toHaveBeenCalledWith('MCP-AGENT1-1-A1B2C3D4', 'agent-1');
+    expect(body.data).toMatchObject({ status: 'processing', history: [] });
+    expect(body.data.location).toBeUndefined();
+  });
+
+  it('authenticates a POST only once and requires an order ID', async () => {
+    const response = await POST(new Request('https://mercora.test/api/mcp/tools/order/track', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ orderId: 'MCP-AGENT1-1-A1B2C3D4' }),
+    }) as import('next/server').NextRequest);
+    expect(response.status).toBe(200);
+    expect(mocks.authenticateAgent).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/unit/lib/mcp/api-key-credentials.test.ts
+++ b/tests/unit/lib/mcp/api-key-credentials.test.ts
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { sha256Hex } from '@/lib/auth/crypto';
+
+let selectResults: unknown[][] = [];
+let insertedValues: Record<string, unknown> | undefined;
+const updatedValues: Record<string, unknown>[] = [];
+
+function makeChain(kind: 'select' | 'insert' | 'update') {
+  const chain: Record<string, any> = {};
+  const passthrough = () => chain;
+  chain.from = passthrough;
+  chain.where = passthrough;
+  chain.orderBy = passthrough;
+  chain.offset = passthrough;
+  chain.limit = () => Promise.resolve(selectResults.shift() ?? []);
+  chain.values = (value: Record<string, unknown>) => {
+    if (kind === 'insert') insertedValues = value;
+    return chain;
+  };
+  chain.set = (value: Record<string, unknown>) => {
+    updatedValues.push(value);
+    return chain;
+  };
+  chain.onConflictDoUpdate = passthrough;
+  chain.returning = () => Promise.resolve([{ agentId: 'agent-1' }]);
+  return chain;
+}
+
+const fakeDb = {
+  select: () => makeChain('select'),
+  insert: () => makeChain('insert'),
+  update: () => makeChain('update'),
+  batch: vi.fn(async () => []),
+};
+
+vi.mock('@/lib/db', () => ({ getDbAsync: vi.fn(async () => fakeDb) }));
+
+import {
+  authenticateAgent,
+  createAgent,
+  extractAgentApiKey,
+  rotateAgentApiKey,
+} from '@/lib/mcp/auth';
+import { canManageAgentPermissions } from '@/lib/mcp/tools/agent';
+
+function request(headers: Record<string, string> = {}, queryKey?: string) {
+  return {
+    headers: { get: (name: string) => headers[name] ?? null },
+    nextUrl: { searchParams: { get: () => queryKey ?? null } },
+  } as unknown as import('next/server').NextRequest;
+}
+
+beforeEach(() => {
+  selectResults = [];
+  insertedValues = undefined;
+  updatedValues.length = 0;
+  fakeDb.batch.mockClear();
+});
+
+describe('MCP agent credentials', () => {
+  it('does not let agents:manage control a more privileged credential', () => {
+    expect(canManageAgentPermissions(['agents:manage'], ['admin'])).toBe(false);
+    expect(canManageAgentPermissions(['agents:manage'], ['agents:manage'])).toBe(true);
+    expect(canManageAgentPermissions(['admin'], ['admin', 'place:orders'])).toBe(true);
+  });
+
+  it('accepts only X-Agent-API-Key or a well-formed Bearer header', () => {
+    expect(extractAgentApiKey(request({ 'X-Agent-API-Key': 'direct' }))).toBe('direct');
+    expect(extractAgentApiKey(request({ Authorization: 'Bearer bearer-key' }))).toBe('bearer-key');
+    expect(extractAgentApiKey(request({ Authorization: 'Basic abc' }))).toBeNull();
+    expect(extractAgentApiKey(request({}, 'query-secret'))).toBeNull();
+  });
+
+  it('stores a hash and retirement marker, never the issued raw key', async () => {
+    const issued = await createAgent({ agentId: 'agent-1', name: 'Agent One' });
+
+    expect(issued.apiKey).toMatch(/^mcp_/);
+    expect(insertedValues?.apiKeyHash).toBe(await sha256Hex(issued.apiKey));
+    expect(insertedValues?.legacyApiKey).toMatch(/^retired:agent-1:/);
+    expect(insertedValues?.apiKeyExpiresAt).toBe(issued.expiresAt);
+    expect(Object.values(insertedValues ?? {})).not.toContain(issued.apiKey);
+  });
+
+  it('authenticates a hashed key and returns fail-closed parsed permissions', async () => {
+    selectResults = [[{
+      agentId: 'agent-1',
+      legacyApiKey: 'retired:agent-1:value',
+      apiKeyHash: await sha256Hex('presented'),
+      apiKeyExpiresAt: new Date(Date.now() + 60_000).toISOString(),
+      permissions: '["write:cart",42]',
+      rateLimitRpm: 100,
+      rateLimitOph: 10,
+      isActive: true,
+    }], []];
+
+    const result = await authenticateAgent(request({ 'X-Agent-API-Key': 'presented' }));
+    expect(result).toMatchObject({ success: true, agentId: 'agent-1', permissions: ['write:cart'] });
+    expect(fakeDb.batch).toHaveBeenCalledOnce();
+  });
+
+  it('upgrades a successfully used plaintext credential in place', async () => {
+    selectResults = [[{
+      agentId: 'legacy-agent',
+      legacyApiKey: 'legacy-secret',
+      apiKeyHash: null,
+      apiKeyExpiresAt: null,
+      permissions: '[]',
+      rateLimitRpm: 100,
+      rateLimitOph: 10,
+      isActive: true,
+    }], []];
+
+    const result = await authenticateAgent(request({ 'X-Agent-API-Key': 'legacy-secret' }));
+    expect(result.success).toBe(true);
+    expect(updatedValues[0]).toMatchObject({
+      apiKeyHash: await sha256Hex('legacy-secret'),
+      credentialVersion: 2,
+    });
+    expect(updatedValues[0].legacyApiKey).toMatch(/^retired:legacy-agent:/);
+  });
+
+  it('rejects an expired credential before consuming rate-limit capacity', async () => {
+    selectResults = [[{
+      agentId: 'expired-agent',
+      legacyApiKey: 'retired:expired-agent:value',
+      apiKeyHash: await sha256Hex('expired'),
+      apiKeyExpiresAt: new Date(Date.now() - 60_000).toISOString(),
+      permissions: '[]',
+      rateLimitRpm: 100,
+      rateLimitOph: 10,
+      isActive: true,
+    }]];
+
+    const result = await authenticateAgent(request({ Authorization: 'Bearer expired' }));
+    expect(result.error?.code).toBe('API_KEY_EXPIRED');
+    expect(fakeDb.batch).not.toHaveBeenCalled();
+  });
+
+  it('rejects an invalid credential expiry instead of failing open', async () => {
+    selectResults = [[{
+      agentId: 'invalid-expiry-agent',
+      legacyApiKey: 'retired:invalid-expiry-agent:value',
+      apiKeyHash: await sha256Hex('presented'),
+      apiKeyExpiresAt: 'not-a-date',
+      permissions: '[]',
+      rateLimitRpm: 100,
+      rateLimitOph: 10,
+      isActive: true,
+    }]];
+
+    const result = await authenticateAgent(request({ Authorization: 'Bearer presented' }));
+    expect(result.error?.code).toBe('API_KEY_EXPIRED');
+    expect(fakeDb.batch).not.toHaveBeenCalled();
+  });
+
+  it('rotates a credential and returns the raw replacement once', async () => {
+    const rotated = await rotateAgentApiKey('agent-1', 30);
+    expect(rotated.apiKey).toMatch(/^mcp_/);
+    expect(updatedValues[0].apiKeyHash).toBe(await sha256Hex(rotated.apiKey));
+    expect(updatedValues[0].legacyApiKey).toMatch(/^retired:agent-1:/);
+    expect(Object.values(updatedValues[0])).not.toContain(rotated.apiKey);
+  });
+});

--- a/tests/unit/lib/mcp/cart-ownership.test.ts
+++ b/tests/unit/lib/mcp/cart-ownership.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/mcp/session', () => ({
+  requireOwnedSession: vi.fn(),
+  updateSessionCart: vi.fn(),
+}));
+vi.mock('@/lib/models/mach/products', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/models/mach/products')>()),
+  getProductBySlug: vi.fn(),
+}));
+
+import { requireOwnedSession, updateSessionCart } from '@/lib/mcp/session';
+import { getProductBySlug } from '@/lib/models/mach/products';
+import {
+  addToCart,
+  bulkAddToCart,
+  clearCart,
+  getCartEstimate,
+  removeFromCart,
+  updateCart,
+} from '@/lib/mcp/tools/cart';
+
+const denied = {
+  ok: false as const,
+  code: 'SESSION_ACCESS_DENIED' as const,
+  message: 'Agent does not own this session',
+};
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('MCP cart ownership', () => {
+  it.each([
+    ['add', () => addToCart({ productId: 1, variantId: 1, sessionId: 's' }, 's', 'attacker')],
+    ['bulk add', () => bulkAddToCart({ items: [], sessionId: 's' }, 's', 'attacker')],
+    ['clear', () => clearCart('s', 'attacker')],
+    ['update', () => updateCart({ productId: 1, variantId: 1, sessionId: 's' }, 's', 'attacker')],
+    ['remove', () => removeFromCart({ productId: 1, variantId: 1, sessionId: 's' }, 's', 'attacker')],
+    ['estimate', () => getCartEstimate('s', 'attacker')],
+  ])('%s rejects a session owned by another agent before reading or mutating it', async (_name, run) => {
+    vi.mocked(requireOwnedSession).mockResolvedValue(denied);
+    const result = await run();
+    expect(result.error?.code).toBe('SESSION_ACCESS_DENIED');
+    expect(updateSessionCart).not.toHaveBeenCalled();
+    expect(getProductBySlug).not.toHaveBeenCalled();
+  });
+
+  it('rejects an empty bulk request without emitting NaN fulfillment metadata', async () => {
+    vi.mocked(requireOwnedSession).mockResolvedValue({
+      ok: true,
+      session: {
+        sessionId: 's',
+        agentId: 'agent',
+        userContext: { agentId: 'agent' },
+        cart: [],
+        created_at: new Date().toISOString(),
+        expires_at: new Date(Date.now() + 60_000).toISOString(),
+      },
+    });
+    const result = await bulkAddToCart({ items: [], sessionId: 's' }, 's', 'agent');
+    expect(result.success).toBe(false);
+    expect(result.metadata.can_fulfill_percentage).toBe(0);
+    expect(Number.isNaN(result.metadata.can_fulfill_percentage)).toBe(false);
+    expect(updateSessionCart).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/lib/mcp/id-generation.test.ts
+++ b/tests/unit/lib/mcp/id-generation.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { generateApiKey } from '@/lib/mcp/auth';
+import { createAgentSessionId, parseAgentContext } from '@/lib/mcp/context';
+
+function contextRequest(value?: unknown) {
+  return {
+    headers: {
+      get: () => value === undefined ? null : JSON.stringify(value),
+    },
+  } as unknown as import('next/server').NextRequest;
+}
+
+describe('MCP security identifiers', () => {
+  it('generates prefixed, high-entropy API keys', () => {
+    const keys = new Set(Array.from({ length: 50 }, () => generateApiKey()));
+    expect(keys.size).toBe(50);
+    for (const key of keys) {
+      expect(key).toMatch(/^mcp_[0-9a-f]{32}$/);
+    }
+  });
+
+  it('generates unique session ids with a CSPRNG UUID suffix', () => {
+    const ids = new Set(Array.from({ length: 50 }, () => createAgentSessionId('agent-x')));
+    expect(ids.size).toBe(50);
+    for (const id of ids) {
+      expect(id).toMatch(/^agent-x_[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+    }
+  });
+
+  it('uses authenticated identity even when no client context header exists', () => {
+    expect(parseAgentContext(contextRequest(), 'authenticated-agent'))
+      .toEqual({ agentId: 'authenticated-agent' });
+  });
+
+  it('overrides a spoofed context identity', () => {
+    expect(parseAgentContext(contextRequest({ agentId: 'attacker' }), 'authenticated-agent'))
+      .toEqual({ agentId: 'authenticated-agent' });
+  });
+});

--- a/tests/unit/lib/mcp/mcp-checkout.test.ts
+++ b/tests/unit/lib/mcp/mcp-checkout.test.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  priceCheckout: vi.fn(),
+  assertInventory: vi.fn(),
+  createPaymentIntent: vi.fn(),
+  cancelPaymentIntent: vi.fn(),
+  inserted: undefined as Record<string, unknown> | undefined,
+  insertError: undefined as Error | undefined,
+}));
+
+vi.mock('@/lib/services/checkout-pricing', () => ({
+  priceCheckout: mocks.priceCheckout,
+  MAX_CHECKOUT_LINES: 100,
+}));
+vi.mock('@/lib/services/inventory-adjustments', () => ({
+  assertCheckoutInventoryAvailable: mocks.assertInventory,
+}));
+vi.mock('@/lib/stripe', () => ({
+  createPaymentIntent: mocks.createPaymentIntent,
+  cancelPaymentIntent: mocks.cancelPaymentIntent,
+}));
+vi.mock('@/lib/db', () => ({
+  getDbAsync: vi.fn(async () => ({
+    insert: () => ({ values: async (value: Record<string, unknown>) => {
+      if (mocks.insertError) throw mocks.insertError;
+      mocks.inserted = value;
+    } }),
+  })),
+}));
+
+import { createMcpCheckout, normalizeMcpAddress } from '@/lib/mcp/checkout';
+
+const money = (amount: number) => ({ amount, currency: 'USD', centAmount: amount, fractionDigits: 2 });
+const quote = {
+  currency: 'USD',
+  items: [{
+    product_id: 'catalog-product',
+    variant_id: 'catalog-variant',
+    sku: 'SKU-1',
+    product_name: 'Catalog Name',
+    quantity: 2,
+    unit_price: money(1200),
+    total_price: money(2400),
+  }],
+  subtotal: money(2400),
+  discount: money(0),
+  merchandiseDiscount: money(0),
+  shippingDiscount: money(0),
+  shipping: money(599),
+  tax: money(150),
+  shippingTax: money(0),
+  lineAllocations: [],
+  tender: money(0),
+  total: money(3149),
+  discountCodes: [],
+  shippingMethod: { id: 'standard', label: 'Standard' },
+  taxSource: 'configured_fallback' as const,
+};
+
+const session = {
+  sessionId: 'session-1',
+  agentId: 'agent-1',
+  userContext: { agentId: 'agent-1' },
+  cart: [{
+    productId: 'catalog-product',
+    variantId: 'catalog-variant',
+    name: 'Spoofed Session Name',
+    quantity: 2,
+    price: money(1),
+    primaryImageUrl: '',
+  }],
+  created_at: new Date().toISOString(),
+  expires_at: new Date(Date.now() + 60_000).toISOString(),
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.inserted = undefined;
+  mocks.insertError = undefined;
+  mocks.priceCheckout.mockResolvedValue(quote);
+  mocks.assertInventory.mockResolvedValue(undefined);
+  mocks.createPaymentIntent.mockResolvedValue({
+    id: 'pi_mcp_1',
+    amount: 3149,
+    currency: 'usd',
+    client_secret: 'secret',
+  });
+  mocks.cancelPaymentIntent.mockResolvedValue(undefined);
+});
+
+describe('MCP authoritative checkout', () => {
+  it('normalizes legacy flat addresses into the MACH shape', () => {
+    expect(normalizeMcpAddress({
+      street: '1 Main',
+      city: 'Denver',
+      state: 'CO',
+      postal_code: '80202',
+      country: 'us',
+    })).toMatchObject({ line1: '1 Main', region: 'CO', country: 'US' });
+  });
+
+  it('prices by product/variant identity and persists only the canonical quote', async () => {
+    const result = await createMcpCheckout({
+      agentId: 'agent-1',
+      session,
+      input: {
+        shippingAddress: {
+          line1: '1 Main', city: 'Denver', region: 'CO', postal_code: '80202', country: 'US',
+        },
+        shippingMethodId: 'standard',
+      },
+    });
+
+    expect(mocks.priceCheckout).toHaveBeenCalledWith(expect.objectContaining({
+      items: [{ productId: 'catalog-product', variantId: 'catalog-variant', quantity: 2 }],
+    }));
+    expect(mocks.inserted?.items).toEqual(quote.items);
+    expect(mocks.inserted?.total_amount).toEqual({ amount: 3149, currency: 'USD' });
+    expect(mocks.inserted?.extensions).toMatchObject({
+      agent_id: 'agent-1',
+      mcp_session_id: 'session-1',
+      payment_intent_id: 'pi_mcp_1',
+    });
+    expect(result).toMatchObject({ paymentIntentId: 'pi_mcp_1', clientSecret: 'secret' });
+  });
+
+  it('cancels an intent whose provider amount does not match the server quote', async () => {
+    mocks.createPaymentIntent.mockResolvedValue({
+      id: 'pi_bad', amount: 1, currency: 'usd', client_secret: 'secret',
+    });
+    await expect(createMcpCheckout({
+      agentId: 'agent-1',
+      session,
+      input: {
+        shippingAddress: {
+          line1: '1 Main', city: 'Denver', region: 'CO', postal_code: '80202', country: 'US',
+        },
+        shippingMethodId: 'standard',
+      },
+    })).rejects.toThrow('invalid intent');
+    expect(mocks.cancelPaymentIntent).toHaveBeenCalledWith('pi_bad');
+    expect(mocks.inserted).toBeUndefined();
+  });
+
+  it('cancels an orphaned intent when pending-order persistence fails', async () => {
+    mocks.insertError = new Error('D1 unavailable');
+    await expect(createMcpCheckout({
+      agentId: 'agent-1',
+      session,
+      input: {
+        shippingAddress: {
+          line1: '1 Main', city: 'Denver', region: 'CO', postal_code: '80202', country: 'US',
+        },
+        shippingMethodId: 'standard',
+      },
+    })).rejects.toThrow('D1 unavailable');
+    expect(mocks.cancelPaymentIntent).toHaveBeenCalledWith('pi_mcp_1');
+  });
+});

--- a/tests/unit/lib/mcp/mcp-place-order.test.ts
+++ b/tests/unit/lib/mcp/mcp-place-order.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  requireOwnedSession: vi.fn(),
+  getBinding: vi.fn(),
+  getOwnedOrder: vi.fn(),
+  finalize: vi.fn(),
+}));
+
+vi.mock('@/lib/mcp/session', () => ({ requireOwnedSession: mocks.requireOwnedSession }));
+vi.mock('@/lib/mcp/checkout', () => ({
+  getOwnedMcpOrderBinding: mocks.getBinding,
+  getOwnedMcpOrder: mocks.getOwnedOrder,
+}));
+vi.mock('@/lib/services/order-finalization', () => {
+  class PaymentVerificationError extends Error {}
+  return { finalizeOrderPayment: mocks.finalize, PaymentVerificationError };
+});
+
+import { getOrderStatus, placeOrder } from '@/lib/mcp/tools/order';
+
+const storedMoney = { amount: 2500, currency: 'USD', centAmount: 2500, fractionDigits: 2 };
+const paidOrder = {
+  id: 'MCP-AGENT1-123456-A1B2C3D4',
+  status: 'processing' as const,
+  payment_status: 'paid' as const,
+  total_amount: storedMoney,
+  currency_code: 'USD',
+  items: [],
+  shipping_address: { line1: '1 Main', city: 'Denver', region: 'CO', country: 'US' },
+  shipping_method: 'Standard',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.requireOwnedSession.mockResolvedValue({
+    ok: true,
+    session: { sessionId: 'session-1', agentId: 'agent-1', cart: [] },
+  });
+  mocks.getBinding.mockResolvedValue(paidOrder);
+  mocks.finalize.mockResolvedValue({ paid: true, promoted: true, order: paidOrder });
+});
+
+describe('MCP order finalization', () => {
+  it('finalizes only the durable order bound to the agent, session, and PaymentIntent', async () => {
+    const result = await placeOrder({
+      orderId: paidOrder.id,
+      paymentIntentId: 'pi_mcp_1',
+    }, 'session-1', 'agent-1');
+
+    expect(mocks.getBinding).toHaveBeenCalledWith({
+      orderId: paidOrder.id,
+      paymentIntentId: 'pi_mcp_1',
+      agentId: 'agent-1',
+      sessionId: 'session-1',
+    });
+    expect(mocks.finalize).toHaveBeenCalledWith(expect.objectContaining({
+      orderId: paidOrder.id,
+      paymentIntentId: 'pi_mcp_1',
+    }));
+    expect(result.success).toBe(true);
+    expect(result.data.total).toMatchObject({ amount: 25, currency: 'USD', precision: 2 });
+  });
+
+  it('does not contact finalization when the binding is not owned', async () => {
+    mocks.getBinding.mockResolvedValue(null);
+    const result = await placeOrder({
+      orderId: paidOrder.id,
+      paymentIntentId: 'pi_mcp_1',
+    }, 'session-1', 'attacker');
+    expect(result.error?.code).toBe('PAYMENT_NOT_BOUND');
+    expect(mocks.finalize).not.toHaveBeenCalled();
+  });
+
+  it('does not reveal orders belonging to another agent', async () => {
+    mocks.getOwnedOrder.mockResolvedValue(null);
+    const result = await getOrderStatus(paidOrder.id, 'attacker');
+    expect(result.error?.code).toBe('ORDER_NOT_FOUND');
+  });
+});

--- a/tests/unit/lib/mcp/request-bounds.test.ts
+++ b/tests/unit/lib/mcp/request-bounds.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  searchProducts: vi.fn(),
+  getProductBySlug: vi.fn(),
+}));
+
+vi.mock('@/lib/models/mach/products', () => ({
+  searchProducts: mocks.searchProducts,
+  getProductBySlug: mocks.getProductBySlug,
+}));
+
+import { assessFulfillmentCapability } from '@/lib/mcp/tools/assess';
+import { getRecommendations } from '@/lib/mcp/tools/recommend';
+import { searchProductsWithContext } from '@/lib/mcp/tools/search';
+
+describe('MCP discovery request bounds', () => {
+  it('rejects an empty fulfillment item list without NaN metadata', async () => {
+    const result = await assessFulfillmentCapability({
+      requirements: { items: [], budget: 0, timeline: '', location: '' },
+    }, 'session');
+    expect(result.success).toBe(false);
+    expect(result.metadata.can_fulfill_percentage).toBe(0);
+    expect(Number.isFinite(result.metadata.estimated_satisfaction)).toBe(true);
+    expect(mocks.searchProducts).not.toHaveBeenCalled();
+  });
+
+  it('rejects an oversized search query before catalog access', async () => {
+    const result = await searchProductsWithContext({ query: 'x'.repeat(257) }, 'session');
+    expect(result.success).toBe(false);
+    expect(mocks.searchProducts).not.toHaveBeenCalled();
+  });
+
+  it('rejects non-finite recommendation budgets before catalog access', async () => {
+    const result = await getRecommendations({ context: { budget: Number.POSITIVE_INFINITY } }, 'session');
+    expect(result.success).toBe(false);
+    expect(mocks.searchProducts).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/lib/mcp/session-ownership.test.ts
+++ b/tests/unit/lib/mcp/session-ownership.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const selectLimit = vi.fn();
+const deleteWhere = vi.fn();
+
+vi.mock('@/lib/db', () => ({
+  getDbAsync: vi.fn(async () => ({
+    select: () => ({ from: () => ({ where: () => ({ limit: selectLimit }) }) }),
+    delete: () => ({ where: deleteWhere }),
+  })),
+}));
+
+import { requireOwnedSession } from '@/lib/mcp/session';
+
+function sessionRow(overrides: Record<string, unknown> = {}) {
+  return {
+    sessionId: 'session-1',
+    agentId: 'agent-a',
+    userId: null,
+    userPreferences: null,
+    sessionContext: null,
+    cart: '[]',
+    createdAt: new Date().toISOString(),
+    expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  selectLimit.mockReset();
+  deleteWhere.mockReset().mockResolvedValue(undefined);
+});
+
+describe('requireOwnedSession', () => {
+  it('returns not found for a missing session', async () => {
+    selectLimit.mockResolvedValue([]);
+    await expect(requireOwnedSession('missing', 'agent-a')).resolves.toEqual({
+      ok: false,
+      code: 'SESSION_NOT_FOUND',
+      message: 'Session not found or expired',
+    });
+  });
+
+  it('deletes and hides an expired session', async () => {
+    selectLimit.mockResolvedValue([sessionRow({ expiresAt: new Date(Date.now() - 1).toISOString() })]);
+    const result = await requireOwnedSession('session-1', 'agent-a');
+    expect(result).toMatchObject({ ok: false, code: 'SESSION_NOT_FOUND' });
+    expect(deleteWhere).toHaveBeenCalledOnce();
+  });
+
+  it('denies a different authenticated agent', async () => {
+    selectLimit.mockResolvedValue([sessionRow({ agentId: 'victim' })]);
+    await expect(requireOwnedSession('session-1', 'attacker')).resolves.toEqual({
+      ok: false,
+      code: 'SESSION_ACCESS_DENIED',
+      message: 'Agent does not own this session',
+    });
+  });
+
+  it('returns an owned active session', async () => {
+    selectLimit.mockResolvedValue([sessionRow()]);
+    const result = await requireOwnedSession('session-1', 'agent-a');
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.session.agentId).toBe('agent-a');
+  });
+});


### PR DESCRIPTION
## Summary

This combines the planned U10 identity work and U11 commerce-integrity work into one coherent MCP feature PR.

- expands agent credentials to hashed, expiring, rotatable keys without destructively invalidating existing agents
- moves the known test credential to a development-only D1 seed
- makes authenticated identity authoritative, enforces session/order ownership, per-tool commerce scopes, management delegation boundaries, and bounded rate limits
- removes direct session-cart overwrite and fabricated tracking behavior found during root review
- derives public capabilities, search, recommendations, shipping, and product serialization from the live Mercora catalog/configuration instead of the original demo store
- creates server-priced pending orders bound to Stripe PaymentIntents, then finalizes them through the shared verified/idempotent payment path
- replaces the stale Voltique demo specification with the implementation-accurate Mercora MCP contract

## Credential migration

Migration `0012_expand_mcp_agent_credentials.sql` deliberately uses an expand/rotate/contract path. Existing plaintext credentials remain readable only while no digest is installed. Their first successful authentication hashes and retires the plaintext value and establishes a 30-day rotation window. New and explicitly rotated credentials default to 90 days (configurable from 1–365 days) and are returned in plaintext once.

A future contract migration can remove the legacy column after operators confirm no version-1 credentials remain.

## Commerce integrity

MCP checkout now ignores persisted display names and prices. It sends only product/variant identity and quantity through the shared checkout pricing and inventory services, verifies the provider amount/currency, persists the exact canonical quote and line allocations, and binds the order, agent, session, and PaymentIntent before shared payment finalization.

Shipment-event-backed tracking remains deferred to the fulfillment vertical slice. Current tracking returns only the authenticated agent's real order status and an empty event history rather than invented carrier data.

## Review structure

- `32999a5` — implementation, migration, and regression coverage
- `8fa4a99` — implementation-accurate MCP security/commerce documentation

## Validation

All checks ran with Node 24:

- TypeScript: `tsc --noEmit`
- ESLint: no warnings or errors
- Unit suite: 77 files, 439 tests passed
- Workers/Miniflare/D1 suite: 9 files, 42 tests passed
- Production Next.js build: passed (53 static pages)
- `git diff --check`: passed

The Workers suite emits only the existing missing-sourcemap warnings from Stripe/standardwebhooks. The build emits the existing missing local Stripe-key notices and package module-type warning.