### PR TITLE
chore(deps): upgrade marked to 18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "drizzle-orm": "^0.45.2",
         "isomorphic-dompurify": "3.22.0",
         "lucide-react": "^1.30.0",
-        "marked": "^16.3.0",
+        "marked": "^18.0.9",
         "next": "^16.3.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -13233,9 +13233,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "16.4.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
-      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+      "version": "18.0.9",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.9.tgz",
+      "integrity": "sha512-/Sa4qiiHZxf0/FQdBBowr9q4r10krCwMvpK48FUBdXdUXScDxiQGR9zCPrFgRVR5LU3iySOiIjy09ZQvADir1w==",
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "drizzle-orm": "^0.45.2",
     "isomorphic-dompurify": "3.22.0",
     "lucide-react": "^1.30.0",
-    "marked": "^16.3.0",
+    "marked": "^18.0.9",
     "next": "^16.3.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",


### PR DESCRIPTION
Supersedes #58, whose CI never re-ran after the Next 16 toolchain fix landed — its last run predates #64 and is not meaningful.

Verified locally against current `main`. `marked` has a single consumer, `app/admin/page.tsx`, and needed no changes.

## Validation

- `npm run lint` — 0 errors
- `npm run typecheck`
- `npm test` — 117 files, 654 tests
- `npm run build` — compiled