### PR TITLE
chore(deps): upgrade web-vitals to 6

### DIFF
--- a/lib/hooks/useWebVitals.ts
+++ b/lib/hooks/useWebVitals.ts
@@ -86,6 +86,11 @@ export function useWebVitals() {
                 : "good",
           entries: [],
           navigationType: "navigate",
+          // web-vitals 6 requires a navigationId so a metric can be attributed
+          // to a soft navigation. This metric is synthesized from a touch
+          // rather than reported by the library, so it belongs to the initial
+          // navigation.
+          navigationId: 1,
           userAgent: navigator.userAgent,
           isMobile: true,
         };

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "sonner": "^2.0.6",
         "stripe": "^22.4.0",
         "tailwind-merge": "^3.6.0",
-        "web-vitals": "^5.1.0",
+        "web-vitals": "^6.1.0",
         "zustand": "^5.0.6"
       },
       "devDependencies": {
@@ -17791,9 +17791,9 @@
       }
     },
     "node_modules/web-vitals": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.3.0.tgz",
-      "integrity": "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-6.1.0.tgz",
+      "integrity": "sha512-ZNoJ/MbU6aaR2WjKrFVUvy5WQx+G96YvXQFSsmKTz3A/0VlAFywjUcxl00hc/S6wef2stfgQ4yWYIJCWCNudkA==",
       "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "sonner": "^2.0.6",
     "stripe": "^22.4.0",
     "tailwind-merge": "^3.6.0",
-    "web-vitals": "^5.1.0",
+    "web-vitals": "^6.1.0",
     "zustand": "^5.0.6"
   },
   "devDependencies": {


### PR DESCRIPTION
Supersedes #61, which fails to type check.

web-vitals 6 requires `navigationId` on every metric so a metric can be attributed to the soft navigation it belongs to. The touch-latency metric in `lib/hooks/useWebVitals.ts` is synthesized here rather than reported by the library, so it carried no `navigationId`.

It is attributed to the initial navigation, which is where a touch measured against the current document belongs.

## Validation

- `npm run lint` — 0 errors
- `npm run typecheck`
- `npm test` — 117 files, 654 tests