### PR TITLE
feat(recommendations): add resilient server-rendered pipeline

### DIFF
--- a/app/admin/settings/page.tsx
+++ b/app/admin/settings/page.tsx
@@ -59,6 +59,7 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
 import { Switch } from "@/components/ui/switch";
+import { RecommendationSettingsCard } from "@/components/admin/RecommendationSettingsCard";
 import { 
   Settings, Store, Bot, Mail, Database, 
   RefreshCw, Save, Globe, DollarSign,
@@ -582,6 +583,7 @@ export default function AdminSettingsPage() {
               </div>
             </div>
           </Card>
+          <RecommendationSettingsCard />
         </div>
       )}
 

--- a/app/api/admin/recommendations/rebuild/route.ts
+++ b/app/api/admin/recommendations/rebuild/route.ts
@@ -1,0 +1,31 @@
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import { NextRequest, NextResponse } from "next/server";
+import { checkAdminPermissions } from "@/lib/auth/admin-middleware";
+import { rebuildProductRecommendations } from "@/lib/recommendations/batch/rebuild";
+
+export async function POST(request: NextRequest) {
+  try {
+    const auth = await checkAdminPermissions(request);
+    if (!auth.success) {
+      return NextResponse.json(
+        { error: auth.error || "Admin access required" },
+        { status: 403 },
+      );
+    }
+
+    const startedAt = Date.now();
+    const { env } = await getCloudflareContext({ async: true });
+    const summary = await rebuildProductRecommendations(env);
+    return NextResponse.json({
+      success: summary.errors.length === 0,
+      durationMs: Date.now() - startedAt,
+      ...summary,
+    });
+  } catch (error) {
+    console.error("Recommendations rebuild route failed", error);
+    return NextResponse.json(
+      { error: "Failed to rebuild recommendations" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/admin/recommendations/settings/route.ts
+++ b/app/api/admin/recommendations/settings/route.ts
@@ -1,0 +1,96 @@
+import { NextRequest, NextResponse } from "next/server";
+import { eq } from "drizzle-orm";
+import { checkAdminPermissions } from "@/lib/auth/admin-middleware";
+import { getDbAsync } from "@/lib/db";
+import { admin_settings } from "@/lib/db/schema/settings";
+import type { RecommendationSettings } from "@/lib/recommendations/types";
+import { getRecommendationSettings } from "@/lib/utils/settings";
+
+const MAX_BODY_BYTES = 2_048;
+
+async function readSettingsBody(request: NextRequest): Promise<RecommendationSettings> {
+  const declaredLength = request.headers.get("content-length");
+  if (declaredLength && /^\d+$/.test(declaredLength) && Number(declaredLength) > MAX_BODY_BYTES) {
+    throw new Error("BODY_TOO_LARGE");
+  }
+  const raw = await request.text();
+  if (new TextEncoder().encode(raw).byteLength > MAX_BODY_BYTES) {
+    throw new Error("BODY_TOO_LARGE");
+  }
+
+  let body: unknown;
+  try {
+    body = JSON.parse(raw);
+  } catch {
+    throw new Error("INVALID_BODY");
+  }
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    throw new Error("INVALID_BODY");
+  }
+  const value = body as Record<string, unknown>;
+  if (
+    (value.strategy !== "deterministic" && value.strategy !== "ai_batch") ||
+    typeof value.personalize !== "boolean" ||
+    typeof value.excludeOwned !== "boolean" ||
+    typeof value.limit !== "number" ||
+    !Number.isInteger(value.limit) ||
+    value.limit < 1 ||
+    value.limit > 6
+  ) {
+    throw new Error("INVALID_BODY");
+  }
+
+  return {
+    strategy: value.strategy,
+    personalize: value.personalize,
+    excludeOwned: value.excludeOwned,
+    limit: value.limit,
+  };
+}
+
+export async function GET(request: NextRequest) {
+  const auth = await checkAdminPermissions(request);
+  if (!auth.success) {
+    return NextResponse.json({ error: auth.error || "Admin access required" }, { status: 403 });
+  }
+  try {
+    return NextResponse.json({ settings: await getRecommendationSettings() });
+  } catch (error) {
+    console.error("Recommendation settings load failed", error);
+    return NextResponse.json({ error: "Failed to load recommendation settings" }, { status: 500 });
+  }
+}
+
+export async function PUT(request: NextRequest) {
+  const auth = await checkAdminPermissions(request);
+  if (!auth.success) {
+    return NextResponse.json({ error: auth.error || "Admin access required" }, { status: 403 });
+  }
+
+  try {
+    const settings = await readSettingsBody(request);
+    const db = await getDbAsync();
+    const updatedAt = new Date().toISOString();
+    const updateSetting = (key: string, value: unknown) =>
+      db
+        .update(admin_settings)
+        .set({ value: JSON.stringify(value), updated_at: updatedAt })
+        .where(eq(admin_settings.key, key));
+    await db.batch([
+      updateSetting("recommendations.strategy", settings.strategy),
+      updateSetting("recommendations.personalize", settings.personalize),
+      updateSetting("recommendations.limit", settings.limit),
+      updateSetting("recommendations.exclude_owned", settings.excludeOwned),
+    ]);
+    return NextResponse.json({ success: true, settings });
+  } catch (error) {
+    if (error instanceof Error && error.message === "BODY_TOO_LARGE") {
+      return NextResponse.json({ error: "Request body is too large" }, { status: 413 });
+    }
+    if (error instanceof Error && error.message === "INVALID_BODY") {
+      return NextResponse.json({ error: "Invalid recommendation settings" }, { status: 400 });
+    }
+    console.error("Recommendation settings update failed", error);
+    return NextResponse.json({ error: "Failed to update recommendation settings" }, { status: 500 });
+  }
+}

--- a/app/product/[slug]/ProductDisplay.tsx
+++ b/app/product/[slug]/ProductDisplay.tsx
@@ -19,6 +19,7 @@
  * ```tsx
  * <ProductDisplay
  *   product={productData}
+ *   recommendations={recommendationList}
  *   reviews={reviewList}
  *   reviewEligibility={eligibility}
  * />
@@ -53,6 +54,7 @@ import {
 
 interface ProductDisplayProps {
   product: Product;
+  recommendations: Product[];
   reviews: Review[];
   reviewEligibility?: ProductReviewEligibility;
 }
@@ -79,6 +81,7 @@ function stringifyDescription(description: Product["description"]): string {
 
 export default function ProductDisplay({
   product,
+  recommendations,
   reviews,
   reviewEligibility,
 }: ProductDisplayProps) {
@@ -333,8 +336,7 @@ export default function ProductDisplay({
         </div>
       </div>
 
-      {/* AI-Powered Product Recommendations */}
-      <ProductRecommendations product={product} />
+      <ProductRecommendations recommendations={recommendations} />
     </>
   );
 }

--- a/app/product/[slug]/page.tsx
+++ b/app/product/[slug]/page.tsx
@@ -45,6 +45,8 @@ import { getProductBySlug, getProductReviews, getProductReviewEligibility } from
 import { notFound } from "next/navigation";
 import ProductDisplay from "./ProductDisplay";
 import { toPublicProduct } from "@/lib/models/mach/product-serializer";
+import { getRecommendationsForProduct } from "@/lib/recommendations";
+import { buildServerUserContext } from "@/lib/recommendations/user-context.server";
 
 export const revalidate = 0;
 
@@ -59,8 +61,9 @@ export default async function ProductPage({ params }: any) {
   const storedProduct = await getProductBySlug(params.slug);
   if (!storedProduct || storedProduct.status !== "active") return notFound();
   const product = toPublicProduct(storedProduct);
+  const userContextPromise = buildServerUserContext(userId);
 
-  const [reviews, reviewEligibility] = await Promise.all([
+  const [reviews, reviewEligibility, recommendations] = await Promise.all([
     getProductReviews({
       productId: product.id,
       status: ["published"],
@@ -70,12 +73,22 @@ export default async function ProductPage({ params }: any) {
       productId: product.id,
       customerId: userId,
     }),
+    userContextPromise
+      .then((userContext) =>
+        getRecommendationsForProduct(storedProduct, { userContext }),
+      )
+      .then((products) => products.map(toPublicProduct)),
   ]);
 
   return (
     <main className="bg-neutral-900 text-white min-h-screen px-4 sm:px-6 lg:px-12 py-12 sm:py-16">
       <div className="max-w-5xl mx-auto">
-        <ProductDisplay product={product} reviews={reviews} reviewEligibility={reviewEligibility} />
+        <ProductDisplay
+          product={product}
+          recommendations={recommendations}
+          reviews={reviews}
+          reviewEligibility={reviewEligibility}
+        />
       </div>
     </main>
   );

--- a/components/ProductRecommendations.tsx
+++ b/components/ProductRecommendations.tsx
@@ -1,297 +1,36 @@
-/**
- * === Product Recommendations Component ===
- *
- * An intelligent product recommendation system that combines AI analysis
- * with user personalization to suggest relevant products. Uses purchase
- * history, user preferences, and product context for optimal suggestions.
- *
- * === Features ===
- * - **Personalized**: Considers user order history and preferences
- * - **AI-Enhanced**: Uses Volt AI for intelligent product matching
- * - **Context-Aware**: Considers product tags, use cases, and characteristics
- * - **Dynamic Layout**: Responsive grid that adapts to number of recommendations
- * - **Loading States**: Shows skeleton placeholders during API calls
- * - **Smart Filtering**: Excludes current product and already purchased items
- * - **Graceful Degradation**: Falls back to generic recommendations if needed
- *
- * === Technical Implementation ===
- * - **Hybrid Approach**: Combines algorithmic and AI-powered recommendations
- * - **User Context**: Integrates with enhanced user context system
- * - **TypeScript Safety**: Fully typed with Product interface
- * - **Performance**: Intelligent caching and optimized API calls
- * - **Error Handling**: Multiple fallback strategies
- *
- * === Usage ===
- * ```tsx
- * <ProductRecommendations product={currentProduct} />
- * ```
- *
- * === Props ===
- * @param product - Optional Product object to base recommendations on
- * @param maxRecommendations - Maximum number of products to show (default: 3)
- */
-
-"use client";
-
+/** Server-resolved PDP recommendations with no client fetch or loading state. */
 import ProductCard from "@/components/ProductCard";
 import type { Product } from "@/lib/types";
-import { useState, useEffect, useMemo, useCallback } from "react";
-import { useEnhancedUserContext } from "@/lib/hooks/useEnhancedUserContext";
-import { getPersonalizedRecommendations } from "@/lib/utils/personalized-recommendations";
-import Image from "next/image";
 
-/**
- * ProductRecommendations component that displays personalized product suggestions
- * 
- * @param product - The current product to base recommendations on
- * @param maxRecommendations - Maximum number of recommendations to show
- * @returns JSX element with recommended products or null if none available
- */
 export default function ProductRecommendations({
-  product,
-  maxRecommendations = 3,
+  recommendations,
 }: {
-  product?: Product;
-  maxRecommendations?: number;
+  recommendations: Product[];
 }) {
-  const [recommendedProducts, setRecommendedProducts] = useState<Product[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
-  const [agentAnswer, setAgentAnswer] = useState<string | null>(null);
-  const userContext = useEnhancedUserContext();
-  const {
-    userId,
-    firstName,
-    orders,
-    isVipCustomer,
-    isLoading: contextLoading,
-  } = userContext;
-  
-  console.log('ProductRecommendations component mount/render:', {
-    productId: product?.id,
-    productName: product?.name,
-    userContextLoading: contextLoading,
-    userContextUserId: userId,
-  });
-  
-  // Create stable reference for user context values we actually need
-  const stableUserContext = useMemo(() => {
-    // Extract all purchased products from order history
-    const purchasedProducts = orders?.flatMap(order => 
-      (order.items || []).map(item => ({
-        name: item.product_name,
-        id: item.product_id,
-      }))
-    ).filter(product => product.name || product.id) || [];
+  if (recommendations.length === 0) return null;
 
-    // Deduplicate by name and ID
-    const uniquePurchasedProducts = purchasedProducts.reduce((acc, product) => {
-      const key = product.name || product.id;
-      if (key && !acc.some(p => (p.name && p.name === product.name) || (p.id && p.id === product.id))) {
-        acc.push(product);
-      }
-      return acc;
-    }, [] as typeof purchasedProducts);
-
-    return {
-      userId,
-      firstName,
-      orders,
-      isVipCustomer,
-      orderCount: orders?.length || 0,
-      isLoading: contextLoading,
-      purchasedProducts: uniquePurchasedProducts,
-      purchasedProductNames: uniquePurchasedProducts.map(p => p.name).filter(Boolean),
-    };
-  }, [
-    userId,
-    firstName,
-    orders,
-    isVipCustomer,
-    contextLoading,
-  ]);
-  
-  
-  // Fetch AI-powered recommendations with enhanced user context
-  /**
-   * Fetch AI-powered recommendations with enhanced user context
-   */
-  const fetchAIRecommendations = useCallback(async (
-    currentProduct: Product, 
-    userContext: typeof stableUserContext
-  ): Promise<Product[]> => {
-    try {
-      const productTags = currentProduct.tags?.join(", ") || "";
-  // Enhanced query with user context and purchase history
-  let recommendationQuery = `I'm currently browsing the site in the ${currentProduct.name} page. It has tags: ${productTags}.`;
-      
-      if (userContext.orderCount > 0) {
-        recommendationQuery += ` I'm a returning customer with ${userContext.orderCount} previous orders.`;
-        
-        // Include purchased products to avoid duplicates
-        if (userContext.purchasedProductNames.length > 0) {
-          recommendationQuery += ` I already own these products: ${userContext.purchasedProductNames.slice(0, 10).join(", ")}.`;
-          recommendationQuery += " Please recommend products I don't already have.";
-        }
-        
-        if (userContext.isVipCustomer) {
-          recommendationQuery += " I'm only interested in premium products.";
-        }
-      }
-      
-      recommendationQuery += " Can you recommend 3 similar or complementary products that would work well with what I'm interested in?";
-      recommendationQuery += " The answer should be short and concise with a little wit.";
-
-      
-      const res = await fetch("/api/agent-chat", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ 
-          question: recommendationQuery,
-          userName: userContext.firstName || "Guest",
-          userContext: {
-            orders: userContext.orders?.slice(0, 3) || [], // Last 3 orders for context
-            isVipCustomer: userContext.isVipCustomer || false,
-            totalOrders: userContext.orderCount,
-            purchasedProducts: userContext.purchasedProductNames.slice(0, 15), // Limit to prevent too long requests
-          },
-          history: []
-        }),
-      });
-
-      if (!res.ok) {
-        return [];
-      }
-      
-      const data = await res.json() as { answer: string; products?: Product[]; productIds?: number[] };
-      setAgentAnswer(data.answer || null);
-      return data.products?.filter((p: Product) => p.id !== currentProduct.id) || [];
-      
-    } catch (error) {
-      console.error("fetchAIRecommendations error:", error);
-      return []; // Return empty array instead of throwing
-    }
-  }, []);
-
-  useEffect(() => {
-    if (!product) {
-      return undefined;
-    }
-
-    const timeoutId = setTimeout(async () => {
-      setIsLoading(true);
-      try {
-        const aiRecommendations = await fetchAIRecommendations(product, stableUserContext);
-        setRecommendedProducts(aiRecommendations.slice(0, maxRecommendations));
-      } catch (error) {
-        console.error("Error fetching AI recommendations:", error);
-        setRecommendedProducts([]);
-      } finally {
-        setIsLoading(false);
-      }
-    }, 500);
-
-    return () => clearTimeout(timeoutId);
-  }, [product, stableUserContext, maxRecommendations, fetchAIRecommendations]);
-
-  // Don't render anything if no product context
-  if (!product) {
-    return null;
-  }
-
-  // Show loading state or results
-  const hasRecommendations = recommendedProducts.length > 0;
-  const hasAgentAnswer = agentAnswer && agentAnswer.trim().length > 0;
-  const shouldShowSection = isLoading || hasRecommendations;
-
-  if (!shouldShowSection) {
-    return null;
-  }
-
-  // Determine section title based on personalization  
-  let sectionTitle = "You may also like";
-  if (isLoading) {
-    sectionTitle = stableUserContext.orderCount > 0 
-    ? "Finding personalized recommendations..." 
-    : "Finding recommendations...";
-  } else if (hasRecommendations) {
-     sectionTitle = `Recommended for ${stableUserContext.firstName || 'you'}`;
-  }
+  const gridClass =
+    recommendations.length === 1
+      ? "grid-cols-1 max-w-sm mx-auto"
+      : recommendations.length === 2
+        ? "grid-cols-1 sm:grid-cols-2 max-w-2xl mx-auto"
+        : "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3";
 
   return (
-    <div className="mt-20 text-center relative">
-      <div className="border-t border-neutral-700 w-full relative mb-10">
-        <span className="text-orange-400 text-xl font-semibold bg-neutral-900 px-4 absolute -top-4 left-1/2 transform -translate-x-1/2 font-serif">
-          {sectionTitle}
-        </span>
+    <section className="relative mt-20 text-center" aria-labelledby="recommendations-title">
+      <div className="relative mb-10 w-full border-t border-neutral-700">
+        <h2
+          id="recommendations-title"
+          className="absolute -top-4 left-1/2 -translate-x-1/2 bg-neutral-900 px-4 font-serif text-xl font-semibold text-orange-400"
+        >
+          You may also like
+        </h2>
       </div>
-
-      {isLoading ? (
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-10">
-          {Array.from({ length: maxRecommendations }, (_, i) => (
-            <div key={i} className="animate-pulse">
-              <div className="bg-gray-200 aspect-square rounded-lg mb-4"></div>
-              <div className="bg-gray-200 h-4 rounded mb-2"></div>
-              <div className="bg-gray-200 h-4 rounded w-2/3 mx-auto"></div>
-            </div>
-          ))}
-        </div>
-      ) : hasRecommendations ? (
-        <div className={`grid gap-10 ${
-          recommendedProducts.length === 1 
-            ? "grid-cols-1 max-w-sm mx-auto" 
-            : recommendedProducts.length === 2 
-            ? "grid-cols-1 sm:grid-cols-2 max-w-2xl mx-auto" 
-            : "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3"
-        }`}>
-          {recommendedProducts.map((prod) => {
-            try {
-              return <ProductCard key={prod.id} product={prod} />;
-            } catch (error) {
-              console.error("Error rendering ProductCard:", error);
-              return null;
-            }
-          })}
-        </div>
-      ) : null}
-      
-      {/* Show agent answer only when we have product recommendations */}
-      {hasRecommendations && hasAgentAnswer && (
-        <div className="flex justify-start items-start mt-10 w-full px-4">
-          <div className="shrink-0 mr-4">
-            <Image
-              src="/volt.svg"
-              alt="Volt mascot"
-              width={60}
-              height={60}
-              className="z-10"
-            />
-          </div>
-          <div className="flex-1 min-w-0 max-w-4xl">
-            <div className="bg-neutral-900 text-white px-6 py-4 rounded-2xl shadow-lg relative text-left"
-                style={{ border: "1px solid #f59e42" }}>
-              <span className="whitespace-pre-wrap wrap-break-word block">{agentAnswer}</span>
-              <span
-                className="absolute left-[-18px] top-6 w-0 h-0"
-                style={{
-                  borderTop: "12px solid transparent",
-                  borderBottom: "12px solid transparent",
-                  borderRight: "18px solid #f59e42"
-                }}
-              />
-              <span
-                className="absolute left-[-16px] top-6 w-0 h-0"
-                style={{
-                  borderTop: "10px solid transparent",
-                  borderBottom: "10px solid transparent",
-                  borderRight: "16px solid #1a1a1a"
-                }}
-              />
-            </div>
-          </div>
-        </div>
-      )}
-    </div>
+      <div className={`grid gap-10 ${gridClass}`}>
+        {recommendations.map((product) => (
+          <ProductCard key={product.id} product={product} />
+        ))}
+      </div>
+    </section>
   );
 }

--- a/components/admin/RecommendationSettingsCard.tsx
+++ b/components/admin/RecommendationSettingsCard.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Bot, RefreshCw, Save } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Switch } from "@/components/ui/switch";
+import type { RecommendationSettings } from "@/lib/recommendations/types";
+
+const defaults: RecommendationSettings = {
+  strategy: "deterministic",
+  personalize: true,
+  limit: 3,
+  excludeOwned: true,
+};
+
+export function RecommendationSettingsCard() {
+  const [settings, setSettings] = useState(defaults);
+  const [busy, setBusy] = useState<"load" | "save" | "rebuild" | null>("load");
+  const [message, setMessage] = useState("");
+
+  useEffect(() => {
+    void fetch("/api/admin/recommendations/settings")
+      .then(async (response) => {
+        if (!response.ok) throw new Error("Could not load settings");
+        const body = (await response.json()) as { settings: RecommendationSettings };
+        setSettings(body.settings);
+      })
+      .catch(() => setMessage("Recommendation settings could not be loaded."))
+      .finally(() => setBusy(null));
+  }, []);
+
+  async function save() {
+    setBusy("save");
+    setMessage("");
+    try {
+      const response = await fetch("/api/admin/recommendations/settings", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(settings),
+      });
+      if (!response.ok) throw new Error("Save failed");
+      setMessage("Recommendation settings saved.");
+    } catch {
+      setMessage("Recommendation settings could not be saved.");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function rebuild() {
+    setBusy("rebuild");
+    setMessage("");
+    try {
+      const response = await fetch("/api/admin/recommendations/rebuild", { method: "POST" });
+      const body = (await response.json()) as {
+        error?: string;
+        rowsWritten?: number;
+        productsProcessed?: number;
+        productsDeferred?: number;
+        errors?: unknown[];
+      };
+      if (!response.ok) throw new Error(body.error || "Rebuild failed");
+      const failures = body.errors?.length ?? 0;
+      setMessage(
+        `Rebuild wrote ${body.rowsWritten ?? 0} rows for ${body.productsProcessed ?? 0} products` +
+          (failures ? ` with ${failures} errors` : "") +
+          ((body.productsDeferred ?? 0) > 0 ? `; ${body.productsDeferred} products deferred.` : "."),
+      );
+    } catch {
+      setMessage("Recommendations could not be rebuilt.");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  return (
+    <Card className="bg-neutral-800 border-neutral-700 p-6">
+      <div className="mb-4 flex items-center space-x-3">
+        <Bot className="h-5 w-5 text-orange-400" />
+        <h3 className="text-lg font-semibold text-white">Product Recommendations</h3>
+      </div>
+      <div className="space-y-4">
+        <label className="block text-sm text-gray-300">
+          Strategy
+          <select
+            value={settings.strategy}
+            disabled={busy !== null}
+            onChange={(event) =>
+              setSettings((current) => ({
+                ...current,
+                strategy: event.target.value === "ai_batch" ? "ai_batch" : "deterministic",
+              }))
+            }
+            className="mt-2 w-full rounded-md border border-neutral-600 bg-neutral-700 px-3 py-2 text-white"
+          >
+            <option value="deterministic">Deterministic</option>
+            <option value="ai_batch">AI batch</option>
+          </select>
+        </label>
+        <label className="block text-sm text-gray-300">
+          Products shown (1–6)
+          <input
+            type="number"
+            min={1}
+            max={6}
+            value={settings.limit}
+            disabled={busy !== null}
+            onChange={(event) =>
+              setSettings((current) => ({
+                ...current,
+                limit: Math.max(1, Math.min(6, Number(event.target.value) || 1)),
+              }))
+            }
+            className="mt-2 w-full rounded-md border border-neutral-600 bg-neutral-700 px-3 py-2 text-white"
+          />
+        </label>
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-gray-300">Personalize from order history</span>
+          <Switch
+            checked={settings.personalize}
+            disabled={busy !== null}
+            onCheckedChange={(personalize) =>
+              setSettings((current) => ({ ...current, personalize }))
+            }
+          />
+        </div>
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-gray-300">Exclude products already owned</span>
+          <Switch
+            checked={settings.excludeOwned}
+            disabled={busy !== null}
+            onCheckedChange={(excludeOwned) =>
+              setSettings((current) => ({ ...current, excludeOwned }))
+            }
+          />
+        </div>
+        {message && <p className="text-xs text-gray-400" role="status">{message}</p>}
+        <div className="flex flex-wrap gap-3 border-t border-neutral-700 pt-4">
+          <Button onClick={save} disabled={busy !== null} className="bg-orange-600 hover:bg-orange-700">
+            {busy === "save" ? <RefreshCw className="mr-2 h-4 w-4 animate-spin" /> : <Save className="mr-2 h-4 w-4" />}
+            Save
+          </Button>
+          <Button onClick={rebuild} disabled={busy !== null} variant="outline">
+            <RefreshCw className={`mr-2 h-4 w-4 ${busy === "rebuild" ? "animate-spin" : ""}`} />
+            Rebuild now
+          </Button>
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/lib/ai/config.ts
+++ b/lib/ai/config.ts
@@ -35,12 +35,12 @@ export const TEXT_GENERATION_MODEL: AIModelConfig = {
 /**
  * Embedding model used for vectorized search and semantic similarity
  */
-export const EMBEDDING_MODEL: AIModelConfig = {
+export const EMBEDDING_MODEL = {
   model: "@cf/baai/bge-base-en-v1.5",
   temperature: 0, // Not applicable for embeddings
   maxTokens: 0, // Not applicable for embeddings
   description: "BGE Base EN v1.5 - High-quality English embeddings for semantic search"
-};
+} as const satisfies AIModelConfig;
 
 /**
  * Model configurations for specific use cases
@@ -167,7 +167,7 @@ export function getCurrentTextModel(): string {
 /**
  * Get the current embedding model identifier
  */
-export function getCurrentEmbeddingModel(): string {
+export function getCurrentEmbeddingModel(): typeof EMBEDDING_MODEL.model {
   return EMBEDDING_MODEL.model;
 }
 

--- a/lib/db/schema/index.ts
+++ b/lib/db/schema/index.ts
@@ -97,6 +97,7 @@ export * from "./order";
 
 // Append-oriented order fulfillment audit log
 export * from "./order-events";
+export * from "./product-recommendations";
 
 // Admin Settings schema (application-specific)
 export * from "./settings";

--- a/lib/db/schema/product-recommendations.ts
+++ b/lib/db/schema/product-recommendations.ts
@@ -1,0 +1,17 @@
+import { sql } from "drizzle-orm";
+import { integer, primaryKey, real, sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+export const product_recommendations = sqliteTable(
+  "product_recommendations",
+  {
+    source_product_id: text("source_product_id").notNull(),
+    recommended_product_id: text("recommended_product_id").notNull(),
+    rank: integer("rank").notNull(),
+    score: real("score"),
+    reason: text("reason"),
+    generated_at: text("generated_at")
+      .notNull()
+      .default(sql`(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`),
+  },
+  (table) => [primaryKey({ columns: [table.source_product_id, table.recommended_product_id] })],
+);

--- a/lib/db/schema/settings.ts
+++ b/lib/db/schema/settings.ts
@@ -165,5 +165,35 @@ export const defaultSettings = [
     category: 'promotions',
     description: 'First-time buyer discount percentage',
     data_type: 'number'
+  },
+
+  // Product recommendations
+  {
+    key: 'recommendations.strategy',
+    value: JSON.stringify('deterministic'),
+    category: 'recommendations',
+    description: 'PDP recommendation source: deterministic or ai_batch',
+    data_type: 'string'
+  },
+  {
+    key: 'recommendations.personalize',
+    value: JSON.stringify(true),
+    category: 'recommendations',
+    description: 'Reserve one recommendation slot for customers with order history',
+    data_type: 'boolean'
+  },
+  {
+    key: 'recommendations.limit',
+    value: JSON.stringify(3),
+    category: 'recommendations',
+    description: 'Number of products shown in the PDP recommendation strip',
+    data_type: 'number'
+  },
+  {
+    key: 'recommendations.exclude_owned',
+    value: JSON.stringify(true),
+    category: 'recommendations',
+    description: 'Hide products the customer already purchased',
+    data_type: 'boolean'
   }
 ];

--- a/lib/recommendations/batch/rebuild.ts
+++ b/lib/recommendations/batch/rebuild.ts
@@ -1,0 +1,281 @@
+import { getCurrentEmbeddingModel } from "@/lib/ai/config";
+
+const DEFAULT_NEIGHBORS = 10;
+const MAX_NEIGHBORS = 20;
+const DEFAULT_PRODUCT_LIMIT = 100;
+const MAX_PRODUCT_LIMIT = 500;
+const STALENESS_THRESHOLD_DAYS = 7;
+const MAX_EMBEDDING_TEXT_LENGTH = 4_000;
+const MAX_ERROR_LENGTH = 500;
+
+export interface RebuildProduct {
+  id: string;
+  name: string;
+  description: string;
+  tags: string[];
+}
+
+export interface RecommendationNeighbor {
+  id: string;
+  score: number;
+}
+
+export interface RecommendationRebuildAdapter {
+  countActiveProducts(): Promise<number>;
+  listActiveProducts(limit: number): Promise<RebuildProduct[]>;
+  embed(product: RebuildProduct): Promise<number[]>;
+  queryNeighbors(vector: number[], topK: number): Promise<RecommendationNeighbor[]>;
+  replaceRecommendations(sourceId: string, neighbors: RecommendationNeighbor[]): Promise<void>;
+  readStaleness(thresholdDays: number): Promise<{
+    staleRowCount: number;
+    oldestGeneratedAt: string | null;
+  }>;
+}
+
+export interface RecommendationRebuildSummary {
+  catalogProducts: number;
+  productsAttempted: number;
+  productsDeferred: number;
+  productsProcessed: number;
+  productsSkipped: number;
+  rowsWritten: number;
+  errors: Array<{ productId: string; error: string }>;
+  stalenessThresholdDays: number;
+  staleRowCount: number;
+  oldestGeneratedAt: string | null;
+}
+
+export interface RecommendationRebuildOptions {
+  neighbors?: number;
+  productLimit?: number;
+}
+
+function boundedInteger(value: number | undefined, fallback: number, max: number): number {
+  if (value === undefined || !Number.isFinite(value)) return fallback;
+  return Math.max(1, Math.min(max, Math.trunc(value)));
+}
+
+function errorMessage(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.slice(0, MAX_ERROR_LENGTH);
+}
+
+export async function rebuildWithAdapter(
+  adapter: RecommendationRebuildAdapter,
+  options: RecommendationRebuildOptions = {},
+): Promise<RecommendationRebuildSummary> {
+  const neighborLimit = boundedInteger(options.neighbors, DEFAULT_NEIGHBORS, MAX_NEIGHBORS);
+  const productLimit = boundedInteger(
+    options.productLimit,
+    DEFAULT_PRODUCT_LIMIT,
+    MAX_PRODUCT_LIMIT,
+  );
+  const [catalogProducts, products] = await Promise.all([
+    adapter.countActiveProducts(),
+    adapter.listActiveProducts(productLimit),
+  ]);
+  const activeIds = new Set(products.map(({ id }) => id));
+  let productsProcessed = 0;
+  let productsSkipped = 0;
+  let rowsWritten = 0;
+  const errors: Array<{ productId: string; error: string }> = [];
+
+  for (const product of products) {
+    try {
+      const vector = await adapter.embed(product);
+      const matches = await adapter.queryNeighbors(vector, neighborLimit + 5);
+      const seen = new Set<string>();
+      const neighbors: RecommendationNeighbor[] = [];
+
+      for (const match of matches) {
+        const id = String(match.id);
+        if (id === product.id || !activeIds.has(id) || seen.has(id)) continue;
+        seen.add(id);
+        neighbors.push({ id, score: Number.isFinite(match.score) ? match.score : 0 });
+        if (neighbors.length >= neighborLimit) break;
+      }
+
+      // Preserve the last known-good rows if Vectorize is empty or incomplete.
+      if (neighbors.length === 0) {
+        productsSkipped += 1;
+        continue;
+      }
+
+      await adapter.replaceRecommendations(product.id, neighbors);
+      productsProcessed += 1;
+      rowsWritten += neighbors.length;
+    } catch (error) {
+      console.error("Recommendations rebuild: product failed", {
+        productId: product.id,
+        error,
+      });
+      errors.push({ productId: product.id, error: errorMessage(error) });
+    }
+  }
+
+  let staleRowCount = 0;
+  let oldestGeneratedAt: string | null = null;
+  try {
+    ({ staleRowCount, oldestGeneratedAt } = await adapter.readStaleness(
+      STALENESS_THRESHOLD_DAYS,
+    ));
+  } catch (error) {
+    // Reporting should not invalidate recommendation rows already rebuilt.
+    console.error("Recommendations rebuild: staleness check failed", error);
+  }
+
+  return {
+    catalogProducts,
+    productsAttempted: products.length,
+    productsDeferred: Math.max(0, catalogProducts - products.length),
+    productsProcessed,
+    productsSkipped,
+    rowsWritten,
+    errors,
+    stalenessThresholdDays: STALENESS_THRESHOLD_DAYS,
+    staleRowCount,
+    oldestGeneratedAt,
+  };
+}
+
+type RecommendationBindings = Pick<CloudflareEnv, "AI" | "DB" | "VECTORIZE">;
+
+interface RawProductRow {
+  id: string;
+  name: string;
+  description: string | null;
+  tags: string | null;
+}
+
+function localizedText(value: string | null): string {
+  if (!value) return "";
+  try {
+    const parsed: unknown = JSON.parse(value);
+    if (typeof parsed === "string") return parsed;
+    if (parsed && typeof parsed === "object") {
+      const values = Object.values(parsed);
+      const first = values.find((entry): entry is string => typeof entry === "string");
+      return first ?? "";
+    }
+  } catch {
+    return value;
+  }
+  return "";
+}
+
+function parseTags(value: string | null): string[] {
+  if (!value) return [];
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return Array.isArray(parsed)
+      ? parsed.filter((entry): entry is string => typeof entry === "string")
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+function productText(product: RebuildProduct): string {
+  return [product.name, product.description, product.tags.join(", ")]
+    .filter(Boolean)
+    .join(". ")
+    .slice(0, MAX_EMBEDDING_TEXT_LENGTH);
+}
+
+export function createCloudflareRebuildAdapter(
+  env: RecommendationBindings,
+): RecommendationRebuildAdapter {
+  return {
+    async countActiveProducts() {
+      const row = await env.DB.prepare(
+        "SELECT count(*) AS count FROM products WHERE status = 'active'",
+      ).first<{ count: number }>();
+      return Number(row?.count ?? 0) || 0;
+    },
+
+    async listActiveProducts(limit) {
+      const result = await env.DB.prepare(
+        "SELECT id, name, description, tags FROM products WHERE status = 'active' ORDER BY id LIMIT ?",
+      )
+        .bind(limit)
+        .all<RawProductRow>();
+      return result.results.map((row) => ({
+        id: String(row.id),
+        name: localizedText(row.name),
+        description: localizedText(row.description),
+        tags: parseTags(row.tags),
+      }));
+    },
+
+    async embed(product) {
+      const output = await env.AI.run(getCurrentEmbeddingModel(), {
+        text: productText(product),
+      });
+      const vector = "data" in output ? output.data?.[0] : undefined;
+      if (!Array.isArray(vector) || vector.length === 0) {
+        throw new Error("Embedding model returned no vector");
+      }
+      return vector;
+    },
+
+    async queryNeighbors(vector, topK) {
+      const result = await env.VECTORIZE.query(vector, {
+        topK,
+        returnMetadata: "all",
+      });
+      return result.matches.flatMap((match) => {
+        const productId = match.metadata?.productId;
+        return typeof productId === "string" || typeof productId === "number"
+          ? [{ id: String(productId), score: match.score }]
+          : [];
+      });
+    },
+
+    async replaceRecommendations(sourceId, neighbors) {
+      const generatedAt = new Date().toISOString();
+      const statements = [
+        env.DB.prepare(
+          "DELETE FROM product_recommendations WHERE source_product_id = ?",
+        ).bind(sourceId),
+        ...neighbors.map((neighbor, rank) =>
+          env.DB.prepare(
+            `INSERT INTO product_recommendations
+              (source_product_id, recommended_product_id, rank, score, reason, generated_at)
+             VALUES (?, ?, ?, ?, ?, ?)`,
+          ).bind(
+            sourceId,
+            neighbor.id,
+            rank,
+            neighbor.score,
+            "vector_similarity",
+            generatedAt,
+          ),
+        ),
+      ];
+      await env.DB.batch(statements);
+    },
+
+    async readStaleness(thresholdDays) {
+      const modifier = `-${thresholdDays} days`;
+      const row = await env.DB.prepare(
+        `SELECT
+           sum(CASE WHEN datetime(generated_at) < datetime('now', ?) THEN 1 ELSE 0 END) AS stale,
+           min(generated_at) AS oldest
+         FROM product_recommendations`,
+      )
+        .bind(modifier)
+        .first<{ stale: number | null; oldest: string | null }>();
+      return {
+        staleRowCount: Number(row?.stale ?? 0) || 0,
+        oldestGeneratedAt: row?.oldest ?? null,
+      };
+    },
+  };
+}
+
+export async function rebuildProductRecommendations(
+  env: RecommendationBindings,
+  options: RecommendationRebuildOptions = {},
+): Promise<RecommendationRebuildSummary> {
+  return rebuildWithAdapter(createCloudflareRebuildAdapter(env), options);
+}

--- a/lib/recommendations/blend.ts
+++ b/lib/recommendations/blend.ts
@@ -1,0 +1,69 @@
+import { isVariantAvailable } from "@/lib/inventory/availability";
+import type { Product } from "@/lib/types";
+import { rankRecommendationCandidates } from "./scoring";
+import type { RecsUserContext } from "./types";
+
+export interface BlendInput {
+  product: Product;
+  base: Product[];
+  allProducts: Product[];
+  userContext: RecsUserContext | null;
+  limit: number;
+  personalize: boolean;
+  excludeOwned: boolean;
+}
+
+export function isRecommendationAvailable(product: Product): boolean {
+  const variants = product.variants ?? [];
+  return variants.length === 0 || variants.some(isVariantAvailable);
+}
+
+/** Blend provider output with one personalized slot and a distinct count top-up. */
+export function blendRecommendations(input: BlendInput): Product[] {
+  const { product, base, allProducts, userContext, personalize, excludeOwned } = input;
+  const limit = Math.max(1, Math.min(6, Math.trunc(input.limit)));
+  const sourceId = String(product.id);
+  const ownedIds = new Set(
+    excludeOwned && userContext ? userContext.recentPurchases.map(String) : [],
+  );
+  const eligible = (candidate: Product) =>
+    String(candidate.id) !== sourceId &&
+    !ownedIds.has(String(candidate.id)) &&
+    isRecommendationAvailable(candidate);
+
+  const seen = new Set<string>();
+  const cleanBase: Product[] = [];
+  for (const candidate of base) {
+    const id = String(candidate.id);
+    if (!eligible(candidate) || seen.has(id)) continue;
+    seen.add(id);
+    cleanBase.push(candidate);
+  }
+
+  let result = cleanBase.slice(0, limit);
+  if (personalize && userContext?.orders.length) {
+    const baseTop = cleanBase.slice(0, Math.max(0, limit - 1));
+    const baseIds = new Set(baseTop.map(({ id }) => String(id)));
+    const personalized = rankRecommendationCandidates(
+      product,
+      allProducts.filter(eligible),
+      limit + 5,
+      userContext,
+    ).find(({ id }) => !baseIds.has(String(id)));
+    result = personalized ? [...baseTop, personalized] : cleanBase.slice(0, limit);
+  }
+
+  const have = new Set(result.map(({ id }) => String(id)));
+  const topUp = (candidates: readonly Product[]) => {
+    for (const candidate of candidates) {
+      if (result.length >= limit) break;
+      const id = String(candidate.id);
+      if (!eligible(candidate) || have.has(id)) continue;
+      have.add(id);
+      result.push(candidate);
+    }
+  };
+  topUp(cleanBase);
+  topUp(allProducts);
+  return result.slice(0, limit);
+}

--- a/lib/recommendations/cron.ts
+++ b/lib/recommendations/cron.ts
@@ -1,0 +1,56 @@
+import {
+  rebuildProductRecommendations,
+  type RecommendationRebuildSummary,
+} from "./batch/rebuild";
+
+type RecommendationBindings = Pick<CloudflareEnv, "AI" | "DB" | "VECTORIZE">;
+type Rebuild = (
+  env: RecommendationBindings,
+) => Promise<RecommendationRebuildSummary>;
+
+export async function runRecommendationCron(
+  env: RecommendationBindings,
+  rebuild: Rebuild = rebuildProductRecommendations,
+): Promise<void> {
+  const startedAt = Date.now();
+  try {
+    const summary = await rebuild(env);
+    const details = {
+      event: "recommendations.rebuild",
+      durationMs: Date.now() - startedAt,
+      ...summary,
+    };
+
+    if (summary.errors.length > 0) {
+      console.error(JSON.stringify({ ...details, outcome: "partial_failure" }));
+      throw new Error(
+        `Recommendation rebuild failed for ${summary.errors.length} product(s)`,
+      );
+    }
+
+    if (summary.rowsWritten === 0) {
+      console.warn(JSON.stringify({ ...details, outcome: "no_rows_written" }));
+      return;
+    }
+
+    if (summary.staleRowCount > 0) {
+      console.warn(JSON.stringify({ ...details, outcome: "stale_rows" }));
+    }
+
+    if (summary.productsDeferred > 0) {
+      console.warn(JSON.stringify({ ...details, outcome: "catalog_truncated" }));
+    }
+
+    console.log(JSON.stringify({ ...details, outcome: "success" }));
+  } catch (error) {
+    console.error(
+      JSON.stringify({
+        event: "recommendations.rebuild",
+        outcome: "failure",
+        durationMs: Date.now() - startedAt,
+        error: error instanceof Error ? error.message : String(error),
+      }),
+    );
+    throw error;
+  }
+}

--- a/lib/recommendations/index.ts
+++ b/lib/recommendations/index.ts
@@ -1,0 +1,46 @@
+import type { Product } from "@/lib/types";
+import { listProducts } from "@/lib/models/mach/products";
+import { getRecommendationSettings } from "@/lib/utils/settings";
+import { blendRecommendations } from "./blend";
+import { getProvider } from "./providers/registry";
+import type { RecsUserContext } from "./types";
+
+export async function getRecommendationsForProduct(
+  product: Product,
+  options: { userContext?: RecsUserContext | null; limit?: number } = {},
+): Promise<Product[]> {
+  try {
+    const settings = await getRecommendationSettings();
+    const requestedLimit = options.limit ?? settings.limit;
+    const limit = Math.max(1, Math.min(6, Math.trunc(requestedLimit)));
+    const allProducts = await listProducts({ status: ["active"] });
+    const provider = getProvider(settings.strategy);
+
+    let base: Product[] = [];
+    try {
+      base = await provider.getBaseRecommendations(product, limit + 5, {
+        allProducts,
+      });
+    } catch (error) {
+      console.error(
+        "getRecommendationsForProduct: provider failed; using catalog fallback",
+        error,
+      );
+    }
+
+    return blendRecommendations({
+      product,
+      base,
+      allProducts,
+      userContext: options.userContext ?? null,
+      limit,
+      personalize: settings.personalize,
+      excludeOwned: settings.excludeOwned,
+    });
+  } catch (error) {
+    console.error("getRecommendationsForProduct: failed", error);
+    return [];
+  }
+}
+
+export type { RecsUserContext } from "./types";

--- a/lib/recommendations/providers/ai-batch.ts
+++ b/lib/recommendations/providers/ai-batch.ts
@@ -1,0 +1,37 @@
+import { eq } from "drizzle-orm";
+import { getDbAsync } from "@/lib/db";
+import { product_recommendations } from "@/lib/db/schema/product-recommendations";
+import type { Product } from "@/lib/types";
+import type { RecommendationProvider } from "../types";
+
+interface BatchRow {
+  recommended_product_id: string;
+  rank: number;
+}
+
+export function hydrateBatchRecommendations(
+  rows: readonly BatchRow[],
+  allProducts: readonly Product[],
+  count: number,
+): Product[] {
+  const byId = new Map(allProducts.map((product) => [String(product.id), product]));
+  return [...rows]
+    .sort((left, right) => left.rank - right.rank)
+    .map((row) => byId.get(String(row.recommended_product_id)))
+    .filter((product): product is Product => product !== undefined)
+    .slice(0, Math.max(0, Math.trunc(count)));
+}
+
+export const aiBatchProvider: RecommendationProvider = {
+  async getBaseRecommendations(product, count, context) {
+    const db = await getDbAsync();
+    const rows = await db
+      .select({
+        recommended_product_id: product_recommendations.recommended_product_id,
+        rank: product_recommendations.rank,
+      })
+      .from(product_recommendations)
+      .where(eq(product_recommendations.source_product_id, String(product.id)));
+    return hydrateBatchRecommendations(rows, context.allProducts, count);
+  },
+};

--- a/lib/recommendations/providers/deterministic.ts
+++ b/lib/recommendations/providers/deterministic.ts
@@ -1,0 +1,8 @@
+import type { RecommendationProvider } from "../types";
+import { rankRecommendationCandidates } from "../scoring";
+
+export const deterministicProvider: RecommendationProvider = {
+  async getBaseRecommendations(product, count, context) {
+    return rankRecommendationCandidates(product, context.allProducts, count);
+  },
+};

--- a/lib/recommendations/providers/registry.ts
+++ b/lib/recommendations/providers/registry.ts
@@ -1,0 +1,7 @@
+import type { RecommendationProvider, RecommendationStrategy } from "../types";
+import { aiBatchProvider } from "./ai-batch";
+import { deterministicProvider } from "./deterministic";
+
+export function getProvider(strategy: RecommendationStrategy): RecommendationProvider {
+  return strategy === "ai_batch" ? aiBatchProvider : deterministicProvider;
+}

--- a/lib/recommendations/scoring.ts
+++ b/lib/recommendations/scoring.ts
@@ -1,0 +1,52 @@
+import type { Product } from "@/lib/types";
+import type { RecsUserContext } from "./types";
+
+function strings(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === "string")
+    : [];
+}
+
+function productSignals(product: Product): Set<string> {
+  return new Set([
+    ...strings(product.tags),
+    ...strings(product.categories),
+    ...(typeof product.type === "string" ? [product.type] : []),
+    ...(typeof product.brand === "string" ? [product.brand] : []),
+  ].map((value) => value.trim().toLowerCase()).filter(Boolean));
+}
+
+function overlap(left: Set<string>, right: Set<string>): number {
+  let count = 0;
+  for (const value of left) if (right.has(value)) count += 1;
+  return count;
+}
+
+/** Stable, catalog-neutral similarity with an optional purchase-history boost. */
+export function rankRecommendationCandidates(
+  source: Product,
+  catalog: readonly Product[],
+  count: number,
+  userContext: RecsUserContext | null = null,
+): Product[] {
+  const sourceSignals = productSignals(source);
+  const purchasedIds = new Set(userContext?.recentPurchases.map(String) ?? []);
+  const purchasedSignals = new Set<string>();
+  for (const product of catalog) {
+    if (!purchasedIds.has(String(product.id))) continue;
+    for (const signal of productSignals(product)) purchasedSignals.add(signal);
+  }
+
+  return catalog
+    .map((product, index) => ({
+      product,
+      index,
+      score:
+        overlap(sourceSignals, productSignals(product)) * 4 +
+        overlap(purchasedSignals, productSignals(product)) * 2,
+    }))
+    .filter(({ product }) => String(product.id) !== String(source.id))
+    .sort((left, right) => right.score - left.score || left.index - right.index)
+    .slice(0, Math.max(0, Math.trunc(count)))
+    .map(({ product }) => product);
+}

--- a/lib/recommendations/types.ts
+++ b/lib/recommendations/types.ts
@@ -1,0 +1,31 @@
+import type { Product } from "@/lib/types";
+
+export type RecommendationStrategy = "deterministic" | "ai_batch";
+
+export interface RecommendationSettings {
+  strategy: RecommendationStrategy;
+  personalize: boolean;
+  limit: number;
+  excludeOwned: boolean;
+}
+
+export interface RecsOrderLike {
+  items?: Array<{ product_id?: string | number; id?: string | number }>;
+}
+
+export interface RecsUserContext {
+  orders: RecsOrderLike[];
+  recentPurchases: string[];
+}
+
+export interface ProviderContext {
+  allProducts: Product[];
+}
+
+export interface RecommendationProvider {
+  getBaseRecommendations(
+    product: Product,
+    count: number,
+    context: ProviderContext,
+  ): Promise<Product[]>;
+}

--- a/lib/recommendations/user-context.server.ts
+++ b/lib/recommendations/user-context.server.ts
@@ -1,0 +1,33 @@
+import "server-only";
+
+import { getOrdersByUserId } from "@/lib/models/mach/orders";
+import type { RecsUserContext } from "./types";
+
+const RECENT_PURCHASE_WINDOW_MS = 90 * 24 * 60 * 60 * 1_000;
+const MAX_RECENT_PURCHASES = 100;
+
+export async function buildServerUserContext(
+  userId: string | null | undefined,
+): Promise<RecsUserContext | null> {
+  if (!userId) return null;
+
+  try {
+    const orders = await getOrdersByUserId(userId);
+    const cutoff = Date.now() - RECENT_PURCHASE_WINDOW_MS;
+    const recentPurchases = orders
+      .filter((order) => {
+        const createdAt = order.created_at ? Date.parse(order.created_at) : Number.NaN;
+        return Number.isFinite(createdAt) && createdAt >= cutoff;
+      })
+      .flatMap((order) => order.items ?? [])
+      .map((item) => item.product_id)
+      .filter((id): id is string => typeof id === "string" && id.length > 0)
+      .map(String)
+      .slice(0, MAX_RECENT_PURCHASES);
+
+    return { orders, recentPurchases };
+  } catch (error) {
+    console.error("buildServerUserContext: failed to load orders", error);
+    return null;
+  }
+}

--- a/lib/utils/settings.ts
+++ b/lib/utils/settings.ts
@@ -20,6 +20,10 @@
 import { getDbAsync } from '@/lib/db';
 import { admin_settings } from '@/lib/db/schema/settings';
 import { eq } from 'drizzle-orm';
+import type {
+  RecommendationSettings,
+  RecommendationStrategy,
+} from '@/lib/recommendations/types';
 
 /**
  * Get a typed settings object for easy use in components
@@ -118,4 +122,27 @@ export interface RefundPolicy {
   minimumRefundAmount: number;
   applyRestockingFeeOnPartialReturn: boolean;
   externalFullRestockEnabled: boolean;
+}
+
+export function normalizeRecommendationSettings(
+  raw: Record<string, unknown>,
+): RecommendationSettings {
+  const strategyRaw = raw['recommendations.strategy'];
+  const strategy: RecommendationStrategy = strategyRaw === 'ai_batch'
+    ? 'ai_batch'
+    : 'deterministic';
+  const rawLimit = raw['recommendations.limit'];
+  const limit = typeof rawLimit === 'number' && Number.isFinite(rawLimit)
+    ? Math.max(1, Math.min(6, Math.trunc(rawLimit)))
+    : 3;
+  return {
+    strategy,
+    personalize: raw['recommendations.personalize'] !== false,
+    limit,
+    excludeOwned: raw['recommendations.exclude_owned'] !== false,
+  };
+}
+
+export async function getRecommendationSettings(): Promise<RecommendationSettings> {
+  return normalizeRecommendationSettings(await getSettings('recommendations'));
 }

--- a/migrations/0017_add_product_recommendations.sql
+++ b/migrations/0017_add_product_recommendations.sql
@@ -1,0 +1,21 @@
+-- Precomputed per-product recommendation lists and configurable PDP defaults.
+
+CREATE TABLE IF NOT EXISTS product_recommendations (
+  source_product_id TEXT NOT NULL,
+  recommended_product_id TEXT NOT NULL,
+  rank INTEGER NOT NULL CHECK (rank >= 0),
+  score REAL,
+  reason TEXT,
+  generated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  PRIMARY KEY (source_product_id, recommended_product_id),
+  CHECK (source_product_id <> recommended_product_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_product_recommendations_source_rank
+  ON product_recommendations (source_product_id, rank);
+
+INSERT OR IGNORE INTO admin_settings (key, value, category, description, data_type) VALUES
+  ('recommendations.strategy', '"deterministic"', 'recommendations', 'PDP recommendation source: deterministic or ai_batch', 'string'),
+  ('recommendations.personalize', 'true', 'recommendations', 'Reserve one recommendation slot for customers with order history', 'boolean'),
+  ('recommendations.limit', '3', 'recommendations', 'Number of products shown in the PDP recommendation strip', 'number'),
+  ('recommendations.exclude_owned', 'true', 'recommendations', 'Hide products the customer already purchased', 'boolean');

--- a/tests/integration/d1-harness.test.ts
+++ b/tests/integration/d1-harness.test.ts
@@ -29,7 +29,49 @@ describe('real D1 Workers harness', () => {
       '0014_add_order_events.sql',
       '0015_normalize_order_timestamps.sql',
       '0016_enforce_order_timestamp_format.sql',
+      '0017_add_product_recommendations.sql',
     ]);
+  });
+
+  it('installs recommendation defaults and enforces recommendation row invariants', async () => {
+    const settings = await env.DB.prepare(
+      `SELECT key, value FROM admin_settings
+       WHERE category = 'recommendations' ORDER BY key`,
+    ).all<{ key: string; value: string }>();
+    expect(settings.results).toEqual([
+      { key: 'recommendations.exclude_owned', value: 'true' },
+      { key: 'recommendations.limit', value: '3' },
+      { key: 'recommendations.personalize', value: 'true' },
+      { key: 'recommendations.strategy', value: '"deterministic"' },
+    ]);
+
+    await expect(
+      env.DB.prepare(
+        `INSERT INTO product_recommendations
+          (source_product_id, recommended_product_id, rank)
+         VALUES ('same', 'same', 0)`,
+      ).run(),
+    ).rejects.toThrow();
+    await expect(
+      env.DB.prepare(
+        `INSERT INTO product_recommendations
+          (source_product_id, recommended_product_id, rank)
+         VALUES ('source', 'recommended', -1)`,
+      ).run(),
+    ).rejects.toThrow();
+  });
+
+  it('generates canonical UTC timestamps for recommendation rows', async () => {
+    await env.DB.prepare(
+      `INSERT INTO product_recommendations
+        (source_product_id, recommended_product_id, rank)
+       VALUES ('source', 'recommended', 0)`,
+    ).run();
+    const row = await env.DB.prepare(
+      `SELECT generated_at FROM product_recommendations
+       WHERE source_product_id = 'source'`,
+    ).first<{ generated_at: string }>();
+    expect(row?.generated_at).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
   });
 
   it('stores canonical ISO UTC timestamps when an order insert omits them', async () => {

--- a/tests/unit/recommendations/ai-batch.test.ts
+++ b/tests/unit/recommendations/ai-batch.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { hydrateBatchRecommendations } from "@/lib/recommendations/providers/ai-batch";
+import type { Product } from "@/lib/types";
+
+const products = [
+  { id: "a", name: "A" },
+  { id: "b", name: "B" },
+] as Product[];
+
+describe("hydrateBatchRecommendations", () => {
+  it("hydrates stored IDs in rank order and ignores missing catalog records", () => {
+    expect(
+      hydrateBatchRecommendations(
+        [
+          { recommended_product_id: "missing", rank: 0 },
+          { recommended_product_id: "b", rank: 2 },
+          { recommended_product_id: "a", rank: 1 },
+        ],
+        products,
+        2,
+      ).map(({ id }) => id),
+    ).toEqual(["a", "b"]);
+  });
+});

--- a/tests/unit/recommendations/cron.test.ts
+++ b/tests/unit/recommendations/cron.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { runRecommendationCron } from "@/lib/recommendations/cron";
+import type { RecommendationRebuildSummary } from "@/lib/recommendations/batch/rebuild";
+
+const env = {} as CloudflareEnv;
+const summary: RecommendationRebuildSummary = {
+  catalogProducts: 2,
+  productsAttempted: 2,
+  productsDeferred: 0,
+  productsProcessed: 2,
+  productsSkipped: 0,
+  rowsWritten: 2,
+  errors: [],
+  stalenessThresholdDays: 7,
+  staleRowCount: 0,
+  oldestGeneratedAt: null,
+};
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("runRecommendationCron", () => {
+  it("rethrows rebuild failures so the scheduled execution fails", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    await expect(
+      runRecommendationCron(env, vi.fn().mockRejectedValue(new Error("offline"))),
+    ).rejects.toThrow("offline");
+  });
+
+  it("treats partial product failures as a failed scheduled execution", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    await expect(
+      runRecommendationCron(
+        env,
+        vi.fn().mockResolvedValue({
+          ...summary,
+          errors: [{ productId: "a", error: "bad vector" }],
+        }),
+      ),
+    ).rejects.toThrow("1 product");
+  });
+
+  it("emits structured warnings for empty and stale rebuilds", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    await runRecommendationCron(
+      env,
+      vi.fn().mockResolvedValue({ ...summary, rowsWritten: 0, staleRowCount: 2 }),
+    );
+    expect(JSON.parse(String(warn.mock.calls[0][0]))).toMatchObject({
+      event: "recommendations.rebuild",
+      outcome: "no_rows_written",
+      staleRowCount: 2,
+    });
+  });
+
+  it("logs a structured success summary", async () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    await runRecommendationCron(env, vi.fn().mockResolvedValue(summary));
+    expect(JSON.parse(String(log.mock.calls[0][0]))).toMatchObject({
+      event: "recommendations.rebuild",
+      outcome: "success",
+      rowsWritten: 2,
+    });
+  });
+});

--- a/tests/unit/recommendations/ranking-and-blend.test.ts
+++ b/tests/unit/recommendations/ranking-and-blend.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import { blendRecommendations } from "@/lib/recommendations/blend";
+import { rankRecommendationCandidates } from "@/lib/recommendations/scoring";
+import type { Product } from "@/lib/types";
+
+function product(
+  id: string,
+  tags: string[] = [],
+  inventory: { track_inventory?: boolean; quantity?: number; allow_backorder?: boolean } | null = null,
+): Product {
+  return {
+    id,
+    name: id,
+    tags,
+    variants: inventory === null
+      ? []
+      : [{ id: `${id}-variant`, sku: id, option_values: [], price: { amount: 100, currency: "USD" }, inventory }],
+  } as Product;
+}
+
+describe("recommendation ranking", () => {
+  it("is catalog-neutral, stable, and excludes the source", () => {
+    const source = product("source", ["shared", "feature"]);
+    const catalog = [
+      source,
+      product("unrelated", ["coffee"]),
+      product("best", ["shared", "feature"]),
+      product("tie", ["shared"]),
+    ];
+    expect(rankRecommendationCandidates(source, catalog, 3).map(({ id }) => id)).toEqual([
+      "best",
+      "tie",
+      "unrelated",
+    ]);
+  });
+});
+
+describe("recommendation blending", () => {
+  it("deduplicates and tops up a short provider response", () => {
+    const source = product("source");
+    const a = product("a");
+    const b = product("b");
+    const c = product("c");
+    expect(
+      blendRecommendations({
+        product: source,
+        base: [a, a],
+        allProducts: [source, a, b, c],
+        userContext: null,
+        limit: 3,
+        personalize: false,
+        excludeOwned: false,
+      }).map(({ id }) => id),
+    ).toEqual(["a", "b", "c"]);
+  });
+
+  it("filters tracked OOS products while retaining untracked and backordered products", () => {
+    const source = product("source");
+    const out = product("out", [], { track_inventory: true, quantity: 0 });
+    const untracked = product("untracked", [], { track_inventory: false, quantity: 0 });
+    const backorder = product("backorder", [], {
+      track_inventory: true,
+      quantity: 0,
+      allow_backorder: true,
+    });
+    const result = blendRecommendations({
+      product: source,
+      base: [out, untracked, backorder],
+      allProducts: [source, out, untracked, backorder],
+      userContext: null,
+      limit: 3,
+      personalize: false,
+      excludeOwned: false,
+    });
+    expect(result.map(({ id }) => id)).toEqual(["untracked", "backorder"]);
+  });
+
+  it("excludes owned products from every candidate source", () => {
+    const source = product("source");
+    const owned = product("owned");
+    const other = product("other");
+    const result = blendRecommendations({
+      product: source,
+      base: [owned],
+      allProducts: [source, owned, other],
+      userContext: { orders: [{}], recentPurchases: ["owned"] },
+      limit: 2,
+      personalize: true,
+      excludeOwned: true,
+    });
+    expect(result.map(({ id }) => id)).toEqual(["other"]);
+  });
+
+  it("reserves one slot for personalization when order history exists", () => {
+    const source = product("source", ["shared"]);
+    const a = product("a", ["shared"]);
+    const b = product("b", ["shared"]);
+    const c = product("c");
+    const d = product("d");
+    const e = product("e");
+    const result = blendRecommendations({
+      product: source,
+      base: [c, d, e],
+      allProducts: [source, a, b, c, d, e],
+      userContext: { orders: [{}], recentPurchases: [] },
+      limit: 3,
+      personalize: true,
+      excludeOwned: false,
+    });
+    expect(result.map(({ id }) => id)).toEqual(["c", "d", "a"]);
+  });
+});

--- a/tests/unit/recommendations/rebuild.test.ts
+++ b/tests/unit/recommendations/rebuild.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  rebuildWithAdapter,
+  type RecommendationRebuildAdapter,
+  type RebuildProduct,
+} from "@/lib/recommendations/batch/rebuild";
+
+const products: RebuildProduct[] = [
+  { id: "a", name: "A", description: "", tags: [] },
+  { id: "b", name: "B", description: "", tags: [] },
+  { id: "c", name: "C", description: "", tags: [] },
+];
+
+function adapter(overrides: Partial<RecommendationRebuildAdapter> = {}) {
+  const base: RecommendationRebuildAdapter = {
+    countActiveProducts: vi.fn().mockResolvedValue(products.length),
+    listActiveProducts: vi.fn().mockResolvedValue(products),
+    embed: vi.fn().mockResolvedValue([0.1]),
+    queryNeighbors: vi.fn().mockResolvedValue([{ id: "b", score: 0.9 }]),
+    replaceRecommendations: vi.fn().mockResolvedValue(undefined),
+    readStaleness: vi.fn().mockResolvedValue({ staleRowCount: 0, oldestGeneratedAt: null }),
+  };
+  return { ...base, ...overrides };
+}
+
+describe("rebuildWithAdapter", () => {
+  it("preserves existing rows when no valid neighbors are returned", async () => {
+    const current = adapter({
+      queryNeighbors: vi.fn().mockResolvedValue([{ id: "missing", score: 1 }]),
+    });
+    const summary = await rebuildWithAdapter(current);
+    expect(current.replaceRecommendations).not.toHaveBeenCalled();
+    expect(summary.productsSkipped).toBe(3);
+    expect(summary.rowsWritten).toBe(0);
+  });
+
+  it("filters self, inactive, and duplicate matches before atomic replacement", async () => {
+    const current = adapter({
+      queryNeighbors: vi.fn().mockResolvedValue([
+        { id: "a", score: 1 },
+        { id: "inactive", score: 0.99 },
+        { id: "b", score: 0.9 },
+        { id: "b", score: 0.8 },
+        { id: "c", score: 0.7 },
+      ]),
+    });
+    await rebuildWithAdapter(current, { neighbors: 2 });
+    expect(current.replaceRecommendations).toHaveBeenCalledWith("a", [
+      { id: "b", score: 0.9 },
+      { id: "c", score: 0.7 },
+    ]);
+  });
+
+  it("continues after a per-product failure and reports it", async () => {
+    const current = adapter({
+      embed: vi.fn(async (product: RebuildProduct) => {
+        if (product.id === "b") throw new Error("embedding failed");
+        return [0.1];
+      }),
+    });
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const summary = await rebuildWithAdapter(current);
+    expect(summary.productsProcessed).toBe(2);
+    expect(summary.errors).toEqual([{ productId: "b", error: "embedding failed" }]);
+    error.mockRestore();
+  });
+
+  it("reports stale rows without failing completed writes", async () => {
+    const current = adapter({
+      readStaleness: vi.fn().mockResolvedValue({
+        staleRowCount: 4,
+        oldestGeneratedAt: "2026-01-01T00:00:00.000Z",
+      }),
+    });
+    const summary = await rebuildWithAdapter(current);
+    expect(summary.staleRowCount).toBe(4);
+    expect(summary.oldestGeneratedAt).toBe("2026-01-01T00:00:00.000Z");
+  });
+
+  it("reports catalog products deferred by the bounded rebuild", async () => {
+    const current = adapter({ countActiveProducts: vi.fn().mockResolvedValue(120) });
+    const summary = await rebuildWithAdapter(current);
+    expect(summary.catalogProducts).toBe(120);
+    expect(summary.productsAttempted).toBe(3);
+    expect(summary.productsDeferred).toBe(117);
+  });
+});

--- a/tests/unit/recommendations/seam.test.ts
+++ b/tests/unit/recommendations/seam.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Product } from "@/lib/types";
+
+const { getRecommendationSettings, listProducts, getBaseRecommendations } = vi.hoisted(() => ({
+  getRecommendationSettings: vi.fn(),
+  listProducts: vi.fn(),
+  getBaseRecommendations: vi.fn(),
+}));
+
+vi.mock("@/lib/utils/settings", () => ({ getRecommendationSettings }));
+vi.mock("@/lib/models/mach/products", () => ({ listProducts }));
+vi.mock("@/lib/recommendations/providers/registry", () => ({
+  getProvider: () => ({ getBaseRecommendations }),
+}));
+
+import { getRecommendationsForProduct } from "@/lib/recommendations";
+
+const source = { id: "source", name: "Source", variants: [] } as Product;
+const a = { id: "a", name: "A", variants: [] } as Product;
+const b = { id: "b", name: "B", variants: [] } as Product;
+
+beforeEach(() => {
+  getRecommendationSettings.mockResolvedValue({
+    strategy: "deterministic",
+    personalize: false,
+    limit: 2,
+    excludeOwned: false,
+  });
+  listProducts.mockResolvedValue([source, a, b]);
+  getBaseRecommendations.mockResolvedValue([a, b]);
+});
+
+describe("getRecommendationsForProduct", () => {
+  it("queries only active catalog products and returns the configured count", async () => {
+    const result = await getRecommendationsForProduct(source);
+    expect(listProducts).toHaveBeenCalledWith({ status: ["active"] });
+    expect(getBaseRecommendations).toHaveBeenCalledWith(source, 7, {
+      allProducts: [source, a, b],
+    });
+    expect(result.map(({ id }) => id)).toEqual(["a", "b"]);
+  });
+
+  it("falls back to the catalog when the selected provider fails", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    getBaseRecommendations.mockRejectedValueOnce(new Error("batch unavailable"));
+    expect((await getRecommendationsForProduct(source)).map(({ id }) => id)).toEqual(["a", "b"]);
+    error.mockRestore();
+  });
+});

--- a/tests/unit/recommendations/settings.test.ts
+++ b/tests/unit/recommendations/settings.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { normalizeRecommendationSettings } from "@/lib/utils/settings";
+
+describe("normalizeRecommendationSettings", () => {
+  it("uses portable defaults for absent or malformed values", () => {
+    expect(normalizeRecommendationSettings({})).toEqual({
+      strategy: "deterministic",
+      personalize: true,
+      limit: 3,
+      excludeOwned: true,
+    });
+    expect(
+      normalizeRecommendationSettings({
+        "recommendations.strategy": "unknown",
+        "recommendations.limit": Number.NaN,
+      }),
+    ).toMatchObject({ strategy: "deterministic", limit: 3 });
+  });
+
+  it("accepts AI batch and clamps the display limit", () => {
+    expect(
+      normalizeRecommendationSettings({
+        "recommendations.strategy": "ai_batch",
+        "recommendations.personalize": false,
+        "recommendations.limit": 99,
+        "recommendations.exclude_owned": false,
+      }),
+    ).toEqual({
+      strategy: "ai_batch",
+      personalize: false,
+      limit: 6,
+      excludeOwned: false,
+    });
+  });
+});

--- a/tests/unit/recommendations/storefront-source.test.ts
+++ b/tests/unit/recommendations/storefront-source.test.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("PDP recommendation boundary", () => {
+  it("resolves recommendations on the server and projects them before client rendering", () => {
+    const page = readFileSync(resolve("app/product/[slug]/page.tsx"), "utf8");
+    const component = readFileSync(resolve("components/ProductRecommendations.tsx"), "utf8");
+    expect(page).toContain("getRecommendationsForProduct(storedProduct");
+    expect(page).toContain("products.map(toPublicProduct)");
+    expect(component).not.toContain("/api/agent-chat");
+    expect(component).not.toContain('"use client"');
+  });
+
+  it("routes the daily cron through the app worker", () => {
+    const worker = readFileSync(resolve("worker.ts"), "utf8");
+    const config = readFileSync(resolve("wrangler.jsonc"), "utf8");
+    expect(worker).toContain('controller.cron === "15 8 * * *"');
+    expect(worker).toContain("runRecommendationCron(env)");
+    expect(config).toContain('"15 8 * * *"');
+  });
+
+  it("keeps recommendation admin mutations authenticated, bounded, and generic on failure", () => {
+    const settings = readFileSync(
+      resolve("app/api/admin/recommendations/settings/route.ts"),
+      "utf8",
+    );
+    const rebuild = readFileSync(
+      resolve("app/api/admin/recommendations/rebuild/route.ts"),
+      "utf8",
+    );
+    expect(settings).toContain("checkAdminPermissions(request)");
+    expect(settings).toContain("MAX_BODY_BYTES");
+    expect(settings).toContain("request.text()");
+    expect(rebuild).toContain("checkAdminPermissions(request)");
+    expect(rebuild).not.toContain("detail:");
+  });
+});

--- a/tests/unit/worker-cron-routing.test.ts
+++ b/tests/unit/worker-cron-routing.test.ts
@@ -2,15 +2,17 @@ import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
 describe('Worker scheduled routing contract', () => {
-  it('routes only the known five-minute and six-hour schedules', () => {
+  it('routes only the known recovery, analytics, and recommendation schedules', () => {
     const source = readFileSync('worker.ts', 'utf8');
     const config = readFileSync('wrangler.jsonc', 'utf8');
 
-    expect(config).toContain('"crons": ["*/5 * * * *", "0 */6 * * *"]');
+    expect(config).toContain('"crons": ["*/5 * * * *", "0 */6 * * *", "15 8 * * *"]');
     expect(source).toContain('controller.cron === "*/5 * * * *"');
     expect(source).toContain('drainOrderEffects({ database: env.DB, limit: 25 })');
     expect(source).toContain('drainInventoryAdjustments({ database: env.DB, limit: 25 })');
     expect(source).toContain('Promise.all([');
+    expect(source).toContain('controller.cron === "15 8 * * *"');
+    expect(source).toContain('runRecommendationCron(env)');
     expect(source).toContain('controller.cron !== "0 */6 * * *"');
     expect(source).toContain('ignoring unknown scheduled trigger');
     expect(source.indexOf('controller.cron !== "0 */6 * * *"'))

--- a/worker.ts
+++ b/worker.ts
@@ -17,6 +17,7 @@ import { default as handler } from "./.open-next/worker.js";
 import { regenerateAnalytics } from "@/lib/analytics/generate-insights";
 import { drainOrderEffects } from "@/lib/services/order-effects";
 import { drainInventoryAdjustments } from "@/lib/services/inventory-adjustments";
+import { runRecommendationCron } from "@/lib/recommendations/cron";
 
 export default {
   fetch: handler.fetch,
@@ -37,6 +38,11 @@ export default {
           )
           .catch((err) => console.error("[cron] recovery queue drain failed:", err))
       );
+      return;
+    }
+
+    if (controller.cron === "15 8 * * *") {
+      ctx.waitUntil(runRecommendationCron(env));
       return;
     }
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -7,8 +7,8 @@
   "name": "mercora",
   "main": "worker.ts",
   "triggers": {
-    // Retry paid-order effects every five minutes and regenerate Admin BI every six hours.
-    "crons": ["*/5 * * * *", "0 */6 * * *"]
+    // Recovery queues: every 5m; Admin BI: every 6h; recommendations: daily at 08:15 UTC.
+    "crons": ["*/5 * * * *", "0 */6 * * *", "15 8 * * *"]
   },
   "compatibility_date": "2026-08-01",
   "compatibility_flags": [


### PR DESCRIPTION
## Summary
- resolve PDP recommendations server-side with deterministic and precomputed AI-batch providers
- add configurable blending, personalization, owned-product exclusion, OOS filtering, and catalog fallback
- add migration 0017, bounded atomic rebuilds, stale/empty-wipe guards, admin controls, and a daily scheduled rebuild
- propagate scheduled partial failures and emit structured rebuild observability

## Safety and portability
- defaults to deterministic recommendations, so no precomputed data is required
- projects every recommended product through the public storefront serializer before client rendering
- contains no BeauTeas content, credentials, worker URLs, or merchant-specific fixtures
- caps each AI rebuild at 100 products and reports any deferred catalog count

## Validation
- Node 24.18.1 typecheck
- 106 unit test files / 608 tests
- 12 Workers integration files / 61 real D1 tests
- production Next.js build