### PR TITLE
chore(deps): upgrade Clerk to v7

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -119,7 +119,7 @@ export default function RootLayout({
   return (
     <ClerkProvider
       appearance={{
-        baseTheme: dark,
+        theme: dark,
       }}
     >
       <html lang="en" suppressHydrationWarning>

--- a/components/login/ClerkLogin.tsx
+++ b/components/login/ClerkLogin.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { SignInButton, SignedIn, SignedOut, UserButton } from "@clerk/nextjs";
+import { SignInButton, Show, UserButton } from "@clerk/nextjs";
 import { Button } from "@/components/ui/button";
 import { LogIn, Package, Shield } from "lucide-react";
 import { useState, useEffect } from "react";
@@ -36,7 +36,7 @@ export default function ClerkLogin() {
 
   return (
     <>
-      <SignedOut>
+      <Show when="signed-out">
         <SignInButton mode="modal">
           <Button
             variant="ghost"
@@ -45,9 +45,9 @@ export default function ClerkLogin() {
             <LogIn className="mr-2 h-4 w-4" /> Sign In / Register
           </Button>
         </SignInButton>
-      </SignedOut>
+      </Show>
 
-      <SignedIn>
+      <Show when="signed-in">
         <UserButton appearance={{ elements: { avatarBox: "w-8 h-8" } }}>
           <UserButton.MenuItems>
             <UserButton.Link
@@ -64,7 +64,7 @@ export default function ClerkLogin() {
             )}
           </UserButton.MenuItems>
         </UserButton>
-      </SignedIn>
+      </Show>
     </>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@clerk/nextjs": "^6.39.6",
-        "@clerk/themes": "^2.4.0",
+        "@clerk/nextjs": "^7.7.4",
+        "@clerk/themes": "^2.4.57",
         "@radix-ui/react-alert-dialog": "^1.1.23",
         "@radix-ui/react-checkbox": "^1.3.11",
         "@radix-ui/react-dialog": "^1.1.14",
@@ -1590,57 +1590,136 @@
       }
     },
     "node_modules/@clerk/backend": {
-      "version": "2.33.6",
-      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-2.33.6.tgz",
-      "integrity": "sha512-5foMmTHEQFt4mDv7AN0RDwUHZhGcg/JYe5hnl9SU/LFS8ZHY29Z2HDtIBmzKgjRfOJTMKj1AM81LgK2UFsGm9Q==",
+      "version": "3.16.4",
+      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.16.4.tgz",
+      "integrity": "sha512-7A9YlBLesYgKFn4DcaCq64Ggezmbzx+xYdWsiQLrMQV+U4Bm9LtDdyaNirQ0SStSsZy6PzL8RHw5zMmmEt0zMA==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "^3.47.8",
-        "@clerk/types": "^4.101.26",
+        "@clerk/shared": "^4.28.1",
         "standardwebhooks": "^1.0.0",
         "tslib": "2.8.1"
       },
       "engines": {
-        "node": ">=18.17.0"
+        "node": ">=20.9.0"
       }
     },
-    "node_modules/@clerk/clerk-react": {
-      "version": "5.61.9",
-      "resolved": "https://registry.npmjs.org/@clerk/clerk-react/-/clerk-react-5.61.9.tgz",
-      "integrity": "sha512-PRIodE1QVem/eV3wrjicJJiJ2pkGiZfI6t1vekE/+04cIHciXyvUezQ/468gGPl31xd7BiCNO3uKNM14TXEKZQ==",
+    "node_modules/@clerk/backend/node_modules/@clerk/shared": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.28.1.tgz",
+      "integrity": "sha512-OhpUczN6t8CYJ+g8HdzN1O4SFC2EANOZRDwlE3rXxKu13eNtyFbLspt+d6Nhb/PmcThS/fIAKYnQQrwv0vIEwg==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "^3.47.8",
-        "tslib": "2.8.1"
+        "@tanstack/query-core": "^5.100.6",
+        "dequal": "2.0.3",
+        "glob-to-regexp": "0.4.1",
+        "js-cookie": "3.0.7"
       },
       "engines": {
-        "node": ">=18.17.0"
+        "node": ">=20.9.0"
       },
       "peerDependencies": {
         "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
         "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/@clerk/nextjs": {
-      "version": "6.39.6",
-      "resolved": "https://registry.npmjs.org/@clerk/nextjs/-/nextjs-6.39.6.tgz",
-      "integrity": "sha512-bfB1mt1kFdlV2khNdJPP4Zynrz6XfXjqiJogEHWpeK0ch46uWX7lNN9wrstkokDMHTmvpVkDZPAKkncdK3vZ6w==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@clerk/nextjs/-/nextjs-7.7.4.tgz",
+      "integrity": "sha512-i+H7HTssKVpIgI93s0jeHicjXDjaAVCApmHi0xQi0tFV9mT1jOvw7KcZYVZIseh2JYW1ForS+A3Xy8MgvVC4Sg==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/backend": "^2.33.6",
-        "@clerk/clerk-react": "^5.61.9",
-        "@clerk/shared": "^3.47.8",
-        "@clerk/types": "^4.101.26",
+        "@clerk/backend": "^3.16.4",
+        "@clerk/react": "^6.14.1",
+        "@clerk/shared": "^4.28.1",
         "server-only": "0.0.1",
         "tslib": "2.8.1"
       },
       "engines": {
-        "node": ">=18.17.0"
+        "node": ">=20.9.0"
       },
       "peerDependencies": {
-        "next": "^13.5.7 || ^14.2.25 || ^15.2.3 || ^16",
+        "next": "^15.2.8 || ^15.3.8 || ^15.4.10 || ^15.5.9 || ^15.6.0-0 || ^16.0.10 || ^16.1.0-0",
         "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
         "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
+      }
+    },
+    "node_modules/@clerk/nextjs/node_modules/@clerk/shared": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.28.1.tgz",
+      "integrity": "sha512-OhpUczN6t8CYJ+g8HdzN1O4SFC2EANOZRDwlE3rXxKu13eNtyFbLspt+d6Nhb/PmcThS/fIAKYnQQrwv0vIEwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "^5.100.6",
+        "dequal": "2.0.3",
+        "glob-to-regexp": "0.4.1",
+        "js-cookie": "3.0.7"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
+        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@clerk/react": {
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/@clerk/react/-/react-6.14.1.tgz",
+      "integrity": "sha512-rSFJUyfOuMeySbmkTv+g4DpPp492lpgVKERtrzm0wo+PwnWXoGjVkrpWb6mZMKLQAvq2dU2LnKitljcbLDKUXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/shared": "^4.28.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
+        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
+      }
+    },
+    "node_modules/@clerk/react/node_modules/@clerk/shared": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.28.1.tgz",
+      "integrity": "sha512-OhpUczN6t8CYJ+g8HdzN1O4SFC2EANOZRDwlE3rXxKu13eNtyFbLspt+d6Nhb/PmcThS/fIAKYnQQrwv0vIEwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "^5.100.6",
+        "dequal": "2.0.3",
+        "glob-to-regexp": "0.4.1",
+        "js-cookie": "3.0.7"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
+        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/@clerk/shared": {
@@ -1681,18 +1760,6 @@
       "dependencies": {
         "@clerk/shared": "^3.47.2",
         "tslib": "2.8.1"
-      },
-      "engines": {
-        "node": ">=18.17.0"
-      }
-    },
-    "node_modules/@clerk/types": {
-      "version": "4.101.26",
-      "resolved": "https://registry.npmjs.org/@clerk/types/-/types-4.101.26.tgz",
-      "integrity": "sha512-tUeiElAZoXu9Dxom9t6IjkEfsfP7aWSVf5x5mCoHnSr2w+wV4EtEwoLl9vexT5LL0di4qidROSfcrOnorzczIQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@clerk/shared": "^3.47.8"
       },
       "engines": {
         "node": ">=18.17.0"
@@ -7532,6 +7599,16 @@
       },
       "peerDependencies": {
         "tailwindcss": ">=3.0.0 || >=4.0.0 || insiders"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.101.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.4.tgz",
+      "integrity": "sha512-gNwcvOJcRbLWPOLG/2OBm+zM+Yv+MKsXKEOWC57USuZDEsI71hEErQsiEGx5wX9rzWWkfwM0fVSPoiIFSsxfiw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tsconfig/node18": {

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "token:revoke": "tsx scripts/manage-tokens.ts revoke"
   },
   "dependencies": {
-    "@clerk/nextjs": "^6.39.6",
-    "@clerk/themes": "^2.4.0",
+    "@clerk/nextjs": "^7.7.4",
+    "@clerk/themes": "^2.4.57",
     "@radix-ui/react-alert-dialog": "^1.1.23",
     "@radix-ui/react-checkbox": "^1.3.11",
     "@radix-ui/react-dialog": "^1.1.14",


### PR DESCRIPTION
Supersedes #62, which fails to compile.

## Breaking changes handled

**`SignedIn` / `SignedOut` removed.** Clerk Core 3 consolidates `SignedIn`, `SignedOut`, and `Protect` into one `Show` component. The header's two auth states move to `<Show when="signed-out">` and `<Show when="signed-in">`.

**`appearance.baseTheme` renamed to `theme`.** The dark theme is otherwise unchanged.

## Checked and not affected

| v7 change | This repository |
|---|---|
| Requires Next ≥15.2.3 | on 16.3.0 |
| `auth.protect()` returns 401 not 404 | no handler checks for 404 |
| `afterSignInUrl`/`afterSignUpUrl`/`redirectUrl` removed | not used |
| `UserButton afterSignOutUrl`/`signOutUrl` removed | not used |
| `client.activeSessions` → `sessions` | the `activeSessions` here is this project's own MCP counter |
| `verifyToken()`/`verifySecret()` → `verify()` | not used |

## Worth knowing for later

v7 requires `ClerkProvider` inside `<body>` when Next 16 cache components are enabled. It currently wraps `<html>`, which is fine because `cacheComponents` is off. Enabling that flag will require moving it.

## Validation

- `npm run lint` — 0 errors
- `npm run typecheck`
- `npm test` — 117 files, 654 tests
- `npm run build` — 55/55 pages

## Note

Sign-in and sign-out are not covered by automated tests. Worth exercising both after this deploys.