### PR TITLE
chore(deps): upgrade Clerk, Stripe, web-vitals, marked, and TypeScript

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -119,7 +119,7 @@ export default function RootLayout({
   return (
     <ClerkProvider
       appearance={{
-        baseTheme: dark,
+        theme: dark,
       }}
     >
       <html lang="en" suppressHydrationWarning>

--- a/components/checkout/PaymentForm.tsx
+++ b/components/checkout/PaymentForm.tsx
@@ -70,7 +70,8 @@ export default function PaymentForm({
     layout: {
       type: 'tabs',
       defaultCollapsed: false,
-      radios: false,
+      // stripe-js 9 replaced the boolean with an enum; false became 'never'.
+      radios: 'never',
       spacedAccordionItems: isMobileSafari // More spacing on mobile Safari
     },
     paymentMethodOrder: ['card', 'apple_pay', 'google_pay'],

--- a/components/login/ClerkLogin.tsx
+++ b/components/login/ClerkLogin.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { SignInButton, SignedIn, SignedOut, UserButton } from "@clerk/nextjs";
+import { SignInButton, Show, UserButton } from "@clerk/nextjs";
 import { Button } from "@/components/ui/button";
 import { LogIn, Package, Shield } from "lucide-react";
 import { useState, useEffect } from "react";
@@ -36,7 +36,7 @@ export default function ClerkLogin() {
 
   return (
     <>
-      <SignedOut>
+      <Show when="signed-out">
         <SignInButton mode="modal">
           <Button
             variant="ghost"
@@ -45,9 +45,9 @@ export default function ClerkLogin() {
             <LogIn className="mr-2 h-4 w-4" /> Sign In / Register
           </Button>
         </SignInButton>
-      </SignedOut>
+      </Show>
 
-      <SignedIn>
+      <Show when="signed-in">
         <UserButton appearance={{ elements: { avatarBox: "w-8 h-8" } }}>
           <UserButton.MenuItems>
             <UserButton.Link
@@ -64,7 +64,7 @@ export default function ClerkLogin() {
             )}
           </UserButton.MenuItems>
         </UserButton>
-      </SignedIn>
+      </Show>
     </>
   );
 }

--- a/lib/hooks/useWebVitals.ts
+++ b/lib/hooks/useWebVitals.ts
@@ -86,6 +86,11 @@ export function useWebVitals() {
                 : "good",
           entries: [],
           navigationType: "navigate",
+          // web-vitals 6 requires a navigationId so a metric can be attributed
+          // to a soft navigation. This metric is synthesized from a touch
+          // rather than reported by the library, so it belongs to the initial
+          // navigation.
+          navigationId: 1,
           userAgent: navigator.userAgent,
           isMobile: true,
         };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@clerk/nextjs": "^6.39.6",
-        "@clerk/themes": "^2.4.0",
+        "@clerk/nextjs": "^7.7.4",
+        "@clerk/themes": "^2.4.57",
         "@radix-ui/react-alert-dialog": "^1.1.23",
         "@radix-ui/react-checkbox": "^1.3.11",
         "@radix-ui/react-dialog": "^1.1.14",
@@ -27,8 +27,8 @@
         "@react-email/components": "^1.0.12",
         "@react-email/render": "^2.1.0",
         "@shadcn/ui": "^0.0.4",
-        "@stripe/react-stripe-js": "^3.9.0",
-        "@stripe/stripe-js": "^7.8.0",
+        "@stripe/react-stripe-js": "^6.8.1",
+        "@stripe/stripe-js": "^9.13.0",
         "@tailwindcss/typography": "^0.5.20",
         "big.js": "^7.0.1",
         "class-variance-authority": "^0.7.1",
@@ -36,7 +36,7 @@
         "drizzle-orm": "^0.45.2",
         "isomorphic-dompurify": "3.22.0",
         "lucide-react": "^1.30.0",
-        "marked": "^16.3.0",
+        "marked": "^18.0.9",
         "next": "^16.3.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -47,7 +47,7 @@
         "sonner": "^2.0.6",
         "stripe": "^22.4.0",
         "tailwind-merge": "^3.6.0",
-        "web-vitals": "^5.1.0",
+        "web-vitals": "^6.1.0",
         "zustand": "^5.0.6"
       },
       "devDependencies": {
@@ -68,7 +68,7 @@
         "tailwindcss": "^4.3.3",
         "tsx": "^4.23.11",
         "tw-animate-css": "^1.3.5",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "vitest": "^4.1.10",
         "wrangler": "^4.120.0"
       },
@@ -1590,57 +1590,136 @@
       }
     },
     "node_modules/@clerk/backend": {
-      "version": "2.33.6",
-      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-2.33.6.tgz",
-      "integrity": "sha512-5foMmTHEQFt4mDv7AN0RDwUHZhGcg/JYe5hnl9SU/LFS8ZHY29Z2HDtIBmzKgjRfOJTMKj1AM81LgK2UFsGm9Q==",
+      "version": "3.16.4",
+      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.16.4.tgz",
+      "integrity": "sha512-7A9YlBLesYgKFn4DcaCq64Ggezmbzx+xYdWsiQLrMQV+U4Bm9LtDdyaNirQ0SStSsZy6PzL8RHw5zMmmEt0zMA==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "^3.47.8",
-        "@clerk/types": "^4.101.26",
+        "@clerk/shared": "^4.28.1",
         "standardwebhooks": "^1.0.0",
         "tslib": "2.8.1"
       },
       "engines": {
-        "node": ">=18.17.0"
+        "node": ">=20.9.0"
       }
     },
-    "node_modules/@clerk/clerk-react": {
-      "version": "5.61.9",
-      "resolved": "https://registry.npmjs.org/@clerk/clerk-react/-/clerk-react-5.61.9.tgz",
-      "integrity": "sha512-PRIodE1QVem/eV3wrjicJJiJ2pkGiZfI6t1vekE/+04cIHciXyvUezQ/468gGPl31xd7BiCNO3uKNM14TXEKZQ==",
+    "node_modules/@clerk/backend/node_modules/@clerk/shared": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.28.1.tgz",
+      "integrity": "sha512-OhpUczN6t8CYJ+g8HdzN1O4SFC2EANOZRDwlE3rXxKu13eNtyFbLspt+d6Nhb/PmcThS/fIAKYnQQrwv0vIEwg==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "^3.47.8",
-        "tslib": "2.8.1"
+        "@tanstack/query-core": "^5.100.6",
+        "dequal": "2.0.3",
+        "glob-to-regexp": "0.4.1",
+        "js-cookie": "3.0.7"
       },
       "engines": {
-        "node": ">=18.17.0"
+        "node": ">=20.9.0"
       },
       "peerDependencies": {
         "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
         "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/@clerk/nextjs": {
-      "version": "6.39.6",
-      "resolved": "https://registry.npmjs.org/@clerk/nextjs/-/nextjs-6.39.6.tgz",
-      "integrity": "sha512-bfB1mt1kFdlV2khNdJPP4Zynrz6XfXjqiJogEHWpeK0ch46uWX7lNN9wrstkokDMHTmvpVkDZPAKkncdK3vZ6w==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@clerk/nextjs/-/nextjs-7.7.4.tgz",
+      "integrity": "sha512-i+H7HTssKVpIgI93s0jeHicjXDjaAVCApmHi0xQi0tFV9mT1jOvw7KcZYVZIseh2JYW1ForS+A3Xy8MgvVC4Sg==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/backend": "^2.33.6",
-        "@clerk/clerk-react": "^5.61.9",
-        "@clerk/shared": "^3.47.8",
-        "@clerk/types": "^4.101.26",
+        "@clerk/backend": "^3.16.4",
+        "@clerk/react": "^6.14.1",
+        "@clerk/shared": "^4.28.1",
         "server-only": "0.0.1",
         "tslib": "2.8.1"
       },
       "engines": {
-        "node": ">=18.17.0"
+        "node": ">=20.9.0"
       },
       "peerDependencies": {
-        "next": "^13.5.7 || ^14.2.25 || ^15.2.3 || ^16",
+        "next": "^15.2.8 || ^15.3.8 || ^15.4.10 || ^15.5.9 || ^15.6.0-0 || ^16.0.10 || ^16.1.0-0",
         "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
         "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
+      }
+    },
+    "node_modules/@clerk/nextjs/node_modules/@clerk/shared": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.28.1.tgz",
+      "integrity": "sha512-OhpUczN6t8CYJ+g8HdzN1O4SFC2EANOZRDwlE3rXxKu13eNtyFbLspt+d6Nhb/PmcThS/fIAKYnQQrwv0vIEwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "^5.100.6",
+        "dequal": "2.0.3",
+        "glob-to-regexp": "0.4.1",
+        "js-cookie": "3.0.7"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
+        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@clerk/react": {
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/@clerk/react/-/react-6.14.1.tgz",
+      "integrity": "sha512-rSFJUyfOuMeySbmkTv+g4DpPp492lpgVKERtrzm0wo+PwnWXoGjVkrpWb6mZMKLQAvq2dU2LnKitljcbLDKUXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/shared": "^4.28.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
+        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
+      }
+    },
+    "node_modules/@clerk/react/node_modules/@clerk/shared": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.28.1.tgz",
+      "integrity": "sha512-OhpUczN6t8CYJ+g8HdzN1O4SFC2EANOZRDwlE3rXxKu13eNtyFbLspt+d6Nhb/PmcThS/fIAKYnQQrwv0vIEwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "^5.100.6",
+        "dequal": "2.0.3",
+        "glob-to-regexp": "0.4.1",
+        "js-cookie": "3.0.7"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
+        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/@clerk/shared": {
@@ -1681,18 +1760,6 @@
       "dependencies": {
         "@clerk/shared": "^3.47.2",
         "tslib": "2.8.1"
-      },
-      "engines": {
-        "node": ">=18.17.0"
-      }
-    },
-    "node_modules/@clerk/types": {
-      "version": "4.101.26",
-      "resolved": "https://registry.npmjs.org/@clerk/types/-/types-4.101.26.tgz",
-      "integrity": "sha512-tUeiElAZoXu9Dxom9t6IjkEfsfP7aWSVf5x5mCoHnSr2w+wV4EtEwoLl9vexT5LL0di4qidROSfcrOnorzczIQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@clerk/shared": "^3.47.8"
       },
       "engines": {
         "node": ">=18.17.0"
@@ -7142,23 +7209,23 @@
       "license": "MIT"
     },
     "node_modules/@stripe/react-stripe-js": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@stripe/react-stripe-js/-/react-stripe-js-3.10.0.tgz",
-      "integrity": "sha512-UPqHZwMwDzGSax0ZI7XlxR3tZSpgIiZdk3CiwjbTK978phwR/fFXeAXQcN/h8wTAjR4ZIAzdlI9DbOqJhuJdeg==",
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@stripe/react-stripe-js/-/react-stripe-js-6.8.1.tgz",
+      "integrity": "sha512-Wzy7KCF8lM819x8rVFSKUr2ofITdX1c/49ceJprJzGhPzHb3fhrcAoEmNQwV5UYRci7YY1joyG8oz3So3JAMRg==",
       "license": "MIT",
       "dependencies": {
         "prop-types": "^15.7.2"
       },
       "peerDependencies": {
-        "@stripe/stripe-js": ">=1.44.1 <8.0.0",
+        "@stripe/stripe-js": ">=9.5.0 <10.0.0",
         "react": ">=16.8.0 <20.0.0",
         "react-dom": ">=16.8.0 <20.0.0"
       }
     },
     "node_modules/@stripe/stripe-js": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-7.9.0.tgz",
-      "integrity": "sha512-ggs5k+/0FUJcIgNY08aZTqpBTtbExkJMYMLSMwyucrhtWexVOEY1KJmhBsxf+E/Q15f5rbwBpj+t0t2AW2oCsQ==",
+      "version": "9.13.0",
+      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-9.13.0.tgz",
+      "integrity": "sha512-/0c72BUgzzVkVTlsw5uBn8x3waTdVJ/PZGfQ6jY1eu6K7olUPf4d9lgDPA9/0sIdsR8j7o3QIG8fOCO6ItcL7A==",
       "license": "MIT",
       "engines": {
         "node": ">=12.16"
@@ -7532,6 +7599,16 @@
       },
       "peerDependencies": {
         "tailwindcss": ">=3.0.0 || >=4.0.0 || insiders"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.101.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.4.tgz",
+      "integrity": "sha512-gNwcvOJcRbLWPOLG/2OBm+zM+Yv+MKsXKEOWC57USuZDEsI71hEErQsiEGx5wX9rzWWkfwM0fVSPoiIFSsxfiw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tsconfig/node18": {
@@ -13233,9 +13310,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "16.4.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
-      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+      "version": "18.0.9",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.9.tgz",
+      "integrity": "sha512-/Sa4qiiHZxf0/FQdBBowr9q4r10krCwMvpK48FUBdXdUXScDxiQGR9zCPrFgRVR5LU3iySOiIjy09ZQvADir1w==",
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
@@ -17053,9 +17130,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -17791,9 +17868,9 @@
       }
     },
     "node_modules/web-vitals": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.3.0.tgz",
-      "integrity": "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-6.1.0.tgz",
+      "integrity": "sha512-ZNoJ/MbU6aaR2WjKrFVUvy5WQx+G96YvXQFSsmKTz3A/0VlAFywjUcxl00hc/S6wef2stfgQ4yWYIJCWCNudkA==",
       "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "token:revoke": "tsx scripts/manage-tokens.ts revoke"
   },
   "dependencies": {
-    "@clerk/nextjs": "^6.39.6",
-    "@clerk/themes": "^2.4.0",
+    "@clerk/nextjs": "^7.7.4",
+    "@clerk/themes": "^2.4.57",
     "@radix-ui/react-alert-dialog": "^1.1.23",
     "@radix-ui/react-checkbox": "^1.3.11",
     "@radix-ui/react-dialog": "^1.1.14",
@@ -53,8 +53,8 @@
     "@react-email/components": "^1.0.12",
     "@react-email/render": "^2.1.0",
     "@shadcn/ui": "^0.0.4",
-    "@stripe/react-stripe-js": "^3.9.0",
-    "@stripe/stripe-js": "^7.8.0",
+    "@stripe/react-stripe-js": "^6.8.1",
+    "@stripe/stripe-js": "^9.13.0",
     "@tailwindcss/typography": "^0.5.20",
     "big.js": "^7.0.1",
     "class-variance-authority": "^0.7.1",
@@ -62,7 +62,7 @@
     "drizzle-orm": "^0.45.2",
     "isomorphic-dompurify": "3.22.0",
     "lucide-react": "^1.30.0",
-    "marked": "^16.3.0",
+    "marked": "^18.0.9",
     "next": "^16.3.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
@@ -73,7 +73,7 @@
     "sonner": "^2.0.6",
     "stripe": "^22.4.0",
     "tailwind-merge": "^3.6.0",
-    "web-vitals": "^5.1.0",
+    "web-vitals": "^6.1.0",
     "zustand": "^5.0.6"
   },
   "devDependencies": {
@@ -94,7 +94,7 @@
     "tailwindcss": "^4.3.3",
     "tsx": "^4.23.11",
     "tw-animate-css": "^1.3.5",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.10",
     "wrangler": "^4.120.0"
   }


### PR DESCRIPTION
Supersedes #65, #67, #68, #69, #70. They share one lockfile, so landing them separately means rebasing and revalidating the rest after each merge, and five deployments where one will do.

## Contents

| Package | From → To | Source change |
|---|---|---|
| `@clerk/nextjs` | 6.39.6 → 7.7.4 | `SignedIn`/`SignedOut` → `Show`, `baseTheme` → `theme` |
| `@stripe/stripe-js` | 7.9.0 → 9.13.0 | `radios: false` → `'never'` |
| `@stripe/react-stripe-js` | 3.10.0 → 6.8.1 | (peer-locked to the above) |
| `web-vitals` | 5.3.0 → 6.1.0 | `navigationId` on the synthetic touch metric |
| `marked` | 16.4.2 → 18.0.9 | none |
| `typescript` | 5.9.3 → 6.0.3 | none |

## Why the Stripe packages are one change

`react-stripe-js@6` peers `stripe-js@>=9.5.0 <10`; the installed `react-stripe-js@3` peered `<8.0.0`. Each Dependabot PR failed at `npm ci` with ERESOLVE because neither package can cross that boundary alone.

## Why TypeScript 6 and not 7

`typescript-eslint` has no support for the TypeScript 7 compiler API and `eslint-config-next` depends on it, so linting aborts before reading a file. The compiler and the build are fine on 7 — only linting is blocked. 7.x is held in `.github/dependabot.yml` with the tracking issue recorded.

## Validation (Node 24.18.1)

- `npm run lint` — 0 errors, 56 warnings (the pre-existing React Compiler backlog)
- `npm run typecheck`
- `npm test` — 117 files, 654 tests
- `npm run test:workers` — 12 files, 61 tests
- `npm run build` — compiled, 55/55 static pages

Each upgrade was also verified individually on its own branch before being combined.

## Not covered by tests

Nothing here exercises a live card payment or a real sign-in. Both surfaces change in this PR, so checkout and sign-in/sign-out are worth exercising by hand after it deploys.