### PR TITLE
chore(deps): group routine updates and hold ESLint 10

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,32 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+
+    # Every update rewrites package-lock.json, so ten separate pull requests
+    # means nine conflicts the moment the first one merges. Grouping the routine
+    # updates makes that one lockfile change instead. Majors stay ungrouped so a
+    # framework or toolchain jump still arrives as its own reviewable pull
+    # request rather than riding along with patch bumps.
+    groups:
+      production-dependencies:
+        dependency-type: production
+        update-types:
+          - minor
+          - patch
+      dev-dependencies:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+
+    ignore:
+      # No published eslint-plugin-react supports ESLint 10 — 7.37.5 peers on
+      # eslint "^3 || ... || ^9.7" — and eslint-config-next depends on it, so
+      # linting fails with "contextOrFilename.getFilename is not a function"
+      # before any repository configuration is consulted.
+      #
+      # Remove this entry once eslint-plugin-react accepts ESLint 10 and
+      # eslint-config-next has picked the release up.
+      - dependency-name: eslint
+        versions:
+          - 10.x


### PR DESCRIPTION
## Summary

- group routine minor/patch updates so a week of Dependabot arrives as two pull requests instead of ten
- hold ESLint 10 with a documented reason and removal condition

## Why grouping

Every update rewrites `package-lock.json`. With ten separate pull requests that means the first merge leaves the other nine conflicting, each rebasing and re-running CI — which is what happened across PRs 45–54 today.

Majors are deliberately left ungrouped, so a jump like Next 16 or TypeScript 7 still arrives as its own reviewable pull request rather than riding along with patch bumps.

## Why ESLint 10 is held rather than closed

No published `eslint-plugin-react` supports ESLint 10 — `7.37.5` peers on `eslint: "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"` — and `eslint-config-next@16.3.0` depends on `eslint-plugin-react: ^7.37.0`.

The failure happens inside the plugin, before any repository configuration is consulted:

```
TypeError: Error while loading rule 'react/display-name':
contextOrFilename.getFilename is not a function
```

Verified this persists with `eslint-config-next@16`, so it is not a pinning problem and no override resolves it. The ignore entry records the cause and what has to change before it is removed; a closed pull request would leave neither.

## Not addressed here

PR #49 (Next 16) and PR #50 (TypeScript 7) remain open and are unaffected by this change. TypeScript 7 typechecks and builds cleanly once Next 16 lands and `baseUrl` is dropped from `tsconfig.json`.
