### PR TITLE
feat(migration): add safe Shopify migration toolkit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,13 @@ linkedin-article.md
 !/migrations/**
 !/data/d1/**
 !/tests/fixtures/**
+
+# Operator migration inputs and generated artifacts may contain customer data.
+/scripts/shopify-migration/input/**
+/scripts/shopify-migration/data/**
+/scripts/shopify-migration/output/**
+/scripts/shopify-migration/**/*.log
+/scripts/shopify-migration/**/id-map*.json
+/scripts/shopify-migration/**/manifest*.json
+!/scripts/shopify-migration/input/.gitkeep
+!/scripts/shopify-migration/output/.gitkeep

--- a/app/media/[...key]/route.ts
+++ b/app/media/[...key]/route.ts
@@ -1,12 +1,10 @@
 import { getCloudflareContext } from "@opennextjs/cloudflare";
+import { resolvePublicMediaKey } from "@/lib/media/public-key";
 
 interface RouteContext {
   params: Promise<{ key?: string[] }>;
 }
 
-const PUBLIC_MEDIA_PREFIXES = new Set(["products", "categories", "blog", "pages"]);
-const SAFE_KEY_SEGMENT = /^[A-Za-z0-9][A-Za-z0-9._~-]*$/;
-const MAX_KEY_LENGTH = 1024;
 const REVALIDATING_CACHE = "public, max-age=0, must-revalidate";
 const INERT_MEDIA_CSP = "default-src 'none'; sandbox";
 
@@ -29,28 +27,6 @@ function simpleResponse(message: string, status: number, head = false): Response
       "X-Content-Type-Options": "nosniff",
     },
   });
-}
-
-/** Next has already decoded dynamic route params; never decode them again. */
-export function resolvePublicMediaKey(segments: readonly string[] | undefined): string | null {
-  if (!segments || segments.length < 2 || !PUBLIC_MEDIA_PREFIXES.has(segments[0])) return null;
-  if (segments.length > 12) return null;
-
-  for (const segment of segments) {
-    if (
-      segment.length > 255
-      || !SAFE_KEY_SEGMENT.test(segment)
-      || segment === "."
-      || segment === ".."
-      || segment.includes("%")
-      || segment.includes("\\")
-    ) {
-      return null;
-    }
-  }
-
-  const key = segments.join("/");
-  return key.length <= MAX_KEY_LENGTH ? key : null;
 }
 
 function verifiedContentType(object: R2Object): string | null {

--- a/app/media/[...key]/route.ts
+++ b/app/media/[...key]/route.ts
@@ -8,6 +8,7 @@ const PUBLIC_MEDIA_PREFIXES = new Set(["products", "categories", "blog", "pages"
 const SAFE_KEY_SEGMENT = /^[A-Za-z0-9][A-Za-z0-9._~-]*$/;
 const MAX_KEY_LENGTH = 1024;
 const IMMUTABLE_CACHE = "public, max-age=31536000, immutable";
+const INERT_MEDIA_CSP = "default-src 'none'; sandbox";
 
 const CONTENT_TYPES_BY_EXTENSION: Readonly<Record<string, string>> = {
   avif: "image/avif",
@@ -23,6 +24,7 @@ function simpleResponse(message: string, status: number, head = false): Response
     status,
     headers: {
       "Cache-Control": "no-store",
+      "Content-Security-Policy": INERT_MEDIA_CSP,
       "Content-Type": "text/plain; charset=utf-8",
       "X-Content-Type-Options": "nosniff",
     },
@@ -63,6 +65,7 @@ function verifiedContentType(object: R2Object): string | null {
 function responseHeaders(object: R2Object, contentType: string): Headers {
   const headers = new Headers({
     "Cache-Control": IMMUTABLE_CACHE,
+    "Content-Security-Policy": INERT_MEDIA_CSP,
     "Content-Length": String(object.size),
     "Content-Type": contentType,
     "ETag": object.httpEtag,

--- a/app/media/[...key]/route.ts
+++ b/app/media/[...key]/route.ts
@@ -111,7 +111,7 @@ async function serveMedia(request: Request, context: RouteContext, head: boolean
 
     if (head) return new Response(null, { status: 200, headers });
     if (!("body" in object) || !object.body) return simpleResponse("Service unavailable", 503, head);
-    return new Response(object.body, { status: 200, headers });
+    return new Response(object.body as ReadableStream, { status: 200, headers });
   } catch {
     return simpleResponse("Service unavailable", 503, head);
   }

--- a/app/media/[...key]/route.ts
+++ b/app/media/[...key]/route.ts
@@ -7,7 +7,7 @@ interface RouteContext {
 const PUBLIC_MEDIA_PREFIXES = new Set(["products", "categories", "blog", "pages"]);
 const SAFE_KEY_SEGMENT = /^[A-Za-z0-9][A-Za-z0-9._~-]*$/;
 const MAX_KEY_LENGTH = 1024;
-const IMMUTABLE_CACHE = "public, max-age=31536000, immutable";
+const REVALIDATING_CACHE = "public, max-age=0, must-revalidate";
 const INERT_MEDIA_CSP = "default-src 'none'; sandbox";
 
 const CONTENT_TYPES_BY_EXTENSION: Readonly<Record<string, string>> = {
@@ -64,7 +64,7 @@ function verifiedContentType(object: R2Object): string | null {
 
 function responseHeaders(object: R2Object, contentType: string): Headers {
   const headers = new Headers({
-    "Cache-Control": IMMUTABLE_CACHE,
+    "Cache-Control": REVALIDATING_CACHE,
     "Content-Security-Policy": INERT_MEDIA_CSP,
     "Content-Length": String(object.size),
     "Content-Type": contentType,

--- a/app/media/[...key]/route.ts
+++ b/app/media/[...key]/route.ts
@@ -1,0 +1,123 @@
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+
+interface RouteContext {
+  params: Promise<{ key?: string[] }>;
+}
+
+const PUBLIC_MEDIA_PREFIXES = new Set(["products", "categories", "blog", "pages"]);
+const SAFE_KEY_SEGMENT = /^[A-Za-z0-9][A-Za-z0-9._~-]*$/;
+const MAX_KEY_LENGTH = 1024;
+const IMMUTABLE_CACHE = "public, max-age=31536000, immutable";
+
+const CONTENT_TYPES_BY_EXTENSION: Readonly<Record<string, string>> = {
+  avif: "image/avif",
+  gif: "image/gif",
+  jpeg: "image/jpeg",
+  jpg: "image/jpeg",
+  png: "image/png",
+  webp: "image/webp",
+};
+
+function simpleResponse(message: string, status: number, head = false): Response {
+  return new Response(head ? null : message, {
+    status,
+    headers: {
+      "Cache-Control": "no-store",
+      "Content-Type": "text/plain; charset=utf-8",
+      "X-Content-Type-Options": "nosniff",
+    },
+  });
+}
+
+/** Next has already decoded dynamic route params; never decode them again. */
+export function resolvePublicMediaKey(segments: readonly string[] | undefined): string | null {
+  if (!segments || segments.length < 2 || !PUBLIC_MEDIA_PREFIXES.has(segments[0])) return null;
+  if (segments.length > 12) return null;
+
+  for (const segment of segments) {
+    if (
+      segment.length > 255
+      || !SAFE_KEY_SEGMENT.test(segment)
+      || segment === "."
+      || segment === ".."
+      || segment.includes("%")
+      || segment.includes("\\")
+    ) {
+      return null;
+    }
+  }
+
+  const key = segments.join("/");
+  return key.length <= MAX_KEY_LENGTH ? key : null;
+}
+
+function verifiedContentType(object: R2Object): string | null {
+  const extension = object.key.split(".").pop()?.toLowerCase();
+  if (!extension) return null;
+  const expected = CONTENT_TYPES_BY_EXTENSION[extension];
+  const declared = object.httpMetadata?.contentType?.split(";", 1)[0].trim().toLowerCase();
+  const normalizedDeclared = declared === "image/jpg" ? "image/jpeg" : declared;
+  return expected && normalizedDeclared === expected ? expected : null;
+}
+
+function responseHeaders(object: R2Object, contentType: string): Headers {
+  const headers = new Headers({
+    "Cache-Control": IMMUTABLE_CACHE,
+    "Content-Length": String(object.size),
+    "Content-Type": contentType,
+    "ETag": object.httpEtag,
+    "X-Content-Type-Options": "nosniff",
+  });
+  if (object.uploaded instanceof Date && Number.isFinite(object.uploaded.getTime())) {
+    headers.set("Last-Modified", object.uploaded.toUTCString());
+  }
+  return headers;
+}
+
+function etagMatches(header: string | null, etag: string): boolean {
+  if (!header) return false;
+  const normalizedEtag = etag.startsWith("W/") ? etag.slice(2) : etag;
+  return header.split(",").some((value) => {
+    const candidate = value.trim();
+    return candidate === "*" || (candidate.startsWith("W/") ? candidate.slice(2) : candidate) === normalizedEtag;
+  });
+}
+
+async function serveMedia(request: Request, context: RouteContext, head: boolean): Promise<Response> {
+  const { key: segments } = await context.params;
+  const key = resolvePublicMediaKey(segments);
+  if (!key) return simpleResponse("Not found", 404, head);
+
+  try {
+    const { env } = await getCloudflareContext({ async: true });
+    const bucket: CloudflareEnv["MEDIA"] | undefined = env.MEDIA;
+    if (!bucket) return simpleResponse("Service unavailable", 503, head);
+
+    const object = head ? await bucket.head(key) : await bucket.get(key);
+    if (!object) return simpleResponse("Not found", 404, head);
+
+    const contentType = verifiedContentType(object);
+    if (!contentType) return simpleResponse("Not found", 404, head);
+
+    const headers = responseHeaders(object, contentType);
+    if (etagMatches(request.headers.get("if-none-match"), object.httpEtag)) {
+      headers.delete("Content-Length");
+      headers.delete("Content-Type");
+      return new Response(null, { status: 304, headers });
+    }
+
+    if (head) return new Response(null, { status: 200, headers });
+    if (!("body" in object) || !object.body) return simpleResponse("Service unavailable", 503, head);
+    return new Response(object.body, { status: 200, headers });
+  } catch {
+    return simpleResponse("Service unavailable", 503, head);
+  }
+}
+
+export function GET(request: Request, context: RouteContext): Promise<Response> {
+  return serveMedia(request, context, false);
+}
+
+export function HEAD(request: Request, context: RouteContext): Promise<Response> {
+  return serveMedia(request, context, true);
+}

--- a/docs/migration-reservations.md
+++ b/docs/migration-reservations.md
@@ -6,7 +6,8 @@ ledger. Reservations prevent parallel feature branches from reusing a number.
 | Migration | Owner | Purpose | State |
 | --- | --- | --- | --- |
 | `0018` | `O01` | Email preferences and unsubscribe suppression | Merged |
-| `0019` | `O02` | Blog and neutral structured content publishing | Reserved on `agent/o02-content-publishing` |
+| `0019` | `O02` | Blog and neutral structured content publishing | Merged |
+| `0020` | `O05` | Exact legacy URL redirect map | Reserved on `agent/o05-shopify-migration-toolkit` |
 
-The next schema-bearing extraction must start at `0020` and reconcile against
+The next schema-bearing extraction must start at `0021` and reconcile against
 the then-current main branch before it commits a migration.

--- a/docs/shopify-migration.md
+++ b/docs/shopify-migration.md
@@ -1,0 +1,163 @@
+# Shopify migration toolkit
+
+The operator-only Shopify migration toolkit imports catalog, content, media, customers, historical orders, and optionally Judge.me reviews into Mercora. It defaults to a local dry run. A dry run extracts and transforms data, resolves the named Wrangler targets, and builds the complete D1 plan without constructing R2, Clerk, or D1 write adapters.
+
+The toolkit is deliberately fail-fast between phases. An apply validates deterministic source transforms before it obtains write adapters, then executes in this order:
+
+1. verify and persist Shopify media to the Wrangler `MEDIA` R2 bucket;
+2. resolve existing Clerk identities and, only when separately authorized, create source-verified customer identities;
+3. rebuild the identity-dependent order/review plan, run the D1 schema preflight, apply dependency-ordered chunks, and validate the result.
+
+It does not deploy Mercora, create Cloudflare resources, migrate schemas, obtain credentials, send email, or change Shopify/Judge.me.
+
+## Prerequisites
+
+- Node 24 and the repository dependencies installed locally.
+- Mercora database migrations `0001` through `0020` already applied to the selected D1 database.
+- A reviewed `wrangler.jsonc` with exactly one canonical `DB` binding and one canonical `MEDIA` binding for the selected environment. Use `MIGRATION_DATABASE_NAME` or `--expected-database-name` to pin the expected D1 name.
+- A stable inventory location ID, page/blog actor ID, fallback blog author, ISO-4217 currency, fulfillment type, and unresolved-customer policy chosen by the merchant.
+- An operator-created private input directory. Never place exports in the repository or a web-served directory.
+- For API extraction, an exact `https://{shop}.myshopify.com` origin, a pinned quarterly Admin API version, and a read-only Shopify access token scoped only to the resources being migrated.
+- For apply, Cloudflare R2 S3 credentials limited to the target bucket and the existing local Wrangler authentication/configuration needed by the D1 runner.
+
+Run Mercora's normal tests and deployment preflight before beginning. Confirm the selected Wrangler environment and binding names independently; the migration refuses ambiguous or mismatched targets, but an operator is still responsible for selecting the intended account.
+
+## Private input layout
+
+File mode accepts JSON or CSV files with these basenames. Provide an empty array for a resource with no records so a missing export is not mistaken for an empty export.
+
+```text
+private-shopify-export/
+  custom_collections.json
+  smart_collections.json
+  collects.json
+  products.json
+  pages.json
+  blogs.json
+  articles.json
+  redirects.json
+  customers.json             # only with sensitive import
+  orders.json                # only with sensitive import
+  judge-me-reviews.csv       # optional, sensitive
+  review-attributions.json   # optional, sensitive
+  verified-purchases.json    # optional, sensitive
+```
+
+API mode reads collections, collects, products, pages, blogs/articles, redirects, and—when confirmed—customers and all order statuses. Judge.me remains a bounded local CSV input, so API mode also needs `MIGRATION_INPUT_ROOT` when `JUDGE_ME_FILE` is set.
+
+Review attribution files are JSON arrays. Every item contains a `reviewFingerprint` plus the final Mercora `productId`, historical `orderId`, Clerk `customerId`, and optional `orderItemId`. Verified-purchase rows contain the same identifiers and `verified: true`. The toolkit rejects missing, duplicate, synthetic, or contradictory attribution rather than inventing purchase history.
+
+## Required configuration
+
+Use environment variables for values and secrets; command-line flags are available for non-secret migration decisions.
+
+```text
+MIGRATION_INPUT_ROOT=/absolute/private/input
+MIGRATION_CURRENCY=USD
+MIGRATION_INVENTORY_LOCATION_ID=main
+MIGRATION_FULFILLMENT_TYPE=physical
+MIGRATION_ACTOR_ID=user_operator
+MIGRATION_FALLBACK_AUTHOR=Store team
+MIGRATION_MEDIA_HOSTS=cdn.shopify.com,store.myshopify.com
+MIGRATION_UNRESOLVED_CUSTOMER=reject
+MIGRATION_DATABASE_NAME=mercora-db
+```
+
+Allowed fulfillment values are `physical`, `digital`, and `service`. The unresolved-customer policy must explicitly be `reject` or `guest`; `reject` is the safer default for historical orders.
+
+`MIGRATION_MEDIA_HOSTS` is an explicit allowlist, but it cannot broaden the toolkit's trust boundary. Media is accepted only from exact Shopify-owned asset hosts: `cdn.shopify.com`, or an exact `*.myshopify.com` host with a `/cdn/` path. Arbitrary custom CDNs are intentionally unsupported. Inline external images that fail this policy are removed from imported HTML.
+
+API mode additionally requires:
+
+```text
+MIGRATION_SOURCE_MODE=api
+SHOPIFY_STORE_URL=https://store.myshopify.com
+SHOPIFY_ACCESS_TOKEN=private-read-token
+SHOPIFY_API_VERSION=2026-07
+```
+
+Apply-only R2 credentials are read from `CLOUDFLARE_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, and `R2_SECRET_ACCESS_KEY`. Clerk uses `CLERK_SECRET_KEY`. Secrets are never accepted as command-line flags, written to the manifest, or admitted into structured logs.
+
+## Dry run
+
+Dry run is the default:
+
+```sh
+npm run migrate:shopify
+```
+
+The single JSON report written to stdout is non-authoritative and contains only target labels, aggregate counts, and phase results. It does not contain source records, customer fields, order data, emails, addresses, raw provider IDs, or credentials. A dry run does not write a manifest file and does not construct or call R2, Clerk, or D1 write adapters.
+
+Review every skipped and warning count. The detailed transform code uses one-way source fingerprints in operational warnings; source payloads are never logged. Fix or deliberately accept the source condition before applying. Re-run the same dry run after every export or configuration change.
+
+## Sensitive data and Clerk
+
+Customers, orders, and Judge.me inputs require both flags:
+
+```sh
+npm run migrate:shopify -- --include-sensitive --confirm-sensitive-data
+```
+
+This confirmation permits the process to read customer names, email addresses, phone/address fields, historical orders, and review attribution. It does not authorize identity creation.
+
+During apply, existing Clerk users are resolved only by an exact migration external ID. An email lookup detects ownership conflicts but never silently links an unrelated identity. Customers without a resolved Clerk identity are reconciled or skipped according to the downstream policy.
+
+Clerk's backend `createUser` operation treats supplied email addresses as verified. Creation is therefore disabled unless all of these are present:
+
+```text
+--apply
+--include-sensitive
+--confirm-sensitive-data
+--create-clerk-users
+--confirm-clerk-auto-verification
+```
+
+Even then, the toolkit creates an identity only when Shopify marked the source email verified. It does not send an invitation, create a password, or auto-link by email. The operator must review Clerk reconciliation counts before treating the migration as complete.
+
+Judge.me is enabled with `--judge-me-file=judge-me-reviews.csv`. Add `--review-attributions=review-attributions.json` and, if available, `--verified-purchases=verified-purchases.json`. A review without real matching product, order, Clerk customer, and optional line-item attribution is skipped. Historical Shopify payments remain non-authoritative and are never imported as Mercora-paid effects.
+
+## Apply targets
+
+Local apply requires `--apply`. Remote targets also require an explicit target and matching confirmation:
+
+```sh
+npm run migrate:shopify -- --apply --target=local
+npm run migrate:shopify -- --apply --target=preview --confirm-preview
+MERCORA_ALLOW_PRODUCTION_IMPORTS=1 npm run migrate:shopify -- --apply --target=production --confirm-production
+```
+
+Use `--env=<wrangler-environment>` when the reviewed bindings live in a named Wrangler environment. Production's environment variable is an additional circuit breaker, not a substitute for the target and confirmation flags.
+
+Existing merchant rows are compare-only by default. A semantic mismatch aborts instead of overwriting merchant changes. Overwrite mode requires both `--overwrite` and `--confirm-overwrite`; use it only after reviewing the exact conflict and taking a backup.
+
+For an apply report written as a private atomic `0600` file, set `MIGRATION_OUTPUT_ROOT` to a private existing directory. The resulting `manifest.json` contains aggregate counts only. Export files, attribution files, SQL chunks, logs, ID maps, and manifests are ignored by the repository's migration artifact rules, but operators must still verify they are not staged or uploaded.
+
+## Deployment order
+
+1. Merge and deploy a Mercora release that includes migration `0020`, `/media/*` object serving, and exact legacy redirect lookup.
+2. Apply all Mercora migrations to the chosen D1 target and verify the normal deployment preflight.
+3. Take and verify an independent D1 backup using the current Wrangler D1 export workflow. Record the target database and bucket outside the repository.
+4. Run the complete migration as a dry run against the same target selection.
+5. Apply to local or preview, verify catalog/content pages, media headers, customer/order visibility, and exact legacy URLs.
+6. Repeat the dry run immediately before production, then run the separately confirmed production apply.
+7. Retain the private source exports, reviewed report, backup, and reconciliation list according to the merchant's data-retention policy.
+
+R2 is applied before D1 so imported rows never intentionally reference media that has not been cryptographically verified as written or already identical. Clerk precedes customer/order D1 rows because Mercora customer primary keys must be final `user_*` IDs.
+
+## Resuming and rerunning
+
+Transforms use deterministic provider fingerprints and target IDs. Media writes use conditional creation and verify existing object metadata/content hashes. Clerk uses the source fingerprint as its external identity. D1 inserts compare existing content unless overwrite was separately confirmed. Consequently, the supported resume procedure is to correct the failed prerequisite and rerun the same inputs and options from the beginning.
+
+Do not edit a manifest to force progress and do not treat it as an authoritative checkpoint. If source exports or domain decisions change, start with a new dry run and review the new counts.
+
+## Disable and rollback
+
+There is no automatic cross-service rollback: R2, Clerk, and chunked D1 operations cannot share one transaction. Before production, maintain a verified D1 backup and a reviewed list of the target resources.
+
+If an apply fails before D1, no imported storefront rows should be active; retain media objects and Clerk reconciliation state until the cause is understood, then rerun. Do not automatically delete Clerk users because they may have become real account identities.
+
+If D1 has begun, stop further applies and storefront deployment changes. Restore the verified D1 backup or remove only fingerprint-proven imported rows in reverse dependency order under a separately reviewed recovery plan. Exact legacy redirects can be disabled by removing only their imported `redirect_map` rows. R2 objects are inert when no D1 content references their `/media/*` paths and can be removed later from the recorded import key set. Rotate or revoke the temporary Shopify/R2 credentials after the migration window.
+
+## Media validation boundary
+
+The downloader bounds redirects, DNS destinations, response time, declared/streamed bytes, and accepted content types. It parses JPEG marker structure, PNG chunks, and WebP RIFF/image payload structure before upload. This is structural validation, not a full pixel decode, image repair, transcoding, malware scanner, or visual review. A structurally valid file can still be undesirable or fail a downstream decoder. Preview every imported image and use an independent media-scanning/decoding workflow when the merchant's risk profile requires it.

--- a/docs/shopify-migration.md
+++ b/docs/shopify-migration.md
@@ -2,11 +2,13 @@
 
 The operator-only Shopify migration toolkit imports catalog, content, media, customers, historical orders, and optionally Judge.me reviews into Mercora. It defaults to a local dry run. A dry run extracts and transforms data, resolves the named Wrangler targets, and builds the complete D1 plan without constructing R2, Clerk, or D1 write adapters.
 
-The toolkit is deliberately fail-fast between phases. An apply validates deterministic source transforms before it obtains write adapters, then executes in this order:
+The toolkit is deliberately fail-fast between phases. An apply validates and transforms the complete source before it obtains write adapters, then executes in this order:
 
-1. verify and persist Shopify media to the Wrangler `MEDIA` R2 bucket;
-2. resolve existing Clerk identities and, only when separately authorized, create source-verified customer identities;
-3. rebuild the identity-dependent order/review plan, run the D1 schema preflight, apply dependency-ordered chunks, and validate the result.
+1. run a read-only D1 canonical-target, schema, and migration-ledger preflight;
+2. when customers are present, read the Clerk instance and verify that the secret belongs to the confirmed instance and target environment;
+3. verify and persist Shopify media to the Wrangler `MEDIA` R2 bucket;
+4. resolve existing Clerk identities and, only when separately authorized, create source-verified customer identities;
+5. rebuild the identity-dependent order/review plan, revalidate D1 to prevent target/config drift, apply dependency-ordered chunks, and validate the result.
 
 It does not deploy Mercora, create Cloudflare resources, migrate schemas, obtain credentials, send email, or change Shopify/Judge.me.
 
@@ -14,10 +16,10 @@ It does not deploy Mercora, create Cloudflare resources, migrate schemas, obtain
 
 - Node 24 and the repository dependencies installed locally.
 - Mercora database migrations `0001` through `0020` already applied to the selected D1 database.
-- A reviewed `wrangler.jsonc` with exactly one canonical `DB` binding and one canonical `MEDIA` binding for the selected environment. Use `MIGRATION_DATABASE_NAME` or `--expected-database-name` to pin the expected D1 name.
+- A reviewed `wrangler.jsonc` with exactly one canonical `DB` binding and one canonical `MEDIA` binding for the selected environment. Remote targets must also declare the selected Cloudflare `account_id` and `vars.CLERK_INSTANCE_ID`. Use `MIGRATION_DATABASE_NAME` or `--expected-database-name` to pin the expected D1 name.
 - A stable inventory location ID, page/blog actor ID, fallback blog author, ISO-4217 currency, fulfillment type, and unresolved-customer policy chosen by the merchant.
-- An operator-created private input directory. Never place exports in the repository or a web-served directory.
-- For API extraction, an exact `https://{shop}.myshopify.com` origin, a pinned quarterly Admin API version, and a read-only Shopify access token scoped only to the resources being migrated.
+- Operator-created input and output directories that already exist, resolve canonically, are separate, and are outside the repository. Never place exports in a web-served directory.
+- For API extraction, an exact `https://{shop}.myshopify.com` origin, a pinned quarterly Admin API version, and a read-only Shopify access token scoped only to the resources being migrated. Historical orders require Shopify approval for `read_all_orders` in addition to `read_orders`; without it Shopify limits order access to the recent window.
 - For apply, Cloudflare R2 S3 credentials limited to the target bucket and the existing local Wrangler authentication/configuration needed by the D1 runner.
 
 Run Mercora's normal tests and deployment preflight before beginning. Confirm the selected Wrangler environment and binding names independently; the migration refuses ambiguous or mismatched targets, but an operator is still responsible for selecting the intended account.
@@ -43,7 +45,7 @@ private-shopify-export/
   verified-purchases.json    # optional, sensitive
 ```
 
-API mode reads collections, collects, products, pages, blogs/articles, redirects, and—when confirmed—customers and all order statuses. Judge.me remains a bounded local CSV input, so API mode also needs `MIGRATION_INPUT_ROOT` when `JUDGE_ME_FILE` is set.
+API mode reads collections, collects, products, pages, blogs/articles, redirects, and—when confirmed—customers and all order statuses. Article endpoints are read sequentially with per-blog and total bounds. For historical orders, obtain an independent exact source count, pass `--confirm-shopify-read-all-orders --expected-shopify-order-count=<count>`, and require the extracted count to match before transformation. Judge.me remains a bounded local CSV input, so API mode also needs `MIGRATION_INPUT_ROOT` when `JUDGE_ME_FILE` is set.
 
 Review attribution files are JSON arrays. Every item contains a `reviewFingerprint` plus the final Mercora `productId`, historical `orderId`, Clerk `customerId`, and optional `orderItemId`. Verified-purchase rows contain the same identifiers and `verified: true`. The toolkit rejects missing, duplicate, synthetic, or contradictory attribution rather than inventing purchase history.
 
@@ -63,6 +65,8 @@ MIGRATION_UNRESOLVED_CUSTOMER=reject
 MIGRATION_DATABASE_NAME=mercora-db
 ```
 
+Every configured input/output root must be an absolute canonical path to an existing directory outside the Mercora repository. The repository ignore rules are defense in depth for accidental artifacts; they do not make an in-repository export safe, and the CLI rejects such roots.
+
 Allowed fulfillment values are `physical`, `digital`, and `service`. The unresolved-customer policy must explicitly be `reject` or `guest`; `reject` is the safer default for historical orders.
 
 `MIGRATION_MEDIA_HOSTS` is an explicit allowlist, but it cannot broaden the toolkit's trust boundary. Media is accepted only from exact Shopify-owned asset hosts: `cdn.shopify.com`, or an exact `*.myshopify.com` host with a `/cdn/` path. Arbitrary custom CDNs are intentionally unsupported. Inline external images that fail this policy are removed from imported HTML.
@@ -76,7 +80,16 @@ SHOPIFY_ACCESS_TOKEN=private-read-token
 SHOPIFY_API_VERSION=2026-07
 ```
 
-Apply-only R2 credentials are read from `CLOUDFLARE_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, and `R2_SECRET_ACCESS_KEY`. Clerk uses `CLERK_SECRET_KEY`. Secrets are never accepted as command-line flags, written to the manifest, or admitted into structured logs.
+For sensitive API extraction, also require Shopify's approved `read_all_orders` scope and provide both the explicit acknowledgement and independently established total:
+
+```text
+--include-sensitive --confirm-sensitive-data
+--confirm-shopify-read-all-orders --expected-shopify-order-count=1234
+```
+
+A mismatch aborts without logging order records. Record how the source total was obtained alongside the private migration evidence.
+
+Remote apply requires `MIGRATION_CLOUDFLARE_ACCOUNT_ID` to match the selected Wrangler `account_id`. When customers will be resolved, `MIGRATION_CLERK_INSTANCE_ID` must match the selected Wrangler `vars.CLERK_INSTANCE_ID`. Apply-only R2 credentials are read from `CLOUDFLARE_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, and `R2_SECRET_ACCESS_KEY`; their account ID must independently match the confirmed target. Clerk uses `CLERK_SECRET_KEY`, which is bound before mutation by a bounded, abortable read of `/v1/instance`: preview requires a Clerk `development` instance and production requires `production`. Secrets are never accepted as command-line flags, written to the manifest, or admitted into structured logs.
 
 ## Dry run
 
@@ -126,11 +139,13 @@ npm run migrate:shopify -- --apply --target=preview --confirm-preview
 MERCORA_ALLOW_PRODUCTION_IMPORTS=1 npm run migrate:shopify -- --apply --target=production --confirm-production
 ```
 
+Local apply never constructs remote R2 or Clerk clients. It therefore accepts only plans with no media uploads and no customer identity work; use local dry run for the full dataset and a confirmed preview target for an end-to-end apply.
+
 Use `--env=<wrangler-environment>` when the reviewed bindings live in a named Wrangler environment. Production's environment variable is an additional circuit breaker, not a substitute for the target and confirmation flags.
 
 Existing merchant rows are compare-only by default. A semantic mismatch aborts instead of overwriting merchant changes. Overwrite mode requires both `--overwrite` and `--confirm-overwrite`; use it only after reviewing the exact conflict and taking a backup.
 
-For an apply report written as a private atomic `0600` file, set `MIGRATION_OUTPUT_ROOT` to a private existing directory. The resulting `manifest.json` contains aggregate counts only. Export files, attribution files, SQL chunks, logs, ID maps, and manifests are ignored by the repository's migration artifact rules, but operators must still verify they are not staged or uploaded.
+For an apply report written as a private atomic `0600` file, set `MIGRATION_OUTPUT_ROOT` to a private existing canonical directory outside the repository and separate from the input root. The resulting `manifest.json` contains aggregate counts only. Repository ignore rules provide defense in depth for accidental artifacts, but operators must still verify private files are not staged or uploaded.
 
 ## Deployment order
 
@@ -142,7 +157,7 @@ For an apply report written as a private atomic `0600` file, set `MIGRATION_OUTP
 6. Repeat the dry run immediately before production, then run the separately confirmed production apply.
 7. Retain the private source exports, reviewed report, backup, and reconciliation list according to the merchant's data-retention policy.
 
-R2 is applied before D1 so imported rows never intentionally reference media that has not been cryptographically verified as written or already identical. Clerk precedes customer/order D1 rows because Mercora customer primary keys must be final `user_*` IDs.
+The read-only D1 preflight happens before R2 or Clerk mutation, and D1 is revalidated immediately before its write phase. R2 is applied before D1 so imported rows never intentionally reference media that has not been cryptographically verified as written or already identical. Clerk identity work precedes customer/order D1 rows because Mercora customer primary keys must be final `user_*` IDs.
 
 ## Resuming and rerunning
 

--- a/lib/db/schema/index.ts
+++ b/lib/db/schema/index.ts
@@ -130,3 +130,6 @@ export * from "./email-deliveries";
 
 // Store-neutral content publishing
 export * from "./blog";
+
+// Exact legacy URL redirects populated by migration tooling
+export * from "./redirect-map";

--- a/lib/db/schema/redirect-map.ts
+++ b/lib/db/schema/redirect-map.ts
@@ -1,0 +1,54 @@
+import { sql } from "drizzle-orm";
+import { check, index, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+/** Exact legacy URL mappings populated by migration tooling. */
+export const redirectMap = sqliteTable("redirect_map", {
+  id: integer("id", { mode: "number" }).primaryKey({ autoIncrement: true }),
+  sourcePath: text("source_path").notNull().unique(),
+  targetPath: text("target_path").notNull(),
+  statusCode: integer("status_code", { mode: "number" }).notNull().default(301),
+  entityType: text("entity_type"),
+  createdAt: integer("created_at", { mode: "number" }).notNull().default(sql`(unixepoch())`),
+}, (table) => [
+  index("redirect_map_source_path_idx").on(table.sourcePath),
+  check("redirect_map_source_path_check", sql`
+    length(${table.sourcePath}) BETWEEN 3 AND 2048
+    AND substr(${table.sourcePath}, 1, 1) = '/'
+    AND substr(${table.sourcePath}, 1, 2) != '//'
+    AND instr(${table.sourcePath}, '?') = 0
+    AND instr(${table.sourcePath}, '#') = 0
+    AND instr(${table.sourcePath}, char(92)) = 0
+    AND instr(${table.sourcePath}, char(0)) = 0
+    AND instr(${table.sourcePath}, char(9)) = 0
+    AND instr(${table.sourcePath}, char(10)) = 0
+    AND instr(${table.sourcePath}, char(13)) = 0
+  `),
+  check("redirect_map_target_path_check", sql`
+    length(${table.targetPath}) BETWEEN 1 AND 2048
+    AND substr(${table.targetPath}, 1, 1) = '/'
+    AND substr(${table.targetPath}, 1, 2) != '//'
+    AND instr(${table.targetPath}, '?') = 0
+    AND instr(${table.targetPath}, '#') = 0
+    AND instr(${table.targetPath}, char(92)) = 0
+    AND instr(${table.targetPath}, char(0)) = 0
+    AND instr(${table.targetPath}, char(9)) = 0
+    AND instr(${table.targetPath}, char(10)) = 0
+    AND instr(${table.targetPath}, char(13)) = 0
+  `),
+  check("redirect_map_no_direct_loop_check", sql`${table.sourcePath} != ${table.targetPath}`),
+  check("redirect_map_no_legacy_target_check", sql`
+    ${table.targetPath} NOT LIKE '/products/%'
+    AND ${table.targetPath} NOT LIKE '/collections/%'
+    AND ${table.targetPath} NOT LIKE '/pages/%'
+    AND ${table.targetPath} NOT LIKE '/blogs/%'
+    AND ${table.targetPath} NOT LIKE '/policies/%'
+  `),
+  check("redirect_map_status_code_check", sql`${table.statusCode} IN (301, 308)`),
+  check("redirect_map_entity_type_check", sql`
+    ${table.entityType} IS NULL OR length(trim(${table.entityType})) BETWEEN 1 AND 64
+  `),
+  check("redirect_map_created_at_check", sql`${table.createdAt} >= 0`),
+]);
+
+export type RedirectMapRow = typeof redirectMap.$inferSelect;
+export type RedirectMapInsert = typeof redirectMap.$inferInsert;

--- a/lib/media/public-key.ts
+++ b/lib/media/public-key.ts
@@ -1,0 +1,25 @@
+const PUBLIC_MEDIA_PREFIXES = new Set(["products", "categories", "blog", "pages"]);
+const SAFE_KEY_SEGMENT = /^[A-Za-z0-9][A-Za-z0-9._~-]*$/;
+const MAX_KEY_LENGTH = 1024;
+
+/** Next has already decoded dynamic route params; never decode them again. */
+export function resolvePublicMediaKey(segments: readonly string[] | undefined): string | null {
+  if (!segments || segments.length < 2 || !PUBLIC_MEDIA_PREFIXES.has(segments[0])) return null;
+  if (segments.length > 12) return null;
+
+  for (const segment of segments) {
+    if (
+      segment.length > 255
+      || !SAFE_KEY_SEGMENT.test(segment)
+      || segment === "."
+      || segment === ".."
+      || segment.includes("%")
+      || segment.includes("\\")
+    ) {
+      return null;
+    }
+  }
+
+  const key = segments.join("/");
+  return key.length <= MAX_KEY_LENGTH ? key : null;
+}

--- a/lib/redirects/policy.ts
+++ b/lib/redirects/policy.ts
@@ -1,0 +1,69 @@
+export const LEGACY_REDIRECT_PREFIXES = [
+  "/products/",
+  "/collections/",
+  "/pages/",
+  "/blogs/",
+  "/policies/",
+] as const;
+
+export type PermanentRedirectStatus = 301 | 308;
+
+export interface RedirectCandidate {
+  targetPath: string;
+  statusCode: number | null;
+}
+
+export interface ValidatedRedirect {
+  targetPath: string;
+  statusCode: PermanentRedirectStatus;
+}
+
+const SAFE_SEGMENT = /^[A-Za-z0-9][A-Za-z0-9._~-]*$/;
+const CONTROL_CHARACTER = /[\u0000-\u001f\u007f]/;
+
+function hasSafeSegments(pathname: string): boolean {
+  if (pathname === "/") return true;
+  const segments = pathname.slice(1).split("/");
+  return segments.length <= 12 && segments.every((segment) => SAFE_SEGMENT.test(segment));
+}
+
+/** Limit D1 work to canonical old-platform paths that the importer can own. */
+export function isLegacyRedirectLookupPath(pathname: string): boolean {
+  return pathname.length <= 2048
+    && LEGACY_REDIRECT_PREFIXES.some((prefix) => pathname.startsWith(prefix))
+    && !CONTROL_CHARACTER.test(pathname)
+    && !pathname.includes("\\")
+    && !pathname.includes("%")
+    && !pathname.includes("?")
+    && !pathname.includes("#")
+    && hasSafeSegments(pathname);
+}
+
+/** Validate untrusted redirect rows again at their runtime use boundary. */
+export function validateRedirectCandidate(
+  sourcePath: string,
+  candidate: RedirectCandidate | null,
+): ValidatedRedirect | null {
+  if (!candidate || (candidate.statusCode !== 301 && candidate.statusCode !== 308)) {
+    return null;
+  }
+
+  const targetPath = candidate.targetPath;
+  if (
+    targetPath.length > 2048
+    || !targetPath.startsWith("/")
+    || targetPath.startsWith("//")
+    || CONTROL_CHARACTER.test(targetPath)
+    || targetPath.includes("\\")
+    || targetPath.includes("%")
+    || targetPath.includes("?")
+    || targetPath.includes("#")
+    || !hasSafeSegments(targetPath)
+    || sourcePath === targetPath
+    || LEGACY_REDIRECT_PREFIXES.some((prefix) => targetPath.startsWith(prefix))
+  ) {
+    return null;
+  }
+
+  return { targetPath, statusCode: candidate.statusCode };
+}

--- a/lib/redirects/resolver.ts
+++ b/lib/redirects/resolver.ts
@@ -1,0 +1,43 @@
+import {
+  isLegacyRedirectLookupPath,
+  validateRedirectCandidate,
+  type RedirectCandidate,
+  type ValidatedRedirect,
+} from "./policy";
+
+export type RedirectLookup = (sourcePath: string) => Promise<RedirectCandidate | null>;
+
+export interface ResolvedRedirect extends ValidatedRedirect {
+  url: URL;
+}
+
+/**
+ * Resolve one exact importer-owned mapping. Missing state and D1 failures are
+ * intentionally indistinguishable from a normal non-redirected request.
+ */
+export async function resolveLegacyRedirect(
+  requestUrl: string,
+  lookup: RedirectLookup,
+): Promise<ResolvedRedirect | null> {
+  const sourceUrl = new URL(requestUrl);
+  const sourcePath = sourceUrl.pathname;
+  if (!isLegacyRedirectLookupPath(sourcePath)) return null;
+
+  let candidate: RedirectCandidate | null;
+  try {
+    candidate = await lookup(sourcePath);
+  } catch {
+    return null;
+  }
+
+  const redirect = validateRedirectCandidate(sourcePath, candidate);
+  if (!redirect) return null;
+
+  const url = new URL(redirect.targetPath, sourceUrl.origin);
+  if (url.origin !== sourceUrl.origin || url.pathname !== redirect.targetPath) return null;
+
+  // Query state such as campaign attribution belongs to the request, not the
+  // durable redirect map. Fragments never reach the server.
+  url.search = sourceUrl.search;
+  return { ...redirect, url };
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -58,6 +58,10 @@ import { NextRequest, NextResponse } from "next/server";
 import { getSettings } from "@/lib/utils/settings";
 import { getStoreConfig } from "@/lib/store-config";
 import { escapeHtmlText, safeMaintenanceMessage } from "@/lib/utils/maintenance-html";
+import { getDbAsync } from "@/lib/db";
+import { redirectMap } from "@/lib/db/schema/redirect-map";
+import { eq } from "drizzle-orm";
+import { resolveLegacyRedirect } from "@/lib/redirects/resolver";
 
 /**
  * Custom middleware that combines Clerk authentication with maintenance mode checking
@@ -168,6 +172,20 @@ export default clerkMiddleware(async (auth, req: NextRequest) => {
   } catch (error) {
     // If settings check fails, continue normally to avoid breaking the site
     console.error('Error checking maintenance mode:', error);
+  }
+
+  const redirect = await resolveLegacyRedirect(req.url, async (sourcePath) => {
+    const db = await getDbAsync();
+    const row = await db
+      .select({ targetPath: redirectMap.targetPath, statusCode: redirectMap.statusCode })
+      .from(redirectMap)
+      .where(eq(redirectMap.sourcePath, sourcePath))
+      .limit(1)
+      .get();
+    return row ?? null;
+  });
+  if (redirect) {
+    return NextResponse.redirect(redirect.url, redirect.statusCode);
   }
   
   // Continue with normal Clerk authentication

--- a/middleware.ts
+++ b/middleware.ts
@@ -202,6 +202,9 @@ export default clerkMiddleware(async (auth, req: NextRequest) => {
  */
 export const config = {
   matcher: [
+    // Legacy commerce paths must reach the exact redirect resolver even when a
+    // historical handle ends in a file-like extension such as `.html`.
+    "/(products|collections|pages|blogs|policies)/(.*)",
     // Match all routes except static assets and Next.js internals
     "/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)",
     // Include all API and tRPC routes for protection

--- a/middleware.ts
+++ b/middleware.ts
@@ -70,14 +70,14 @@ import { isLegacyRedirectLookupPath } from "@/lib/redirects/policy";
 export default clerkMiddleware(async (auth, req: NextRequest) => {
   const { pathname } = req.nextUrl;
   const isLegacyRedirectPath = isLegacyRedirectLookupPath(pathname);
-  
+
   // Skip maintenance check for static assets and Next.js internals
-  if (!isLegacyRedirectPath && (pathname.includes('/_next') || 
-      pathname.includes('/favicon') || 
+  if (!isLegacyRedirectPath && (pathname.includes('/_next') ||
+      pathname.includes('/favicon') ||
       pathname.match(/\.(js|css|png|jpg|jpeg|gif|svg|ico|woff|woff2|ttf)$/))) {
     return NextResponse.next();
   }
-  
+
   // Skip maintenance check for admin routes and MCP API - always accessible
   if (pathname.startsWith('/admin') || 
       pathname.startsWith('/api/admin') || 

--- a/middleware.ts
+++ b/middleware.ts
@@ -62,17 +62,19 @@ import { getDbAsync } from "@/lib/db";
 import { redirectMap } from "@/lib/db/schema/redirect-map";
 import { eq } from "drizzle-orm";
 import { resolveLegacyRedirect } from "@/lib/redirects/resolver";
+import { isLegacyRedirectLookupPath } from "@/lib/redirects/policy";
 
 /**
  * Custom middleware that combines Clerk authentication with maintenance mode checking
  */
 export default clerkMiddleware(async (auth, req: NextRequest) => {
   const { pathname } = req.nextUrl;
+  const isLegacyRedirectPath = isLegacyRedirectLookupPath(pathname);
   
   // Skip maintenance check for static assets and Next.js internals
-  if (pathname.includes('/_next') || 
+  if (!isLegacyRedirectPath && (pathname.includes('/_next') || 
       pathname.includes('/favicon') || 
-      pathname.match(/\.(js|css|png|jpg|jpeg|gif|svg|ico|woff|woff2|ttf)$/)) {
+      pathname.match(/\.(js|css|png|jpg|jpeg|gif|svg|ico|woff|woff2|ttf)$/))) {
     return NextResponse.next();
   }
   

--- a/migrations/0020_add_redirect_map.sql
+++ b/migrations/0020_add_redirect_map.sql
@@ -1,0 +1,49 @@
+-- O05 reservation: exact legacy URL redirects populated by migration tooling.
+--
+-- This migration is deliberately empty. Old application versions ignore the
+-- table, while new versions treat an absent row as "no exact redirect".
+CREATE TABLE redirect_map (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  source_path TEXT NOT NULL UNIQUE,
+  target_path TEXT NOT NULL,
+  status_code INTEGER NOT NULL DEFAULT 301,
+  entity_type TEXT,
+  created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+  CHECK (
+    length(source_path) BETWEEN 3 AND 2048
+    AND substr(source_path, 1, 1) = '/'
+    AND substr(source_path, 1, 2) != '//'
+    AND instr(source_path, '?') = 0
+    AND instr(source_path, '#') = 0
+    AND instr(source_path, char(92)) = 0
+    AND instr(source_path, char(0)) = 0
+    AND instr(source_path, char(9)) = 0
+    AND instr(source_path, char(10)) = 0
+    AND instr(source_path, char(13)) = 0
+  ),
+  CHECK (
+    length(target_path) BETWEEN 1 AND 2048
+    AND substr(target_path, 1, 1) = '/'
+    AND substr(target_path, 1, 2) != '//'
+    AND instr(target_path, '?') = 0
+    AND instr(target_path, '#') = 0
+    AND instr(target_path, char(92)) = 0
+    AND instr(target_path, char(0)) = 0
+    AND instr(target_path, char(9)) = 0
+    AND instr(target_path, char(10)) = 0
+    AND instr(target_path, char(13)) = 0
+  ),
+  CHECK (source_path != target_path),
+  CHECK (
+    target_path NOT LIKE '/products/%'
+    AND target_path NOT LIKE '/collections/%'
+    AND target_path NOT LIKE '/pages/%'
+    AND target_path NOT LIKE '/blogs/%'
+    AND target_path NOT LIKE '/policies/%'
+  ),
+  CHECK (status_code IN (301, 308)),
+  CHECK (entity_type IS NULL OR length(trim(entity_type)) BETWEEN 1 AND 64),
+  CHECK (created_at >= 0)
+);
+
+CREATE INDEX redirect_map_source_path_idx ON redirect_map(source_path);

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
         "@cloudflare/vitest-pool-workers": "0.20.3",
         "@cloudflare/workers-types": "^5.20260809.1",
         "@opennextjs/cloudflare": "^1.20.2",
+        "@smithy/node-http-handler": "4.9.13",
         "@tailwindcss/postcss": "^4.3.3",
         "@types/big.js": "^7.0.0",
         "@types/node": "^26.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "zustand": "^5.0.6"
       },
       "devDependencies": {
+        "@aws-sdk/client-s3": "3.984.0",
         "@cloudflare/vitest-pool-workers": "0.20.3",
         "@cloudflare/workers-types": "^5.20260809.1",
         "@opennextjs/cloudflare": "^1.20.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
         "@types/react-dom": "^19",
         "@types/sanitize-html": "2.16.1",
         "autoprefixer": "^10.5.4",
+        "csv-parse": "6.1.0",
         "drizzle-kit": "^0.31.10",
         "eslint": "^9.36.0",
         "eslint-config-next": "^16.3.0",
@@ -9410,6 +9411,13 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "license": "MIT"
+    },
+    "node_modules/csv-parse": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-6.1.0.tgz",
+      "integrity": "sha512-CEE+jwpgLn+MmtCpVcPtiCZpVtB6Z2OKPTr34pycYYoL7sxdOkXDdQ4lRiw6ioC0q6BLqhc6cKweCVvral8yhw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "@types/react-dom": "^19",
     "@types/sanitize-html": "2.16.1",
     "autoprefixer": "^10.5.4",
+    "csv-parse": "6.1.0",
     "drizzle-kit": "^0.31.10",
     "eslint": "^9.36.0",
     "eslint-config-next": "^16.3.0",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "zustand": "^5.0.6"
   },
   "devDependencies": {
+    "@aws-sdk/client-s3": "3.984.0",
     "@cloudflare/vitest-pool-workers": "0.20.3",
     "@cloudflare/workers-types": "^5.20260809.1",
     "@opennextjs/cloudflare": "^1.20.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "cf-typecheck": "wrangler types --env-interface CloudflareEnv --strict-vars false ./cloudflare-env.d.ts --check",
     "token:generate": "tsx scripts/manage-tokens.ts generate",
     "token:list": "tsx scripts/manage-tokens.ts list",
-    "token:revoke": "tsx scripts/manage-tokens.ts revoke"
+    "token:revoke": "tsx scripts/manage-tokens.ts revoke",
+    "migrate:shopify": "tsx scripts/shopify-migration/cli.ts"
   },
   "dependencies": {
     "@clerk/nextjs": "^7.7.4",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "@cloudflare/vitest-pool-workers": "0.20.3",
     "@cloudflare/workers-types": "^5.20260809.1",
     "@opennextjs/cloudflare": "^1.20.2",
+    "@smithy/node-http-handler": "4.9.13",
     "@tailwindcss/postcss": "^4.3.3",
     "@types/big.js": "^7.0.0",
     "@types/node": "^26.2.0",

--- a/scripts/shopify-migration/adapters/clerk/index.ts
+++ b/scripts/shopify-migration/adapters/clerk/index.ts
@@ -1,0 +1,254 @@
+import type { ExecutionPlan } from "../../lib/config.js";
+import type { CustomerProvisioningPlan } from "../../transformers/sensitive/customers.js";
+import { safeClerkUserId } from "../../transformers/sensitive/_shared.js";
+
+const MAX_CLERK_RESULTS = 2;
+const MAX_CLERK_PLANS = 100_000;
+const SAFE_SOURCE_FINGERPRINT = /^[a-f0-9]{64}$/;
+
+export interface ClerkMigrationUser {
+  id: string;
+  externalId: string | null;
+}
+
+export interface ClerkMigrationClient {
+  users: {
+    getUserList(params: {
+      externalId?: readonly string[];
+      emailAddress?: readonly string[];
+      limit: number;
+    }): Promise<{ data: readonly ClerkMigrationUser[] }>;
+    createUser(params: {
+      emailAddress: readonly [string];
+      firstName?: string;
+      lastName?: string;
+      externalId: string;
+      skipLegalChecks: true;
+    }): Promise<ClerkMigrationUser>;
+  };
+}
+
+export type ClerkReconciliationReason =
+  | "external-identity-ambiguous"
+  | "external-identity-invalid"
+  | "email-conflict"
+  | "source-email-unverified"
+  | "creation-not-authorized"
+  | "provider-request-failed"
+  | "created-identity-invalid"
+  | "plan-invalid";
+
+export interface ClerkReconciliationItem {
+  sourceFingerprint: string;
+  reason: ClerkReconciliationReason;
+}
+
+export interface ClerkProvisioningResult {
+  /** Only source fingerprints mapped to validated final Clerk `user_*` IDs. */
+  idMap: Map<string, string>;
+  created: number;
+  existing: number;
+  reconciliation: ClerkReconciliationItem[];
+}
+
+interface ProvisioningIdentity {
+  email: string;
+  firstName?: string;
+  lastName?: string;
+  sourceVerified: boolean;
+}
+
+function assertAuthorizedExecution(execution: ExecutionPlan): void {
+  if (execution.dryRun || !execution.apply) {
+    throw new Error("Clerk identity resolution is disabled during dry runs");
+  }
+  if (!execution.includeSensitive || !execution.confirmedSensitiveData) {
+    throw new Error("Clerk identity resolution requires confirmed sensitive-data access");
+  }
+  if (
+    execution.createClerkUsers &&
+    !execution.confirmedClerkAutoVerification
+  ) {
+    throw new Error("Clerk identity creation requires explicit auto-verification confirmation");
+  }
+}
+
+function parseProvisioningIdentity(plan: CustomerProvisioningPlan): ProvisioningIdentity {
+  const person = JSON.parse(plan.customerFields.person) as unknown;
+  const preferences = JSON.parse(plan.customerFields.communication_preferences) as unknown;
+  if (!person || typeof person !== "object" || Array.isArray(person)) {
+    throw new TypeError("Customer identity payload is invalid");
+  }
+  if (!preferences || typeof preferences !== "object" || Array.isArray(preferences)) {
+    throw new TypeError("Customer communication preferences are invalid");
+  }
+
+  const personRecord = person as Record<string, unknown>;
+  const preferenceRecord = preferences as Record<string, unknown>;
+  const emailPreference = preferenceRecord.email;
+  const email = personRecord.email;
+  if (typeof email !== "string" || email.length > 254 || !/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(email)) {
+    throw new TypeError("Customer email is invalid");
+  }
+  if (!emailPreference || typeof emailPreference !== "object" || Array.isArray(emailPreference)) {
+    throw new TypeError("Customer email verification state is invalid");
+  }
+
+  const firstName = personRecord.first_name;
+  const lastName = personRecord.last_name;
+  if (firstName !== undefined && (typeof firstName !== "string" || firstName.length > 100)) {
+    throw new TypeError("Customer first name is invalid");
+  }
+  if (lastName !== undefined && (typeof lastName !== "string" || lastName.length > 100)) {
+    throw new TypeError("Customer last name is invalid");
+  }
+
+  return {
+    email,
+    ...(typeof firstName === "string" && firstName ? { firstName } : {}),
+    ...(typeof lastName === "string" && lastName ? { lastName } : {}),
+    sourceVerified:
+      plan.customerFields.status === "active" &&
+      (emailPreference as Record<string, unknown>).verified === true,
+  };
+}
+
+function exactExternalUser(
+  users: readonly ClerkMigrationUser[],
+  sourceFingerprint: string,
+): { id: string | null; reason?: ClerkReconciliationReason } {
+  const exact = users.filter((user) => user.externalId === sourceFingerprint);
+  if (exact.length > 1) return { id: null, reason: "external-identity-ambiguous" };
+  if (exact.length === 0) {
+    return users.length === 0
+      ? { id: null }
+      : { id: null, reason: "external-identity-invalid" };
+  }
+  const id = safeClerkUserId(exact[0].id);
+  return id ? { id } : { id: null, reason: "external-identity-invalid" };
+}
+
+function pushReconciliation(
+  items: ClerkReconciliationItem[],
+  sourceFingerprint: string,
+  reason: ClerkReconciliationReason,
+): void {
+  items.push({ sourceFingerprint, reason });
+}
+
+/**
+ * Resolve or create Clerk identities for transformed Shopify customers.
+ *
+ * The caller must never invoke this function for a dry run: the function
+ * rejects before touching the injected client. Email lookups detect ownership
+ * conflicts only; they are deliberately never used to link an existing user.
+ */
+export async function provisionClerkCustomers(
+  plans: readonly CustomerProvisioningPlan[],
+  execution: ExecutionPlan,
+  client: ClerkMigrationClient,
+): Promise<ClerkProvisioningResult> {
+  assertAuthorizedExecution(execution);
+  if (plans.length > MAX_CLERK_PLANS) throw new RangeError("Clerk provisioning batch is too large");
+  const sourceFingerprints = new Set<string>();
+  for (const plan of plans) {
+    if (!SAFE_SOURCE_FINGERPRINT.test(plan.sourceFingerprint)) {
+      throw new TypeError("Clerk provisioning plan contains an invalid source fingerprint");
+    }
+    if (sourceFingerprints.has(plan.sourceFingerprint)) {
+      throw new TypeError("Clerk provisioning plan contains a duplicate source fingerprint");
+    }
+    sourceFingerprints.add(plan.sourceFingerprint);
+  }
+  const idMap = new Map<string, string>();
+  const resolvedUserIds = new Set<string>();
+  const reconciliation: ClerkReconciliationItem[] = [];
+  let created = 0;
+  let existing = 0;
+
+  for (const plan of plans) {
+    let identity: ProvisioningIdentity;
+    try {
+      identity = parseProvisioningIdentity(plan);
+    } catch {
+      pushReconciliation(reconciliation, plan.sourceFingerprint, "plan-invalid");
+      continue;
+    }
+
+    let externalUsers: readonly ClerkMigrationUser[];
+    try {
+      externalUsers = (await client.users.getUserList({
+        externalId: [plan.sourceFingerprint],
+        limit: MAX_CLERK_RESULTS,
+      })).data;
+    } catch {
+      pushReconciliation(reconciliation, plan.sourceFingerprint, "provider-request-failed");
+      continue;
+    }
+
+    const resolved = exactExternalUser(externalUsers, plan.sourceFingerprint);
+    if (resolved.reason) {
+      pushReconciliation(reconciliation, plan.sourceFingerprint, resolved.reason);
+      continue;
+    }
+    if (resolved.id) {
+      if (resolvedUserIds.has(resolved.id)) {
+        pushReconciliation(reconciliation, plan.sourceFingerprint, "external-identity-ambiguous");
+        continue;
+      }
+      idMap.set(plan.sourceFingerprint, resolved.id);
+      resolvedUserIds.add(resolved.id);
+      existing += 1;
+      continue;
+    }
+
+    let emailUsers: readonly ClerkMigrationUser[];
+    try {
+      emailUsers = (await client.users.getUserList({
+        emailAddress: [identity.email],
+        limit: MAX_CLERK_RESULTS,
+      })).data;
+    } catch {
+      pushReconciliation(reconciliation, plan.sourceFingerprint, "provider-request-failed");
+      continue;
+    }
+    if (emailUsers.length > 0) {
+      pushReconciliation(reconciliation, plan.sourceFingerprint, "email-conflict");
+      continue;
+    }
+    if (!identity.sourceVerified) {
+      pushReconciliation(reconciliation, plan.sourceFingerprint, "source-email-unverified");
+      continue;
+    }
+    if (!execution.createClerkUsers) {
+      pushReconciliation(reconciliation, plan.sourceFingerprint, "creation-not-authorized");
+      continue;
+    }
+
+    try {
+      const user = await client.users.createUser({
+        emailAddress: [identity.email],
+        ...(identity.firstName ? { firstName: identity.firstName } : {}),
+        ...(identity.lastName ? { lastName: identity.lastName } : {}),
+        externalId: plan.sourceFingerprint,
+        skipLegalChecks: true,
+      });
+      const userId = user.externalId === plan.sourceFingerprint
+        ? safeClerkUserId(user.id)
+        : null;
+      if (!userId || resolvedUserIds.has(userId)) {
+        pushReconciliation(reconciliation, plan.sourceFingerprint, "created-identity-invalid");
+        continue;
+      }
+      idMap.set(plan.sourceFingerprint, userId);
+      resolvedUserIds.add(userId);
+      created += 1;
+    } catch {
+      // Provider messages can echo emails or request payloads, so return only
+      // a bounded stable reason and let a rerun reconcile by external ID.
+      pushReconciliation(reconciliation, plan.sourceFingerprint, "provider-request-failed");
+    }
+  }
+
+  return { idMap, created, existing, reconciliation };
+}

--- a/scripts/shopify-migration/adapters/clerk/index.ts
+++ b/scripts/shopify-migration/adapters/clerk/index.ts
@@ -3,8 +3,18 @@ import type { CustomerProvisioningPlan } from "../../transformers/sensitive/cust
 import { safeClerkUserId } from "../../transformers/sensitive/_shared.js";
 
 const MAX_CLERK_RESULTS = 2;
-const MAX_CLERK_PLANS = 100_000;
+const MAX_CLERK_PLANS = 1_000;
+const DEFAULT_OPERATION_TIMEOUT_MS = 10_000;
+const MAX_OPERATION_TIMEOUT_MS = 30_000;
+const DEFAULT_MAX_ATTEMPTS = 3;
+const MAX_ATTEMPTS = 3;
+const BASE_RETRY_DELAY_MS = 250;
+const MAX_RETRY_DELAY_MS = 5_000;
 const SAFE_SOURCE_FINGERPRINT = /^[a-f0-9]{64}$/;
+
+export interface ClerkRequestContext {
+  signal: AbortSignal;
+}
 
 export interface ClerkMigrationUser {
   id: string;
@@ -17,15 +27,55 @@ export interface ClerkMigrationClient {
       externalId?: readonly string[];
       emailAddress?: readonly string[];
       limit: number;
-    }): Promise<{ data: readonly ClerkMigrationUser[] }>;
+    }, context?: ClerkRequestContext): Promise<{ data: readonly ClerkMigrationUser[] }>;
     createUser(params: {
       emailAddress: readonly [string];
       firstName?: string;
       lastName?: string;
       externalId: string;
       skipLegalChecks: true;
-    }): Promise<ClerkMigrationUser>;
+    }, context?: ClerkRequestContext): Promise<ClerkMigrationUser>;
   };
+}
+
+export interface ClerkRetryDirective {
+  retryable: boolean;
+  /** Parsed Retry-After duration. Values are capped by the adapter. */
+  retryAfterMs?: number;
+}
+
+export type ClerkErrorClassifier = (error: unknown) => ClerkRetryDirective;
+export type ClerkOperationRunner = <T>(
+  operation: (signal: AbortSignal) => Promise<T>,
+  timeoutMs: number,
+) => Promise<T>;
+export type ClerkRetrySleeper = (delayMs: number) => Promise<void>;
+
+export interface ClerkProvisioningOptions {
+  operationTimeoutMs?: number;
+  maxAttempts?: number;
+  runOperation?: ClerkOperationRunner;
+  sleep?: ClerkRetrySleeper;
+  classifyError?: ClerkErrorClassifier;
+}
+
+/**
+ * Narrow error seam for a Clerk SDK wrapper. The wrapper may parse an HTTP
+ * Retry-After header, convert it to milliseconds, and throw this redacted
+ * error without exposing a provider response or request payload.
+ */
+export class ClerkRetryableRequestError extends Error {
+  constructor(readonly retryAfterMs?: number) {
+    super("Clerk migration request may be retried");
+    this.name = "ClerkRetryableRequestError";
+  }
+}
+
+class ClerkOperationTimeoutError extends Error {
+  constructor() {
+    super("Clerk migration request timed out");
+    this.name = "ClerkOperationTimeoutError";
+  }
 }
 
 export type ClerkReconciliationReason =
@@ -65,12 +115,130 @@ function assertAuthorizedExecution(execution: ExecutionPlan): void {
   if (!execution.includeSensitive || !execution.confirmedSensitiveData) {
     throw new Error("Clerk identity resolution requires confirmed sensitive-data access");
   }
+  if (!(["local", "preview", "production"] as const).includes(execution.target)) {
+    throw new Error("Clerk identity resolution target is invalid");
+  }
+  if (execution.target === "preview" && !execution.confirmedPreview) {
+    throw new Error("Clerk preview identity resolution requires explicit preview confirmation");
+  }
+  if (execution.target === "production" && !execution.confirmedProduction) {
+    throw new Error("Clerk production identity resolution requires explicit production confirmation");
+  }
+  if (execution.confirmedPreview && execution.target !== "preview") {
+    throw new Error("Clerk preview confirmation does not match the execution target");
+  }
+  if (execution.confirmedProduction && execution.target !== "production") {
+    throw new Error("Clerk production confirmation does not match the execution target");
+  }
+  if (execution.confirmedClerkAutoVerification && !execution.createClerkUsers) {
+    throw new Error("Clerk auto-verification confirmation requires identity creation authorization");
+  }
   if (
     execution.createClerkUsers &&
     !execution.confirmedClerkAutoVerification
   ) {
     throw new Error("Clerk identity creation requires explicit auto-verification confirmation");
   }
+}
+
+function boundedInteger(value: number, minimum: number, maximum: number, name: string): number {
+  if (!Number.isSafeInteger(value) || value < minimum || value > maximum) {
+    throw new RangeError(`${name} must be an integer between ${minimum} and ${maximum}`);
+  }
+  return value;
+}
+
+const defaultRunOperation: ClerkOperationRunner = async (operation, timeoutMs) => {
+  const controller = new AbortController();
+  return await new Promise((resolve, reject) => {
+    let settled = false;
+    const settle = (callback: () => void): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      callback();
+    };
+    const timer = setTimeout(() => {
+      controller.abort();
+      settle(() => reject(new ClerkOperationTimeoutError()));
+    }, timeoutMs);
+    void Promise.resolve().then(() => operation(controller.signal)).then(
+      (result) => settle(() => resolve(result)),
+      (error: unknown) => settle(() => reject(error)),
+    );
+  });
+};
+
+const defaultSleep: ClerkRetrySleeper = async (delayMs) => {
+  await new Promise<void>((resolve) => setTimeout(resolve, delayMs));
+};
+
+const defaultClassifyError: ClerkErrorClassifier = (error) => ({
+  retryable: error instanceof ClerkRetryableRequestError || error instanceof ClerkOperationTimeoutError,
+  ...(error instanceof ClerkRetryableRequestError && error.retryAfterMs !== undefined
+    ? { retryAfterMs: error.retryAfterMs }
+    : {}),
+});
+
+function retryDelay(directive: ClerkRetryDirective, attempt: number): number {
+  const retryAfter = directive.retryAfterMs;
+  if (retryAfter !== undefined && Number.isFinite(retryAfter) && retryAfter >= 0) {
+    return Math.min(Math.ceil(retryAfter), MAX_RETRY_DELAY_MS);
+  }
+  return Math.min(BASE_RETRY_DELAY_MS * (2 ** (attempt - 1)), MAX_RETRY_DELAY_MS);
+}
+
+async function clerkRequest<T>(
+  operation: (signal: AbortSignal) => Promise<T>,
+  runtime: Required<ClerkProvisioningOptions>,
+): Promise<T> {
+  for (let attempt = 1; attempt <= runtime.maxAttempts; attempt += 1) {
+    try {
+      return await runtime.runOperation(operation, runtime.operationTimeoutMs);
+    } catch (error) {
+      const directive = runtime.classifyError(error);
+      if (!directive.retryable || attempt === runtime.maxAttempts) throw error;
+      await runtime.sleep(retryDelay(directive, attempt));
+    }
+  }
+  throw new Error("Clerk migration request failed");
+}
+
+function provisioningRuntime(options: ClerkProvisioningOptions): Required<ClerkProvisioningOptions> {
+  return {
+    operationTimeoutMs: boundedInteger(
+      options.operationTimeoutMs ?? DEFAULT_OPERATION_TIMEOUT_MS,
+      1,
+      MAX_OPERATION_TIMEOUT_MS,
+      "Clerk operation timeout",
+    ),
+    maxAttempts: boundedInteger(
+      options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS,
+      1,
+      MAX_ATTEMPTS,
+      "Clerk request attempts",
+    ),
+    runOperation: options.runOperation ?? defaultRunOperation,
+    sleep: options.sleep ?? defaultSleep,
+    classifyError: options.classifyError ?? defaultClassifyError,
+  };
+}
+
+function userListData(value: unknown): readonly ClerkMigrationUser[] {
+  if (!value || typeof value !== "object" || !Array.isArray((value as { data?: unknown }).data)) {
+    throw new TypeError("Clerk provider returned an invalid user list");
+  }
+  const users = (value as { data: unknown[] }).data;
+  if (users.length > MAX_CLERK_RESULTS) throw new RangeError("Clerk provider returned too many users");
+  if (users.some((user) => {
+    if (!user || typeof user !== "object") return true;
+    const candidate = user as { id?: unknown; externalId?: unknown };
+    return typeof candidate.id !== "string" ||
+      (candidate.externalId !== null && typeof candidate.externalId !== "string");
+  })) {
+    throw new TypeError("Clerk provider returned an invalid user");
+  }
+  return users as unknown as readonly ClerkMigrationUser[];
 }
 
 function parseProvisioningIdentity(plan: CustomerProvisioningPlan): ProvisioningIdentity {
@@ -124,6 +292,7 @@ function exactExternalUser(
       ? { id: null }
       : { id: null, reason: "external-identity-invalid" };
   }
+  if (users.length !== 1) return { id: null, reason: "external-identity-ambiguous" };
   const id = safeClerkUserId(exact[0].id);
   return id ? { id } : { id: null, reason: "external-identity-invalid" };
 }
@@ -147,8 +316,10 @@ export async function provisionClerkCustomers(
   plans: readonly CustomerProvisioningPlan[],
   execution: ExecutionPlan,
   client: ClerkMigrationClient,
+  options: ClerkProvisioningOptions = {},
 ): Promise<ClerkProvisioningResult> {
   assertAuthorizedExecution(execution);
+  const runtime = provisioningRuntime(options);
   if (plans.length > MAX_CLERK_PLANS) throw new RangeError("Clerk provisioning batch is too large");
   const sourceFingerprints = new Set<string>();
   for (const plan of plans) {
@@ -177,10 +348,13 @@ export async function provisionClerkCustomers(
 
     let externalUsers: readonly ClerkMigrationUser[];
     try {
-      externalUsers = (await client.users.getUserList({
-        externalId: [plan.sourceFingerprint],
-        limit: MAX_CLERK_RESULTS,
-      })).data;
+      externalUsers = userListData(await clerkRequest(
+        (signal) => client.users.getUserList({
+          externalId: [plan.sourceFingerprint],
+          limit: MAX_CLERK_RESULTS,
+        }, { signal }),
+        runtime,
+      ));
     } catch {
       pushReconciliation(reconciliation, plan.sourceFingerprint, "provider-request-failed");
       continue;
@@ -202,20 +376,6 @@ export async function provisionClerkCustomers(
       continue;
     }
 
-    let emailUsers: readonly ClerkMigrationUser[];
-    try {
-      emailUsers = (await client.users.getUserList({
-        emailAddress: [identity.email],
-        limit: MAX_CLERK_RESULTS,
-      })).data;
-    } catch {
-      pushReconciliation(reconciliation, plan.sourceFingerprint, "provider-request-failed");
-      continue;
-    }
-    if (emailUsers.length > 0) {
-      pushReconciliation(reconciliation, plan.sourceFingerprint, "email-conflict");
-      continue;
-    }
     if (!identity.sourceVerified) {
       pushReconciliation(reconciliation, plan.sourceFingerprint, "source-email-unverified");
       continue;
@@ -225,14 +385,35 @@ export async function provisionClerkCustomers(
       continue;
     }
 
+    let emailUsers: readonly ClerkMigrationUser[];
     try {
-      const user = await client.users.createUser({
-        emailAddress: [identity.email],
-        ...(identity.firstName ? { firstName: identity.firstName } : {}),
-        ...(identity.lastName ? { lastName: identity.lastName } : {}),
-        externalId: plan.sourceFingerprint,
-        skipLegalChecks: true,
-      });
+      emailUsers = userListData(await clerkRequest(
+        (signal) => client.users.getUserList({
+          emailAddress: [identity.email],
+          limit: MAX_CLERK_RESULTS,
+        }, { signal }),
+        runtime,
+      ));
+    } catch {
+      pushReconciliation(reconciliation, plan.sourceFingerprint, "provider-request-failed");
+      continue;
+    }
+    if (emailUsers.length > 0) {
+      pushReconciliation(reconciliation, plan.sourceFingerprint, "email-conflict");
+      continue;
+    }
+
+    try {
+      const user = await clerkRequest(
+        (signal) => client.users.createUser({
+          emailAddress: [identity.email],
+          ...(identity.firstName ? { firstName: identity.firstName } : {}),
+          ...(identity.lastName ? { lastName: identity.lastName } : {}),
+          externalId: plan.sourceFingerprint,
+          skipLegalChecks: true,
+        }, { signal }),
+        runtime,
+      );
       const userId = user.externalId === plan.sourceFingerprint
         ? safeClerkUserId(user.id)
         : null;

--- a/scripts/shopify-migration/adapters/d1/index.ts
+++ b/scripts/shopify-migration/adapters/d1/index.ts
@@ -1,0 +1,3 @@
+export * from "./plan.js";
+export * from "./runner.js";
+export * from "./sql.js";

--- a/scripts/shopify-migration/adapters/d1/plan.ts
+++ b/scripts/shopify-migration/adapters/d1/plan.ts
@@ -465,7 +465,7 @@ export function buildD1ImportPlan(input: MaterializedD1Input, options: D1PlanOpt
         page.title !== version.title || page.content !== version.content ||
         page.excerpt !== version.excerpt || page.meta_title !== version.meta_title ||
         page.meta_description !== version.meta_description || page.meta_keywords !== version.meta_keywords ||
-        typeof page.template !== "string" || !page.template.trim() || page.template.length > 100 ||
+        page.template !== "default" ||
         page.custom_css !== null || page.custom_js !== null) {
       throw new TypeError("Initial page version must exactly match the supported page snapshot contract");
     }

--- a/scripts/shopify-migration/adapters/d1/plan.ts
+++ b/scripts/shopify-migration/adapters/d1/plan.ts
@@ -1,0 +1,635 @@
+import type { ExecutionPlan } from "../../lib/config.js";
+import type { BlogCategoryPlan, BlogPostPlan } from "../../transformers/blog.js";
+import type { CategoryTransformRecord } from "../../transformers/categories.js";
+import type { PageTransformRecord } from "../../transformers/pages.js";
+import type { ProductTransformRecord } from "../../transformers/products.js";
+import type { RedirectCandidate } from "../../transformers/redirects.js";
+import {
+  DEFAULT_D1_CHUNK_BYTES,
+  DEFAULT_D1_CHUNK_STATEMENTS,
+  MAX_D1_STATEMENT_BYTES,
+  buildInsertStatement,
+  sqlLiteral,
+  type SqlRecord,
+  type SqlScalar,
+} from "./sql.js";
+
+export const D1_DEPENDENCIES = [
+  "categories",
+  "products",
+  "variants",
+  "inventory",
+  "pages",
+  "page-versions",
+  "blog-categories",
+  "blog-posts",
+  "customers",
+  "orders",
+  "reviews",
+  "redirects",
+] as const;
+
+export type D1Dependency = (typeof D1_DEPENDENCIES)[number];
+
+export interface MaterializedD1Input {
+  categories?: readonly CategoryTransformRecord[];
+  products?: readonly ProductTransformRecord[];
+  pages?: readonly PageTransformRecord[];
+  blog?: {
+    categories: readonly BlogCategoryPlan[];
+    records: readonly BlogPostPlan[];
+  };
+  /** Rows must already contain final Clerk user IDs, never provisioning IDs. */
+  customers?: readonly object[];
+  orders?: readonly { order: object }[];
+  reviews?: readonly { review: object }[];
+  redirects?: readonly RedirectCandidate[];
+}
+
+export interface D1PlanOptions {
+  overwrite?: boolean;
+  maxChunkBytes?: number;
+  maxChunkStatements?: number;
+}
+
+export interface D1StatementUnit {
+  dependency: D1Dependency;
+  statements: readonly string[];
+}
+
+export interface D1ValidationUnit {
+  dependency: D1Dependency | "references";
+  sql: string;
+}
+
+export interface D1ImportPlan {
+  overwrite: boolean;
+  containsSensitiveRows: boolean;
+  counts: Readonly<Record<D1Dependency, number>>;
+  chunks: readonly string[];
+  validation: readonly D1ValidationUnit[];
+  requiredMediaPaths: readonly string[];
+}
+
+const TABLE_COLUMNS = {
+  categories: new Set([
+    "id", "name", "description", "slug", "status", "parent_id", "position", "path",
+    "external_references", "created_at", "updated_at", "children", "product_count", "attributes",
+    "tags", "primary_image", "media", "seo", "extensions",
+  ]),
+  products: new Set([
+    "id", "name", "type", "status", "external_references", "created_at", "updated_at", "description",
+    "slug", "brand", "categories", "tags", "options", "default_variant_id", "fulfillment_type",
+    "tax_category", "primary_image", "media", "seo", "rating", "related_products", "extensions",
+  ]),
+  product_variants: new Set([
+    "id", "product_id", "sku", "option_values", "price", "status", "position", "compare_at_price",
+    "cost", "weight", "dimensions", "barcode", "inventory", "tax_category", "shipping_required", "media",
+    "attributes", "created_at", "updated_at",
+  ]),
+  inventory: new Set([
+    "id", "sku_id", "location_id", "quantities", "status", "stock_status", "external_references",
+    "created_at", "updated_at", "policy_id", "backorderable", "backorder_eta", "safety_stock", "version",
+    "extensions",
+  ]),
+  pages: new Set([
+    "title", "slug", "content", "excerpt", "meta_title", "meta_description", "meta_keywords", "status",
+    "published_at", "template", "parent_id", "sort_order", "created_at", "updated_at", "created_by",
+    "updated_by", "version", "show_in_nav", "nav_title", "custom_css", "custom_js", "is_protected",
+    "required_roles",
+  ]),
+  page_versions: new Set([
+    "title", "content", "excerpt", "meta_title", "meta_description", "meta_keywords", "version",
+    "change_summary", "created_at", "created_by",
+  ]),
+  blog_categories: new Set(["name", "slug", "description", "created_at", "updated_at"]),
+  blog_posts: new Set([
+    "title", "slug", "author", "excerpt", "tags", "cover_image_url", "cover_image_alt", "status",
+    "editor_json", "html", "reading_time", "meta_title", "meta_description", "published_at", "created_at",
+    "updated_at", "created_by", "updated_by",
+  ]),
+  customers: new Set([
+    "id", "type", "status", "external_references", "created_at", "updated_at", "person", "company",
+    "contacts", "addresses", "communication_preferences", "segments", "tags", "loyalty", "authentication",
+    "extensions",
+  ]),
+  orders: new Set([
+    "id", "customer_id", "status", "total_amount", "currency_code", "shipping_address", "billing_address",
+    "items", "shipping_method", "shipping_carrier", "payment_method", "payment_status", "notes", "created_at",
+    "updated_at", "shipped_at", "delivered_at", "tracking_number", "external_references", "extensions",
+  ]),
+  product_reviews: new Set([
+    "id", "product_id", "order_id", "order_item_id", "customer_id", "rating", "title", "body", "status",
+    "is_verified", "automated_moderation", "moderation_notes", "admin_response", "response_author_id",
+    "responded_at", "submitted_at", "published_at", "created_at", "updated_at", "metadata",
+  ]),
+  redirect_map: new Set(["source_path", "target_path", "status_code", "entity_type", "created_at"]),
+} as const;
+
+type TableName = keyof typeof TABLE_COLUMNS;
+
+const REQUIRED_COLUMNS: Readonly<Record<TableName, readonly string[]>> = {
+  categories: ["id", "name"],
+  products: ["id", "name", "default_variant_id"],
+  product_variants: ["id", "product_id", "sku", "option_values", "price"],
+  inventory: ["id", "sku_id", "location_id", "quantities"],
+  pages: ["title", "slug", "content", "created_by"],
+  page_versions: ["title", "content", "version", "created_by"],
+  blog_categories: ["name", "slug"],
+  blog_posts: ["title", "slug", "author", "tags", "html", "reading_time"],
+  customers: ["id", "type"],
+  orders: ["id", "total_amount", "currency_code", "items"],
+  product_reviews: ["id", "product_id", "order_id", "customer_id", "rating", "body", "status"],
+  redirect_map: ["source_path", "target_path", "status_code"],
+};
+
+function isSqlScalar(value: unknown): value is SqlScalar {
+  return value === null || typeof value === "string" || typeof value === "boolean" ||
+    (typeof value === "number" && Number.isSafeInteger(value));
+}
+
+function rowFor(table: TableName, value: object): SqlRecord {
+  if (!value || Array.isArray(value) || Object.getPrototypeOf(value) !== Object.prototype) {
+    throw new TypeError(`${table} row must be a plain object`);
+  }
+  const entries = Object.entries(value);
+  if (entries.length < 1 || entries.length > 64) throw new TypeError(`${table} row has an invalid column count`);
+  const allowed = TABLE_COLUMNS[table] as ReadonlySet<string>;
+  for (const [column, scalar] of entries) {
+    if (!allowed.has(column)) throw new TypeError(`${table} row contains an unknown column`);
+    if (!isSqlScalar(scalar)) throw new TypeError(`${table} row contains a non-scalar value`);
+  }
+  for (const column of REQUIRED_COLUMNS[table]) {
+    if (!Object.hasOwn(value, column) || value[column as keyof typeof value] === null) {
+      throw new TypeError(`${table} row is missing a required column`);
+    }
+  }
+  return Object.fromEntries(entries) as SqlRecord;
+}
+
+function requiredText(row: SqlRecord, column: string): string {
+  const value = row[column];
+  if (typeof value !== "string" || !value) throw new TypeError(`Required ${column} reference is invalid`);
+  return value;
+}
+
+function unique(values: readonly string[], description: string): void {
+  if (new Set(values).size !== values.length) throw new TypeError(`Duplicate ${description} in D1 plan`);
+}
+
+function mode(overwrite: boolean): "overwrite" | "compare" {
+  return overwrite ? "overwrite" : "compare";
+}
+
+function boundedStatement(statement: string): string {
+  if (!statement.endsWith(";") || Buffer.byteLength(statement, "utf8") > MAX_D1_STATEMENT_BYTES) {
+    throw new RangeError("Generated D1 statement exceeds the statement safety limit");
+  }
+  return statement;
+}
+
+/** Compare an insert-only row without changing merchant content. A mismatch
+ * assigns NULL to a NOT NULL guard so the enclosing Wrangler SQL batch aborts. */
+function compareExistingStatement(
+  table: TableName,
+  row: SqlRecord,
+  key: string,
+  guard: string,
+  ignored: readonly string[] = [],
+  extraComparison?: string,
+): string {
+  const comparisons = [
+    ...Object.entries(row)
+    .filter(([column]) => !ignored.includes(column))
+    .map(([column, value]) => `"${column}" IS ${sqlLiteral(value)}`),
+    ...(extraComparison ? [extraComparison] : []),
+  ].join(" AND ");
+  if (!comparisons || row[guard] === null || row[guard] === undefined || row[key] === undefined) {
+    throw new TypeError("Insert-only comparison requires a non-null guard and semantic fields");
+  }
+  return boundedStatement(
+    `UPDATE "${table}" SET "${guard}" = CASE WHEN ${comparisons} THEN "${guard}" ELSE NULL END ` +
+    `WHERE "${key}" = ${sqlLiteral(row[key])};`,
+  );
+}
+
+function pageVersionStatement(slug: string, record: SqlRecord): string {
+  const entries = Object.entries(record);
+  const columns = ["page_id", ...entries.map(([column]) => column)];
+  const values = entries.map(([, value]) => sqlLiteral(value));
+  return boundedStatement(
+    `INSERT INTO "page_versions" (${columns.map((column) => `"${column}"`).join(", ")}) ` +
+    `SELECT "id", ${values.join(", ")} FROM "pages" WHERE "slug" = ${sqlLiteral(slug)} AND changes() = 1;`,
+  );
+}
+
+function blogPostStatement(categorySlug: string, record: SqlRecord): string {
+  const entries = Object.entries(record);
+  const columns = [...entries.map(([column]) => column), "category_id"];
+  const values = entries.map(([, value]) => sqlLiteral(value));
+  return boundedStatement(
+    `INSERT INTO "blog_posts" (${columns.map((column) => `"${column}"`).join(", ")}) ` +
+    `SELECT ${values.join(", ")}, "id" FROM "blog_categories" WHERE "slug" = ${sqlLiteral(categorySlug)} ` +
+    `ON CONFLICT ("slug") DO NOTHING;`,
+  );
+}
+
+function chunkUnits(units: readonly D1StatementUnit[], options: D1PlanOptions): string[] {
+  const maxBytes = options.maxChunkBytes ?? DEFAULT_D1_CHUNK_BYTES;
+  const maxStatements = options.maxChunkStatements ?? DEFAULT_D1_CHUNK_STATEMENTS;
+  if (!Number.isSafeInteger(maxBytes) || maxBytes < 256 || maxBytes > 16 * 1024 * 1024) {
+    throw new RangeError("maxChunkBytes is outside the safe range");
+  }
+  if (!Number.isSafeInteger(maxStatements) || maxStatements < 3 || maxStatements > 10_000) {
+    throw new RangeError("maxChunkStatements is outside the safe range");
+  }
+  const header = "PRAGMA foreign_keys = ON;\n";
+  const chunks: string[] = [];
+  let statements: string[] = [];
+  let bytes = Buffer.byteLength(header, "utf8");
+  for (const unit of units) {
+    const unitText = `${unit.statements.join("\n")}\n`;
+    const unitBytes = Buffer.byteLength(unitText, "utf8");
+    if (unit.statements.length + 1 > maxStatements || unitBytes + Buffer.byteLength(header, "utf8") > maxBytes) {
+      throw new RangeError("Atomic D1 statement unit exceeds the configured chunk limit");
+    }
+    if (statements.length && (statements.length + unit.statements.length + 1 > maxStatements || bytes + unitBytes > maxBytes)) {
+      chunks.push(`${header}${statements.join("\n")}\n`);
+      statements = [];
+      bytes = Buffer.byteLength(header, "utf8");
+    }
+    statements.push(...unit.statements);
+    bytes += unitBytes;
+  }
+  if (statements.length) chunks.push(`${header}${statements.join("\n")}\n`);
+  return chunks;
+}
+
+function jsonStringArray(value: SqlScalar, field: string): string[] {
+  if (value === null || value === undefined) return [];
+  if (typeof value !== "string") throw new TypeError(`${field} must be a JSON array`);
+  let parsed: unknown;
+  try { parsed = JSON.parse(value); } catch { throw new TypeError(`${field} must be valid JSON`); }
+  if (!Array.isArray(parsed) || !parsed.every((item) => typeof item === "string" && item.length > 0)) {
+    throw new TypeError(`${field} must be a JSON string array`);
+  }
+  return parsed;
+}
+
+function orderItemReferences(value: SqlScalar): Array<{ id: string; productId: string; variantId?: string }> {
+  if (typeof value !== "string") throw new TypeError("Order items must be JSON");
+  let parsed: unknown;
+  try { parsed = JSON.parse(value); } catch { throw new TypeError("Order items must be valid JSON"); }
+  if (!Array.isArray(parsed) || !parsed.length || !parsed.every((item) => item && typeof item === "object" && !Array.isArray(item))) {
+    throw new TypeError("Order items must be a non-empty object array");
+  }
+  return parsed.map((item) => {
+    const source = item as Record<string, unknown>;
+    if (typeof source.id !== "string" || !source.id || typeof source.product_id !== "string" || !source.product_id) {
+      throw new TypeError("Order item references are invalid");
+    }
+    if (source.variant_id !== undefined && (typeof source.variant_id !== "string" || !source.variant_id)) {
+      throw new TypeError("Order variant reference is invalid");
+    }
+    return {
+      id: source.id,
+      productId: source.product_id,
+      ...(typeof source.variant_id === "string" ? { variantId: source.variant_id } : {}),
+    };
+  });
+}
+
+const MEDIA_PATH = /\/media\/(?:products|categories|blog|pages)\/[A-Za-z0-9._/-]+/gu;
+
+function mediaPaths(rows: readonly SqlRecord[]): string[] {
+  const paths = new Set<string>();
+  for (const row of rows) {
+    for (const value of Object.values(row)) {
+      if (typeof value !== "string") continue;
+      for (const match of value.matchAll(MEDIA_PATH)) paths.add(match[0]);
+    }
+  }
+  return [...paths].sort();
+}
+
+function validationQuery(table: string, key: string, values: readonly string[], joinSql = ""): D1ValidationUnit[] {
+  const units: D1ValidationUnit[] = [];
+  for (let offset = 0; offset < values.length; offset += 100) {
+    const batch = values.slice(offset, offset + 100);
+    const expected = batch.map((value) => `(${sqlLiteral(value)})`).join(", ");
+    const exists = joinSql || `SELECT 1 FROM "${table}" AS row WHERE row."${key}" = expected.value`;
+    units.push({
+      dependency: D1_DEPENDENCIES.find((dependency) => dependency === table) ?? "references",
+      sql: boundedStatement(
+        `WITH expected(value) AS (VALUES ${expected}) ` +
+        `SELECT COUNT(*) AS expected_count, COALESCE(SUM(EXISTS(${exists})), 0) AS actual_count FROM expected;`,
+      ),
+    });
+  }
+  return units;
+}
+
+function pageVersionValidation(pages: readonly { slug: string; actor: string }[]): D1ValidationUnit[] {
+  const units: D1ValidationUnit[] = [];
+  for (let offset = 0; offset < pages.length; offset += 100) {
+    const batch = pages.slice(offset, offset + 100);
+    const expected = batch.map(({ slug, actor }) => `(${sqlLiteral(slug)}, ${sqlLiteral(actor)})`).join(", ");
+    units.push({
+      dependency: "page-versions",
+      sql: boundedStatement(
+        `WITH expected(slug, actor) AS (VALUES ${expected}) ` +
+        `SELECT COUNT(*) AS expected_count, COALESCE(SUM(EXISTS(` +
+        `SELECT 1 FROM "pages" AS page WHERE page."slug" = expected.slug AND (` +
+        `page."created_by" IS NOT expected.actor OR EXISTS(` +
+        `SELECT 1 FROM "page_versions" AS version WHERE version."page_id" = page."id" ` +
+        `AND version."version" = 1 AND version."created_by" = expected.actor` +
+        `))` +
+        `)), 0) AS actual_count FROM expected;`,
+      ),
+    });
+  }
+  return units;
+}
+
+export function assertExecutionGates(execution: ExecutionPlan, containsSensitiveRows: boolean): void {
+  if (!(["local", "preview", "production"] as const).includes(execution.target)) {
+    throw new Error("D1 execution target is invalid");
+  }
+  if (execution.apply === execution.dryRun) throw new Error("Exactly one of apply or dry-run must be selected");
+  if (execution.target === "preview" && execution.apply && !execution.confirmedPreview) {
+    throw new Error("Preview apply requires explicit confirmation");
+  }
+  if (execution.target === "production" && execution.apply && !execution.confirmedProduction) {
+    throw new Error("Production apply requires explicit confirmation");
+  }
+  if (execution.overwrite && execution.apply && !execution.confirmedOverwrite) {
+    throw new Error("Overwrite apply requires explicit confirmation");
+  }
+  if (!execution.overwrite && execution.confirmedOverwrite) {
+    throw new Error("Overwrite confirmation requires overwrite mode");
+  }
+  if (containsSensitiveRows && (!execution.includeSensitive || !execution.confirmedSensitiveData)) {
+    throw new Error("Sensitive rows require both inclusion and confirmation");
+  }
+}
+
+export function buildD1ImportPlan(input: MaterializedD1Input, options: D1PlanOptions = {}): D1ImportPlan {
+  const overwrite = options.overwrite === true;
+  const units: D1StatementUnit[] = [];
+  const allRows: SqlRecord[] = [];
+  const counts = Object.fromEntries(D1_DEPENDENCIES.map((dependency) => [dependency, 0])) as Record<D1Dependency, number>;
+  const ids: Record<"categories" | "products" | "variants" | "inventory" | "customers" | "orders" | "reviews", string[]> = {
+    categories: [], products: [], variants: [], inventory: [], customers: [], orders: [], reviews: [],
+  };
+  const pageSlugs: string[] = [];
+  const pageVersionReferences: Array<{ slug: string; actor: string }> = [];
+  const blogCategorySlugs: string[] = [];
+  const blogPostSlugs: string[] = [];
+  const redirectPaths: string[] = [];
+
+  for (const item of input.categories ?? []) {
+    const row = rowFor("categories", item.category);
+    const id = requiredText(row, "id");
+    if (row.parent_id !== undefined && row.parent_id !== null &&
+        (typeof row.parent_id !== "string" || !ids.categories.includes(row.parent_id))) {
+      throw new TypeError("Category parent reference is unresolved or not dependency ordered");
+    }
+    ids.categories.push(id);
+    allRows.push(row);
+    units.push({ dependency: "categories", statements: [buildInsertStatement({
+      table: "categories", row, conflictColumns: ["id"], mode: mode(overwrite), guardColumn: "name",
+    })] });
+    counts.categories += 1;
+  }
+  unique(ids.categories, "category ID");
+
+  const variantRows: SqlRecord[] = [];
+  const inventoryRows: SqlRecord[] = [];
+  for (const item of input.products ?? []) {
+    const product = rowFor("products", item.product);
+    const productId = requiredText(product, "id");
+    const ownVariants = item.variants.map((value) => rowFor("product_variants", value));
+    const ownVariantIds = ownVariants.map((row) => requiredText(row, "id"));
+    if (!ownVariants.length || !ownVariantIds.includes(requiredText(product, "default_variant_id"))) {
+      throw new TypeError("Product default variant reference is unresolved");
+    }
+    if (ownVariants.some((row) => requiredText(row, "product_id") !== productId)) {
+      throw new TypeError("Variant product reference is unresolved");
+    }
+    for (const categoryId of jsonStringArray(product.categories, "Product categories")) {
+      if (!ids.categories.includes(categoryId)) throw new TypeError("Product category reference is unresolved");
+    }
+    const ownInventory = item.inventory.map((value) => rowFor("inventory", value));
+    if (ownInventory.some((row) => !ownVariantIds.includes(requiredText(row, "sku_id")))) {
+      throw new TypeError("Inventory variant reference is unresolved");
+    }
+    ids.products.push(productId);
+    ids.variants.push(...ownVariantIds);
+    ids.inventory.push(...ownInventory.map((row) => requiredText(row, "id")));
+    allRows.push(product, ...ownVariants, ...ownInventory);
+    units.push({ dependency: "products", statements: [buildInsertStatement({
+      table: "products", row: product, conflictColumns: ["id"], mode: mode(overwrite), guardColumn: "name",
+    })] });
+    variantRows.push(...ownVariants);
+    inventoryRows.push(...ownInventory);
+    counts.products += 1;
+    counts.variants += ownVariants.length;
+    counts.inventory += ownInventory.length;
+  }
+  unique(ids.products, "product ID");
+  unique(ids.variants, "variant ID");
+  unique(ids.inventory, "inventory ID");
+  for (const row of variantRows) units.push({ dependency: "variants", statements: [buildInsertStatement({
+    table: "product_variants", row, conflictColumns: ["id"], mode: mode(overwrite), guardColumn: "product_id",
+  })] });
+  for (const row of inventoryRows) units.push({ dependency: "inventory", statements: [buildInsertStatement({
+    table: "inventory", row, conflictColumns: ["id"], mode: mode(overwrite), guardColumn: "sku_id",
+  })] });
+
+  for (const item of input.pages ?? []) {
+    const page = rowFor("pages", item.page);
+    const version = rowFor("page_versions", item.initialVersion.record);
+    const slug = requiredText(page, "slug");
+    if (item.initialVersion.pageReference.provider !== "shopify" ||
+        item.initialVersion.pageReference.sourceFingerprint !== item.sourceFingerprint ||
+        item.initialVersion.pageReference.slug !== slug || item.conflict.strategy !== "insert-only") {
+      throw new TypeError("Page version reference or conflict policy is invalid");
+    }
+    if (page.parent_id !== null) throw new TypeError("Imported pages cannot use unresolved auto-ID parents");
+    pageSlugs.push(slug);
+    pageVersionReferences.push({ slug, actor: requiredText(page, "created_by") });
+    allRows.push(page, version);
+    units.push({ dependency: "page-versions", statements: [
+      buildInsertStatement({ table: "pages", row: page, conflictColumns: ["slug"], mode: "insert-only" }),
+      pageVersionStatement(slug, version),
+      compareExistingStatement("pages", page, "slug", "title", ["created_at", "updated_at"]),
+    ] });
+    counts.pages += 1;
+    counts["page-versions"] += 1;
+  }
+  unique(pageSlugs, "page slug");
+
+  const categoriesByFingerprint = new Map<string, string>();
+  for (const item of input.blog?.categories ?? []) {
+    const row = rowFor("blog_categories", item.record);
+    const slug = requiredText(row, "slug");
+    if (item.conflict.strategy !== "insert-only") throw new TypeError("Blog category conflict policy is invalid");
+    if (categoriesByFingerprint.has(item.sourceFingerprint)) throw new TypeError("Duplicate blog category fingerprint");
+    categoriesByFingerprint.set(item.sourceFingerprint, slug);
+    blogCategorySlugs.push(slug);
+    allRows.push(row);
+    units.push({ dependency: "blog-categories", statements: [
+      buildInsertStatement({ table: "blog_categories", row, conflictColumns: ["slug"], mode: "insert-only" }),
+      compareExistingStatement("blog_categories", row, "slug", "name", ["created_at", "updated_at"]),
+    ] });
+    counts["blog-categories"] += 1;
+  }
+  unique(blogCategorySlugs, "blog category slug");
+
+  for (const item of input.blog?.records ?? []) {
+    const row = rowFor("blog_posts", item.record);
+    const slug = requiredText(row, "slug");
+    const categorySlug = categoriesByFingerprint.get(item.categoryReference.sourceFingerprint);
+    if (item.categoryReference.provider !== "shopify" || !categorySlug ||
+        categorySlug !== item.categoryReference.slug || item.conflict.strategy !== "insert-only") {
+      throw new TypeError("Blog post category reference or conflict policy is unresolved");
+    }
+    blogPostSlugs.push(slug);
+    allRows.push(row);
+    units.push({ dependency: "blog-posts", statements: [
+      blogPostStatement(categorySlug, row),
+      compareExistingStatement(
+        "blog_posts",
+        row,
+        "slug",
+        "title",
+        ["created_at", "updated_at"],
+        `"category_id" IS (SELECT "id" FROM "blog_categories" WHERE "slug" = ${sqlLiteral(categorySlug)})`,
+      ),
+    ] });
+    counts["blog-posts"] += 1;
+  }
+  unique(blogPostSlugs, "blog post slug");
+
+  const customerRows = (input.customers ?? []).map((value) => rowFor("customers", value));
+  for (const row of customerRows) {
+    const id = requiredText(row, "id");
+    if (!/^user_[A-Za-z0-9]{8,250}$/.test(id)) throw new TypeError("Customer row lacks a final Clerk user ID");
+    ids.customers.push(id);
+    allRows.push(row);
+    units.push({ dependency: "customers", statements: [buildInsertStatement({
+      table: "customers", row, conflictColumns: ["id"], mode: mode(overwrite), guardColumn: "type",
+    })] });
+    counts.customers += 1;
+  }
+  unique(ids.customers, "customer ID");
+
+  const orderReferences = new Map<string, {
+    customerId: string | null;
+    items: ReturnType<typeof orderItemReferences>;
+  }>();
+  for (const item of input.orders ?? []) {
+    const row = rowFor("orders", item.order);
+    const id = requiredText(row, "id");
+    const customer = row.customer_id;
+    if (customer !== null && (typeof customer !== "string" || !ids.customers.includes(customer))) {
+      throw new TypeError("Order customer reference is unresolved");
+    }
+    const items = orderItemReferences(row.items);
+    for (const reference of items) {
+      if (!ids.products.includes(reference.productId) || (reference.variantId && !ids.variants.includes(reference.variantId))) {
+        throw new TypeError("Order product or variant reference is unresolved");
+      }
+    }
+    ids.orders.push(id);
+    orderReferences.set(id, {
+      customerId: typeof customer === "string" ? customer : null,
+      items,
+    });
+    allRows.push(row);
+    units.push({ dependency: "orders", statements: [buildInsertStatement({
+      table: "orders", row, conflictColumns: ["id"], mode: mode(overwrite), guardColumn: "total_amount",
+    })] });
+    counts.orders += 1;
+  }
+  unique(ids.orders, "order ID");
+
+  for (const item of input.reviews ?? []) {
+    const row = rowFor("product_reviews", item.review);
+    const id = requiredText(row, "id");
+    const productId = requiredText(row, "product_id");
+    const orderId = requiredText(row, "order_id");
+    const customerId = requiredText(row, "customer_id");
+    const purchase = orderReferences.get(orderId);
+    if (!ids.products.includes(productId) || !purchase || !ids.customers.includes(customerId) ||
+        purchase.customerId !== customerId) {
+      throw new TypeError("Review product, order, or customer reference is unresolved");
+    }
+    const orderItemId = row.order_item_id;
+    const matchingItems = purchase.items.filter((entry) => entry.productId === productId);
+    if (!matchingItems.length || (orderItemId !== null && (
+      typeof orderItemId !== "string" || !matchingItems.some((entry) => entry.id === orderItemId)
+    ))) throw new TypeError("Review order-item and product provenance is unresolved");
+    if (row.is_verified === true && orderItemId === null) {
+      throw new TypeError("Verified review provenance requires an exact order-item reference");
+    }
+    ids.reviews.push(id);
+    allRows.push(row);
+    units.push({ dependency: "reviews", statements: [buildInsertStatement({
+      table: "product_reviews", row, conflictColumns: ["id"], mode: mode(overwrite), guardColumn: "product_id",
+    })] });
+    counts.reviews += 1;
+  }
+  unique(ids.reviews, "review ID");
+
+  for (const item of input.redirects ?? []) {
+    const row = rowFor("redirect_map", {
+      source_path: item.sourcePath,
+      target_path: item.targetPath,
+      status_code: item.statusCode,
+      entity_type: item.entityType,
+      created_at: 0,
+    });
+    redirectPaths.push(item.sourcePath);
+    allRows.push(row);
+    units.push({ dependency: "redirects", statements: [buildInsertStatement({
+      table: "redirect_map", row, conflictColumns: ["source_path"], mode: mode(overwrite), guardColumn: "target_path",
+    })] });
+    counts.redirects += 1;
+  }
+  unique(redirectPaths, "redirect source path");
+
+  const actualOrder = units.map((unit) => D1_DEPENDENCIES.indexOf(unit.dependency));
+  if (actualOrder.some((value, index) => index > 0 && value < actualOrder[index - 1])) {
+    throw new Error("Internal D1 dependency order is invalid");
+  }
+
+  const validation: D1ValidationUnit[] = [
+    ...validationQuery("categories", "id", ids.categories),
+    ...validationQuery("products", "id", ids.products),
+    ...validationQuery("product_variants", "id", ids.variants,
+      'SELECT 1 FROM "product_variants" AS row JOIN "products" AS parent ON parent."id" = row."product_id" WHERE row."id" = expected.value'),
+    ...validationQuery("inventory", "id", ids.inventory,
+      'SELECT 1 FROM "inventory" AS row JOIN "product_variants" AS parent ON parent."id" = row."sku_id" WHERE row."id" = expected.value'),
+    ...validationQuery("pages", "slug", pageSlugs),
+    ...pageVersionValidation(pageVersionReferences),
+    ...validationQuery("blog_categories", "slug", blogCategorySlugs),
+    ...validationQuery("blog_posts", "slug", blogPostSlugs,
+      'SELECT 1 FROM "blog_posts" AS row JOIN "blog_categories" AS parent ON parent."id" = row."category_id" WHERE row."slug" = expected.value'),
+    ...validationQuery("customers", "id", ids.customers),
+    ...validationQuery("orders", "id", ids.orders,
+      'SELECT 1 FROM "orders" AS row LEFT JOIN "customers" AS parent ON parent."id" = row."customer_id" WHERE row."id" = expected.value AND (row."customer_id" IS NULL OR parent."id" IS NOT NULL)'),
+    ...validationQuery("product_reviews", "id", ids.reviews,
+      'SELECT 1 FROM "product_reviews" AS row JOIN "products" AS product ON product."id" = row."product_id" JOIN "orders" AS purchase ON purchase."id" = row."order_id" JOIN "customers" AS customer ON customer."id" = row."customer_id" WHERE row."id" = expected.value'),
+    ...validationQuery("redirect_map", "source_path", redirectPaths),
+  ];
+
+  return {
+    overwrite,
+    containsSensitiveRows: counts.customers + counts.orders + counts.reviews > 0,
+    counts,
+    chunks: chunkUnits(units, options),
+    validation,
+    requiredMediaPaths: mediaPaths(allRows),
+  };
+}

--- a/scripts/shopify-migration/adapters/d1/plan.ts
+++ b/scripts/shopify-migration/adapters/d1/plan.ts
@@ -133,7 +133,7 @@ const REQUIRED_COLUMNS: Readonly<Record<TableName, readonly string[]>> = {
   products: ["id", "name", "default_variant_id"],
   product_variants: ["id", "product_id", "sku", "option_values", "price"],
   inventory: ["id", "sku_id", "location_id", "quantities"],
-  pages: ["title", "slug", "content", "created_by"],
+  pages: ["title", "slug", "content", "template", "created_by", "updated_by", "version"],
   page_versions: ["title", "content", "version", "created_by"],
   blog_categories: ["name", "slug"],
   blog_posts: ["title", "slug", "author", "tags", "html", "reading_time"],
@@ -456,6 +456,19 @@ export function buildD1ImportPlan(input: MaterializedD1Input, options: D1PlanOpt
       throw new TypeError("Page version reference or conflict policy is invalid");
     }
     if (page.parent_id !== null) throw new TypeError("Imported pages cannot use unresolved auto-ID parents");
+    const pageSnapshotColumns = ["excerpt", "meta_title", "meta_description", "meta_keywords", "custom_css", "custom_js"];
+    const versionSnapshotColumns = ["excerpt", "meta_title", "meta_description", "meta_keywords"];
+    if (!pageSnapshotColumns.every((column) => Object.hasOwn(page, column)) ||
+        !versionSnapshotColumns.every((column) => Object.hasOwn(version, column)) ||
+        page.version !== 1 || version.version !== 1 ||
+        page.created_by !== version.created_by || page.updated_by !== version.created_by ||
+        page.title !== version.title || page.content !== version.content ||
+        page.excerpt !== version.excerpt || page.meta_title !== version.meta_title ||
+        page.meta_description !== version.meta_description || page.meta_keywords !== version.meta_keywords ||
+        typeof page.template !== "string" || !page.template.trim() || page.template.length > 100 ||
+        page.custom_css !== null || page.custom_js !== null) {
+      throw new TypeError("Initial page version must exactly match the supported page snapshot contract");
+    }
     pageSlugs.push(slug);
     pageVersionReferences.push({ slug, actor: requiredText(page, "created_by") });
     allRows.push(page, version);

--- a/scripts/shopify-migration/adapters/d1/runner.ts
+++ b/scripts/shopify-migration/adapters/d1/runner.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
 import { mkdtemp, readFile, realpath, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, isAbsolute, join, relative } from "node:path";
@@ -80,8 +81,29 @@ export interface RunD1ImportOptions {
   expectedDatabaseName?: string;
   mediaEvidence?: readonly D1MediaEvidence[];
   commandRunner: CommandRunner;
+  /** Receipt from the read-only preflight that ran before non-D1 external writes. */
+  preflightReceipt?: D1PreflightReceipt;
   privateFiles?: PrivateSqlFiles;
   planOptions?: Omit<D1PlanOptions, "overwrite">;
+}
+
+export interface PreflightD1Options {
+  execution: ExecutionPlan;
+  /** Absolute, canonical project root containing wrangler.jsonc and local dependencies. */
+  projectRoot: string;
+  projectFiles?: D1ProjectFiles;
+  wranglerEnvironment?: string;
+  expectedDatabaseName?: string;
+  commandRunner: CommandRunner;
+}
+
+export interface D1PreflightReceipt {
+  version: 1;
+  target: WranglerTarget;
+  databaseName: string;
+  databaseId: string | null;
+  environment: string | null;
+  projectDigest: string;
 }
 
 export interface D1DryRunResult {
@@ -487,6 +509,18 @@ interface D1ProjectSnapshot {
   packageJsonBytes: Buffer;
 }
 
+function projectDigest(snapshot: D1ProjectSnapshot): string {
+  const hash = createHash("sha256");
+  for (const value of [
+    snapshot.root,
+    snapshot.configPath,
+    snapshot.executablePath,
+    snapshot.packageJsonPath,
+  ]) hash.update(value, "utf8").update("\0", "utf8");
+  hash.update(snapshot.configBytes).update(snapshot.packageJsonBytes).update(snapshot.executableBytes);
+  return hash.digest("hex");
+}
+
 const MAX_PACKAGE_JSON_BYTES = 256 * 1024;
 const MAX_WRANGLER_ENTRY_BYTES = 8 * 1024 * 1024;
 
@@ -703,6 +737,64 @@ async function checkedRun(
   }
 }
 
+function receiptFor(
+  project: D1ProjectSnapshot,
+  target: ReturnType<typeof resolveDatabaseTarget>,
+): D1PreflightReceipt {
+  return {
+    version: 1,
+    target: target.target,
+    databaseName: target.databaseName,
+    databaseId: target.databaseId ?? null,
+    environment: target.environment ?? null,
+    projectDigest: projectDigest(project),
+  };
+}
+
+function assertPreflightReceipt(
+  receipt: D1PreflightReceipt,
+  project: D1ProjectSnapshot,
+  target: ReturnType<typeof resolveDatabaseTarget>,
+): void {
+  const expected = receiptFor(project, target);
+  if (
+    receipt.version !== expected.version || receipt.target !== expected.target ||
+    receipt.databaseName !== expected.databaseName || receipt.databaseId !== expected.databaseId ||
+    receipt.environment !== expected.environment || receipt.projectDigest !== expected.projectDigest
+  ) {
+    throw new Error("D1 preflight receipt does not match the current canonical target");
+  }
+}
+
+/**
+ * Execute the canonical target/schema/ledger query without creating SQL files
+ * or running any mutating statement. Call this before R2 or Clerk apply phases.
+ */
+export async function preflightD1Target(options: PreflightD1Options): Promise<D1PreflightReceipt> {
+  assertExecutionGates(options.execution, false);
+  if (options.execution.dryRun || !options.execution.apply) {
+    throw new Error("D1 target preflight is reserved for confirmed apply runs");
+  }
+  const projectFiles = options.projectFiles ?? createD1ProjectFiles();
+  const project = await loadD1ProjectSnapshot(options.projectRoot, projectFiles);
+  const verifyProject = () => verifyD1ProjectSnapshot(project, projectFiles);
+  const target = resolveDatabaseTarget(parseWranglerJsonc(project.configText), {
+    target: options.execution.target,
+    ...(options.wranglerEnvironment ? { environment: options.wranglerEnvironment } : {}),
+    ...(options.expectedDatabaseName ? { expectedName: options.expectedDatabaseName } : {}),
+  });
+  const result = await checkedRun(
+    options.commandRunner,
+    project.executablePath,
+    [...baseArgs(target.databaseName, target.target, project.configPath, target.environment), "--command", D1_PREFLIGHT_SQL],
+    "preflight",
+    verifyProject,
+  );
+  try { assertPreflight(result.stdout); } catch { throw new Error("D1 preflight failed"); }
+  await verifyProject();
+  return receiptFor(project, target);
+}
+
 export async function runD1Import(options: RunD1ImportOptions): Promise<D1DryRunResult | D1ApplyResult> {
   const plan = buildD1ImportPlan(options.input, { ...options.planOptions, overwrite: options.execution.overwrite });
   assertExecutionGates(options.execution, plan.containsSensitiveRows);
@@ -727,6 +819,8 @@ export async function runD1Import(options: RunD1ImportOptions): Promise<D1DryRun
       requiredMediaCount: plan.requiredMediaPaths.length,
     };
   }
+
+  if (options.preflightReceipt) assertPreflightReceipt(options.preflightReceipt, project, target);
 
   assertMediaEvidence(plan.requiredMediaPaths, options.mediaEvidence ?? []);
   const commandBase = baseArgs(target.databaseName, target.target, project.configPath, target.environment);

--- a/scripts/shopify-migration/adapters/d1/runner.ts
+++ b/scripts/shopify-migration/adapters/d1/runner.ts
@@ -1,7 +1,7 @@
 import { spawn } from "node:child_process";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { isAbsolute, join } from "node:path";
+import { basename, dirname, isAbsolute, join, resolve } from "node:path";
 
 import type { ExecutionPlan } from "../../lib/config.js";
 import type { AppliedMediaImportResult } from "../media/index.js";
@@ -30,6 +30,26 @@ export interface CommandRunner {
   run(file: string, args: readonly string[]): Promise<CommandResult>;
 }
 
+export interface SpawnedCommand {
+  stdout: { on(event: "data", listener: (chunk: Buffer) => void): unknown };
+  stderr: { on(event: "data", listener: (chunk: Buffer) => void): unknown };
+  once(event: "error", listener: () => void): unknown;
+  once(event: "close", listener: (code: number | null) => void): unknown;
+  kill(signal?: NodeJS.Signals): boolean;
+}
+
+export type SpawnCommand = (
+  file: string,
+  args: readonly string[],
+  options: { shell: false; stdio: ["ignore", "pipe", "pipe"] },
+) => SpawnedCommand;
+
+export interface NodeCommandRunnerOptions {
+  timeoutMs?: number;
+  killGraceMs?: number;
+  spawnCommand?: SpawnCommand;
+}
+
 export interface PrivateSqlFiles {
   createDirectory(): Promise<string>;
   write(directory: string, filename: string, contents: string): Promise<string>;
@@ -43,6 +63,8 @@ export interface RunD1ImportOptions {
   execution: ExecutionPlan;
   wranglerConfigText: string;
   wranglerConfigPath: string;
+  /** Explicit project-local binary; the runner never invokes npx or downloads tools. */
+  wranglerExecutablePath: string;
   wranglerEnvironment?: string;
   expectedDatabaseName?: string;
   mediaEvidence?: readonly D1MediaEvidence[];
@@ -168,21 +190,83 @@ const PREFLIGHT_EXPECTED: Readonly<Record<string, number>> = {
 };
 
 const OUTPUT_LIMIT = 1024 * 1024;
+export const DEFAULT_WRANGLER_TIMEOUT_MS = 120_000;
+export const MAX_WRANGLER_TIMEOUT_MS = 15 * 60_000;
+export const DEFAULT_WRANGLER_KILL_GRACE_MS = 5_000;
+export const MAX_WRANGLER_KILL_GRACE_MS = 30_000;
+
+function boundedMilliseconds(
+  value: number | undefined,
+  fallback: number,
+  minimum: number,
+  maximum: number,
+  name: string,
+): number {
+  const resolved = value ?? fallback;
+  if (!Number.isSafeInteger(resolved) || resolved < minimum || resolved > maximum) {
+    throw new RangeError(`${name} must be an integer between ${minimum} and ${maximum}`);
+  }
+  return resolved;
+}
 
 /** A bounded no-shell backend. It is never selected implicitly by the runner. */
-export function createNodeCommandRunner(): CommandRunner {
+export function createNodeCommandRunner(options: NodeCommandRunnerOptions = {}): CommandRunner {
+  const timeoutMs = boundedMilliseconds(
+    options.timeoutMs,
+    DEFAULT_WRANGLER_TIMEOUT_MS,
+    1_000,
+    MAX_WRANGLER_TIMEOUT_MS,
+    "timeoutMs",
+  );
+  const killGraceMs = boundedMilliseconds(
+    options.killGraceMs,
+    DEFAULT_WRANGLER_KILL_GRACE_MS,
+    100,
+    MAX_WRANGLER_KILL_GRACE_MS,
+    "killGraceMs",
+  );
+  const spawnCommand: SpawnCommand = options.spawnCommand ?? ((file, args, spawnOptions) =>
+    spawn(file, [...args], spawnOptions) as SpawnedCommand);
   return {
     run(file, args) {
       return new Promise((resolve, reject) => {
-        const child = spawn(file, [...args], { shell: false, stdio: ["ignore", "pipe", "pipe"] });
+        let child: SpawnedCommand;
+        try {
+          child = spawnCommand(file, args, { shell: false, stdio: ["ignore", "pipe", "pipe"] });
+        } catch {
+          reject(new Error("Wrangler process could not be started"));
+          return;
+        }
         let stdout = "";
         let stderr = "";
-        let overflow = false;
+        let settled = false;
+        let terminationReason: "timeout" | "overflow" | undefined;
+        let forceKillTimer: ReturnType<typeof setTimeout> | undefined;
+        let timeoutTimer: ReturnType<typeof setTimeout>;
+        const finish = (result: CommandResult | Error): void => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(timeoutTimer);
+          if (forceKillTimer) clearTimeout(forceKillTimer);
+          if (result instanceof Error) reject(result);
+          else resolve(result);
+        };
+        const terminate = (reason: "timeout" | "overflow"): void => {
+          if (settled || terminationReason) return;
+          terminationReason = reason;
+          try { child.kill("SIGTERM"); } catch { /* continue to the bounded hard-stop */ }
+          forceKillTimer = setTimeout(() => {
+            if (settled) return;
+            try { child.kill("SIGKILL"); } catch { /* rejection below remains generic */ }
+            finish(new Error(reason === "timeout" ? "Wrangler command timed out" : "Wrangler output exceeded the safety limit"));
+          }, killGraceMs);
+        };
+        timeoutTimer = setTimeout(() => terminate("timeout"), timeoutMs);
         const append = (target: "stdout" | "stderr", chunk: Buffer): void => {
+          if (settled || terminationReason) return;
           const current = target === "stdout" ? stdout : stderr;
           if (Buffer.byteLength(current, "utf8") + chunk.byteLength > OUTPUT_LIMIT) {
-            overflow = true;
-            child.kill();
+            terminate("overflow");
             return;
           }
           if (target === "stdout") stdout += chunk.toString("utf8");
@@ -190,10 +274,17 @@ export function createNodeCommandRunner(): CommandRunner {
         };
         child.stdout.on("data", (chunk: Buffer) => append("stdout", chunk));
         child.stderr.on("data", (chunk: Buffer) => append("stderr", chunk));
-        child.once("error", () => reject(new Error("Wrangler process could not be started")));
+        child.once("error", () => finish(new Error(
+          terminationReason === "timeout" ? "Wrangler command timed out"
+            : terminationReason === "overflow" ? "Wrangler output exceeded the safety limit"
+              : "Wrangler process could not be started",
+        )));
         child.once("close", (code) => {
-          if (overflow) reject(new Error("Wrangler output exceeded the safety limit"));
-          else resolve({ exitCode: code ?? -1, stdout, stderr });
+          if (terminationReason) {
+            finish(new Error(
+              terminationReason === "timeout" ? "Wrangler command timed out" : "Wrangler output exceeded the safety limit",
+            ));
+          } else finish({ exitCode: code ?? -1, stdout, stderr });
         });
       });
     },
@@ -232,7 +323,7 @@ function baseArgs(
   environment: string | undefined,
 ): string[] {
   return [
-    "wrangler", "d1", "execute", databaseName,
+    "d1", "execute", databaseName,
     ...targetArgs(target),
     "--config", configPath,
     ...(environment ? ["--env", environment] : []),
@@ -307,11 +398,12 @@ function assertMediaEvidence(paths: readonly string[], evidence: readonly D1Medi
 
 async function checkedRun(
   commandRunner: CommandRunner,
+  executable: string,
   args: readonly string[],
   stage: "preflight" | "chunk" | "validation",
 ): Promise<CommandResult> {
   try {
-    const result = await commandRunner.run("npx", args);
+    const result = await commandRunner.run(executable, args);
     if (result.exitCode !== 0) throw new Error("nonzero");
     return result;
   } catch {
@@ -325,6 +417,14 @@ export async function runD1Import(options: RunD1ImportOptions): Promise<D1DryRun
   if (!options.wranglerConfigPath || options.wranglerConfigPath.startsWith("-") ||
       options.wranglerConfigPath.length > 4_096 || /[\0\r\n]/.test(options.wranglerConfigPath)) {
     throw new Error("Wrangler config path is invalid");
+  }
+  const executableName = basename(options.wranglerExecutablePath ?? "");
+  const expectedExecutableDirectory = join(dirname(resolve(options.wranglerConfigPath)), "node_modules", ".bin");
+  if (!isAbsolute(options.wranglerExecutablePath ?? "") ||
+      (executableName !== "wrangler" && executableName !== "wrangler.cmd") ||
+      dirname(options.wranglerExecutablePath) !== expectedExecutableDirectory ||
+      options.wranglerExecutablePath.length > 4_096 || /[\0\r\n]/.test(options.wranglerExecutablePath)) {
+    throw new Error("Local Wrangler executable path is invalid");
   }
   const wranglerConfig = parseWranglerJsonc(options.wranglerConfigText);
   const target = resolveDatabaseTarget(wranglerConfig, {
@@ -350,6 +450,7 @@ export async function runD1Import(options: RunD1ImportOptions): Promise<D1DryRun
 
   const preflight = await checkedRun(
     options.commandRunner,
+    options.wranglerExecutablePath,
     [...commandBase, "--command", D1_PREFLIGHT_SQL],
     "preflight",
   );
@@ -362,7 +463,7 @@ export async function runD1Import(options: RunD1ImportOptions): Promise<D1DryRun
     directory = await files.createDirectory();
     for (let index = 0; index < plan.chunks.length; index += 1) {
       const path = await files.write(directory, `${String(index + 1).padStart(4, "0")}-chunk.sql`, plan.chunks[index]);
-      await checkedRun(options.commandRunner, [...commandBase, "--file", path], "chunk");
+      await checkedRun(options.commandRunner, options.wranglerExecutablePath, [...commandBase, "--file", path], "chunk");
     }
     for (let index = 0; index < plan.validation.length; index += 1) {
       const unit = plan.validation[index];
@@ -371,7 +472,12 @@ export async function runD1Import(options: RunD1ImportOptions): Promise<D1DryRun
         `${String(index + 1).padStart(4, "0")}-validation.sql`,
         `${unit.sql}\n`,
       );
-      const result = await checkedRun(options.commandRunner, [...commandBase, "--file", path], "validation");
+      const result = await checkedRun(
+        options.commandRunner,
+        options.wranglerExecutablePath,
+        [...commandBase, "--file", path],
+        "validation",
+      );
       try { assertValidation(result.stdout); } catch { throw new Error("D1 validation failed"); }
     }
   } catch (error) {

--- a/scripts/shopify-migration/adapters/d1/runner.ts
+++ b/scripts/shopify-migration/adapters/d1/runner.ts
@@ -1,0 +1,397 @@
+import { spawn } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { isAbsolute, join } from "node:path";
+
+import type { ExecutionPlan } from "../../lib/config.js";
+import type { AppliedMediaImportResult } from "../media/index.js";
+import {
+  parseWranglerJsonc,
+  resolveDatabaseTarget,
+  type WranglerTarget,
+} from "../../lib/wrangler-target.js";
+import {
+  D1_DEPENDENCIES,
+  assertExecutionGates,
+  buildD1ImportPlan,
+  type D1Dependency,
+  type D1ImportPlan,
+  type D1PlanOptions,
+  type MaterializedD1Input,
+} from "./plan.js";
+
+export interface CommandResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+export interface CommandRunner {
+  run(file: string, args: readonly string[]): Promise<CommandResult>;
+}
+
+export interface PrivateSqlFiles {
+  createDirectory(): Promise<string>;
+  write(directory: string, filename: string, contents: string): Promise<string>;
+  cleanup(directory: string): Promise<void>;
+}
+
+export type D1MediaEvidence = AppliedMediaImportResult;
+
+export interface RunD1ImportOptions {
+  input: MaterializedD1Input;
+  execution: ExecutionPlan;
+  wranglerConfigText: string;
+  wranglerConfigPath: string;
+  wranglerEnvironment?: string;
+  expectedDatabaseName?: string;
+  mediaEvidence?: readonly D1MediaEvidence[];
+  commandRunner: CommandRunner;
+  privateFiles?: PrivateSqlFiles;
+  planOptions?: Omit<D1PlanOptions, "overwrite">;
+}
+
+export interface D1DryRunResult {
+  dryRun: true;
+  dependencies: ReadonlyArray<{ dependency: D1Dependency; count: number }>;
+  totalRows: number;
+  chunkCount: number;
+  requiredMediaCount: number;
+}
+
+export interface D1ApplyResult {
+  dryRun: false;
+  dependencies: ReadonlyArray<{ dependency: D1Dependency; count: number }>;
+  totalRows: number;
+  chunksApplied: number;
+  validationsPassed: number;
+}
+
+const EXPECTED_MIGRATIONS = [
+  "0001_initial_schema.sql",
+  "0002_add_admin_users.sql",
+  "0003_add_cms_pages.sql",
+  "0004_add_mcp_tables.sql",
+  "0005_add_reviews_tables.sql",
+  "0006_add_review_reminders.sql",
+  "0007_add_analytics_cache.sql",
+  "0008_add_processed_webhook_events.sql",
+  "0009_add_order_effects.sql",
+  "0010_add_inventory_adjustments.sql",
+  "0011_add_external_refund_restock_setting.sql",
+  "0012_expand_mcp_agent_credentials.sql",
+  "0013_add_shipping_carrier.sql",
+  "0014_add_order_events.sql",
+  "0015_normalize_order_timestamps.sql",
+  "0016_enforce_order_timestamp_format.sql",
+  "0017_add_product_recommendations.sql",
+  "0018_add_email_preferences.sql",
+  "0019_add_content_publishing.sql",
+  "0020_add_redirect_map.sql",
+] as const;
+
+const EXPECTED_TABLES = [
+  "categories", "products", "product_variants", "inventory", "pages", "page_versions",
+  "blog_categories", "blog_posts", "customers", "orders", "product_reviews", "redirect_map",
+] as const;
+
+const EXPECTED_INDEXES = [
+  "idx_categories_slug", "idx_products_slug", "idx_product_variants_product_id", "idx_inventory_sku",
+  "pages_slug_idx", "page_versions_page_id_version_idx", "blog_categories_slug_idx", "blog_posts_slug_idx",
+  "idx_customers_type", "idx_orders_customer_id", "product_reviews_product_idx", "redirect_map_source_path_idx",
+] as const;
+
+function quotedList(values: readonly string[]): string {
+  return values.map((value) => `'${value}'`).join(", ");
+}
+
+export const D1_PREFLIGHT_SQL = `
+SELECT
+  (SELECT COUNT(*) FROM d1_migrations) AS migration_count,
+  (SELECT COUNT(*) FROM d1_migrations WHERE name IN (${quotedList(EXPECTED_MIGRATIONS)})) AS expected_migration_count,
+  (SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name IN (${quotedList(EXPECTED_TABLES)})) AS table_count,
+  (SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name IN (${quotedList(EXPECTED_INDEXES)})) AS index_count,
+  (
+    (SELECT COUNT(*) FROM pragma_table_info('categories') WHERE name = 'id' AND pk = 1) +
+    (SELECT COUNT(*) FROM pragma_table_info('products') WHERE name = 'id' AND pk = 1) +
+    (SELECT COUNT(*) FROM pragma_table_info('product_variants') WHERE name = 'id' AND pk = 1) +
+    (SELECT COUNT(*) FROM pragma_table_info('inventory') WHERE name = 'id' AND pk = 1) +
+    (SELECT COUNT(*) FROM pragma_table_info('pages') WHERE name = 'id' AND pk = 1) +
+    (SELECT COUNT(*) FROM pragma_table_info('page_versions') WHERE name = 'id' AND pk = 1) +
+    (SELECT COUNT(*) FROM pragma_table_info('blog_categories') WHERE name = 'id' AND pk = 1) +
+    (SELECT COUNT(*) FROM pragma_table_info('blog_posts') WHERE name = 'id' AND pk = 1) +
+    (SELECT COUNT(*) FROM pragma_table_info('customers') WHERE name = 'id' AND pk = 1) +
+    (SELECT COUNT(*) FROM pragma_table_info('orders') WHERE name = 'id' AND pk = 1) +
+    (SELECT COUNT(*) FROM pragma_table_info('product_reviews') WHERE name = 'id' AND pk = 1) +
+    (SELECT COUNT(*) FROM pragma_table_info('redirect_map') WHERE name = 'id' AND pk = 1)
+  ) AS primary_key_count,
+  (
+    (SELECT COUNT(*) FROM pragma_index_list('product_variants') WHERE origin = 'u') +
+    (SELECT COUNT(*) FROM pragma_index_list('pages') WHERE origin = 'u') +
+    (SELECT COUNT(*) FROM pragma_index_list('blog_categories') WHERE origin = 'u') +
+    (SELECT COUNT(*) FROM pragma_index_list('blog_posts') WHERE origin = 'u') +
+    (SELECT COUNT(*) FROM pragma_index_list('redirect_map') WHERE origin = 'u')
+  ) AS unique_constraint_count,
+  (
+    (SELECT COUNT(*) FROM pragma_foreign_key_list('categories')) +
+    (SELECT COUNT(*) FROM pragma_foreign_key_list('product_variants')) +
+    (SELECT COUNT(*) FROM pragma_foreign_key_list('pages')) +
+    (SELECT COUNT(*) FROM pragma_foreign_key_list('page_versions')) +
+    (SELECT COUNT(*) FROM pragma_foreign_key_list('blog_posts')) +
+    (SELECT COUNT(*) FROM pragma_foreign_key_list('orders'))
+  ) AS foreign_key_count,
+  (SELECT COUNT(*) FROM pragma_table_info('orders') WHERE name = 'shipping_carrier') AS evolved_column_count,
+  (
+    (SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'categories' AND lower(sql) LIKE '%check%status%active%inactive%archived%') +
+    (SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'products' AND lower(sql) LIKE '%check%fulfillment_type%physical%digital%service%') +
+    (SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'product_variants' AND lower(sql) LIKE '%check%shipping_required%0%1%') +
+    (SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'inventory' AND lower(sql) LIKE '%check%version%0%') +
+    (SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'pages' AND lower(sql) LIKE '%check%status%draft%published%archived%') +
+    (SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'blog_categories' AND lower(sql) LIKE '%check%length(slug)%') +
+    (SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'blog_posts' AND lower(sql) LIKE '%check%reading_time%1440%') +
+    (SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'customers' AND lower(sql) LIKE '%check%type%person%company%') +
+    (SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'orders' AND lower(sql) LIKE '%check%length(currency_code)%3%') +
+    (SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'product_reviews' AND lower(sql) LIKE '%check%status%pending%published%suppressed%') +
+    (SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'redirect_map' AND lower(sql) LIKE '%status_code%301%308%')
+  ) AS check_constraint_count;
+`.trim();
+
+const PREFLIGHT_EXPECTED: Readonly<Record<string, number>> = {
+  expected_migration_count: EXPECTED_MIGRATIONS.length,
+  table_count: EXPECTED_TABLES.length,
+  index_count: EXPECTED_INDEXES.length,
+  primary_key_count: EXPECTED_TABLES.length,
+  unique_constraint_count: 5,
+  foreign_key_count: 6,
+  evolved_column_count: 1,
+  check_constraint_count: 11,
+};
+
+const OUTPUT_LIMIT = 1024 * 1024;
+
+/** A bounded no-shell backend. It is never selected implicitly by the runner. */
+export function createNodeCommandRunner(): CommandRunner {
+  return {
+    run(file, args) {
+      return new Promise((resolve, reject) => {
+        const child = spawn(file, [...args], { shell: false, stdio: ["ignore", "pipe", "pipe"] });
+        let stdout = "";
+        let stderr = "";
+        let overflow = false;
+        const append = (target: "stdout" | "stderr", chunk: Buffer): void => {
+          const current = target === "stdout" ? stdout : stderr;
+          if (Buffer.byteLength(current, "utf8") + chunk.byteLength > OUTPUT_LIMIT) {
+            overflow = true;
+            child.kill();
+            return;
+          }
+          if (target === "stdout") stdout += chunk.toString("utf8");
+          else stderr += chunk.toString("utf8");
+        };
+        child.stdout.on("data", (chunk: Buffer) => append("stdout", chunk));
+        child.stderr.on("data", (chunk: Buffer) => append("stderr", chunk));
+        child.once("error", () => reject(new Error("Wrangler process could not be started")));
+        child.once("close", (code) => {
+          if (overflow) reject(new Error("Wrangler output exceeded the safety limit"));
+          else resolve({ exitCode: code ?? -1, stdout, stderr });
+        });
+      });
+    },
+  };
+}
+
+export function createPrivateSqlFiles(): PrivateSqlFiles {
+  return {
+    createDirectory: () => mkdtemp(join(tmpdir(), "mercora-shopify-d1-")),
+    async write(directory, filename, contents) {
+      if (!isAbsolute(directory) || !/^\d{4}-(?:chunk|validation)\.sql$/.test(filename)) {
+        throw new Error("Private SQL file target is invalid");
+      }
+      const path = join(directory, filename);
+      await writeFile(path, contents, { encoding: "utf8", flag: "wx", mode: 0o600 });
+      return path;
+    },
+    cleanup: (directory) => rm(directory, { recursive: true, force: true }),
+  };
+}
+
+function dependencies(plan: D1ImportPlan): Array<{ dependency: D1Dependency; count: number }> {
+  return D1_DEPENDENCIES.map((dependency) => ({ dependency, count: plan.counts[dependency] }));
+}
+
+function targetArgs(target: WranglerTarget): string[] {
+  if (target === "local") return ["--local"];
+  if (target === "preview") return ["--remote", "--preview"];
+  return ["--remote"];
+}
+
+function baseArgs(
+  databaseName: string,
+  target: WranglerTarget,
+  configPath: string,
+  environment: string | undefined,
+): string[] {
+  return [
+    "wrangler", "d1", "execute", databaseName,
+    ...targetArgs(target),
+    "--config", configPath,
+    ...(environment ? ["--env", environment] : []),
+    "--json",
+  ];
+}
+
+function exactJsonRow(stdout: string): Record<string, unknown> {
+  const json = stdout.trim();
+  if (!json) throw new Error("Wrangler JSON response is malformed");
+  let parsed: unknown;
+  try { parsed = JSON.parse(json); } catch { throw new Error("Wrangler JSON response is malformed"); }
+  if (!Array.isArray(parsed) || parsed.length !== 1) throw new Error("Wrangler JSON response is ambiguous");
+  const result = parsed[0];
+  if (!result || typeof result !== "object" || Array.isArray(result)) throw new Error("Wrangler JSON result is malformed");
+  const envelope = result as Record<string, unknown>;
+  if (envelope.success !== true || !Array.isArray(envelope.results) || envelope.results.length !== 1) {
+    throw new Error("Wrangler JSON result is unsuccessful or ambiguous");
+  }
+  const row = envelope.results[0];
+  if (!row || typeof row !== "object" || Array.isArray(row)) throw new Error("Wrangler JSON row is malformed");
+  return row as Record<string, unknown>;
+}
+
+function assertPreflight(stdout: string): void {
+  const row = exactJsonRow(stdout);
+  if (Object.keys(row).length !== Object.keys(PREFLIGHT_EXPECTED).length + 1 ||
+      !Number.isSafeInteger(row.migration_count) || (row.migration_count as number) < EXPECTED_MIGRATIONS.length) {
+    throw new Error("D1 schema preflight result is incomplete");
+  }
+  for (const [name, expected] of Object.entries(PREFLIGHT_EXPECTED)) {
+    if (row[name] !== expected) throw new Error("D1 schema preflight does not match the required ledger");
+  }
+}
+
+function assertValidation(stdout: string): void {
+  const row = exactJsonRow(stdout);
+  if (Object.keys(row).length !== 2 || !Number.isSafeInteger(row.expected_count) || !Number.isSafeInteger(row.actual_count)) {
+    throw new Error("D1 post-write validation result is malformed");
+  }
+  if (row.expected_count !== row.actual_count) throw new Error("D1 post-write validation failed");
+}
+
+const CONTENT_TYPES: Readonly<Record<string, string>> = {
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  png: "image/png",
+  webp: "image/webp",
+};
+
+function assertMediaEvidence(paths: readonly string[], evidence: readonly D1MediaEvidence[]): void {
+  const byPath = new Map<string, D1MediaEvidence>();
+  for (const item of evidence) {
+    if (byPath.has(item.publicPath)) throw new Error("D1 media evidence contains duplicate public paths");
+    if (!/^(?:products|categories|blog|pages)\/[A-Za-z0-9][A-Za-z0-9_-]{0,127}\/(?:cover\/|inline\/)?[1-9][0-9]{0,5}\.(?:jpe?g|png|webp)$/i.test(item.objectKey) ||
+        item.publicPath !== `/media/${item.objectKey}`) {
+      throw new Error("D1 media evidence path is invalid");
+    }
+    const extension = item.objectKey.split(".").at(-1)!.toLowerCase();
+    if ((item.status !== "written" && item.status !== "verified-existing") ||
+        !/^[a-f0-9]{64}$/.test(item.sha256 ?? "") ||
+        item.contentType !== CONTENT_TYPES[extension] ||
+        !Number.isSafeInteger(item.byteLength) || (item.byteLength ?? 0) < 1 || (item.byteLength ?? 0) > 25 * 1024 * 1024) {
+      throw new Error("D1 media evidence is not cryptographically verified");
+    }
+    byPath.set(item.publicPath, item);
+  }
+  for (const path of paths) {
+    if (!byPath.has(path)) throw new Error("D1 row references media without verified persistence evidence");
+  }
+}
+
+async function checkedRun(
+  commandRunner: CommandRunner,
+  args: readonly string[],
+  stage: "preflight" | "chunk" | "validation",
+): Promise<CommandResult> {
+  try {
+    const result = await commandRunner.run("npx", args);
+    if (result.exitCode !== 0) throw new Error("nonzero");
+    return result;
+  } catch {
+    throw new Error(`D1 ${stage} failed`);
+  }
+}
+
+export async function runD1Import(options: RunD1ImportOptions): Promise<D1DryRunResult | D1ApplyResult> {
+  const plan = buildD1ImportPlan(options.input, { ...options.planOptions, overwrite: options.execution.overwrite });
+  assertExecutionGates(options.execution, plan.containsSensitiveRows);
+  if (!options.wranglerConfigPath || options.wranglerConfigPath.startsWith("-") ||
+      options.wranglerConfigPath.length > 4_096 || /[\0\r\n]/.test(options.wranglerConfigPath)) {
+    throw new Error("Wrangler config path is invalid");
+  }
+  const wranglerConfig = parseWranglerJsonc(options.wranglerConfigText);
+  const target = resolveDatabaseTarget(wranglerConfig, {
+    target: options.execution.target,
+    ...(options.wranglerEnvironment ? { environment: options.wranglerEnvironment } : {}),
+    ...(options.expectedDatabaseName ? { expectedName: options.expectedDatabaseName } : {}),
+  });
+  const dependencyCounts = dependencies(plan);
+  const totalRows = dependencyCounts.reduce((sum, item) => sum + item.count, 0);
+
+  if (options.execution.dryRun) {
+    return {
+      dryRun: true,
+      dependencies: dependencyCounts,
+      totalRows,
+      chunkCount: plan.chunks.length,
+      requiredMediaCount: plan.requiredMediaPaths.length,
+    };
+  }
+
+  assertMediaEvidence(plan.requiredMediaPaths, options.mediaEvidence ?? []);
+  const commandBase = baseArgs(target.databaseName, target.target, options.wranglerConfigPath, target.environment);
+
+  const preflight = await checkedRun(
+    options.commandRunner,
+    [...commandBase, "--command", D1_PREFLIGHT_SQL],
+    "preflight",
+  );
+  try { assertPreflight(preflight.stdout); } catch { throw new Error("D1 preflight failed"); }
+
+  const files = options.privateFiles ?? createPrivateSqlFiles();
+  let directory: string | undefined;
+  let failure: Error | undefined;
+  try {
+    directory = await files.createDirectory();
+    for (let index = 0; index < plan.chunks.length; index += 1) {
+      const path = await files.write(directory, `${String(index + 1).padStart(4, "0")}-chunk.sql`, plan.chunks[index]);
+      await checkedRun(options.commandRunner, [...commandBase, "--file", path], "chunk");
+    }
+    for (let index = 0; index < plan.validation.length; index += 1) {
+      const unit = plan.validation[index];
+      const path = await files.write(
+        directory,
+        `${String(index + 1).padStart(4, "0")}-validation.sql`,
+        `${unit.sql}\n`,
+      );
+      const result = await checkedRun(options.commandRunner, [...commandBase, "--file", path], "validation");
+      try { assertValidation(result.stdout); } catch { throw new Error("D1 validation failed"); }
+    }
+  } catch (error) {
+    failure = error instanceof Error && /^D1 (?:chunk|validation) failed$/.test(error.message)
+      ? error
+      : new Error("D1 import failed");
+  } finally {
+    if (directory) {
+      try { await files.cleanup(directory); } catch {
+        failure ??= new Error("D1 private SQL cleanup failed");
+      }
+    }
+  }
+  if (failure) throw failure;
+
+  return {
+    dryRun: false,
+    dependencies: dependencyCounts,
+    totalRows,
+    chunksApplied: plan.chunks.length,
+    validationsPassed: plan.validation.length,
+  };
+}

--- a/scripts/shopify-migration/adapters/d1/runner.ts
+++ b/scripts/shopify-migration/adapters/d1/runner.ts
@@ -1,7 +1,7 @@
 import { spawn } from "node:child_process";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, realpath, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { basename, dirname, isAbsolute, join, resolve } from "node:path";
+import { dirname, isAbsolute, join, relative } from "node:path";
 
 import type { ExecutionPlan } from "../../lib/config.js";
 import type { AppliedMediaImportResult } from "../media/index.js";
@@ -56,15 +56,26 @@ export interface PrivateSqlFiles {
   cleanup(directory: string): Promise<void>;
 }
 
+export interface ProjectFileStat {
+  kind: "file" | "directory";
+  size: number;
+  mode: number;
+}
+
+export interface D1ProjectFiles {
+  realpath(path: string): Promise<string>;
+  readFile(path: string): Promise<Buffer>;
+  stat(path: string): Promise<ProjectFileStat>;
+}
+
 export type D1MediaEvidence = AppliedMediaImportResult;
 
 export interface RunD1ImportOptions {
   input: MaterializedD1Input;
   execution: ExecutionPlan;
-  wranglerConfigText: string;
-  wranglerConfigPath: string;
-  /** Explicit project-local binary; the runner never invokes npx or downloads tools. */
-  wranglerExecutablePath: string;
+  /** Absolute, canonical project root containing wrangler.jsonc and local dependencies. */
+  projectRoot: string;
+  projectFiles?: D1ProjectFiles;
   wranglerEnvironment?: string;
   expectedDatabaseName?: string;
   mediaEvidence?: readonly D1MediaEvidence[];
@@ -123,16 +134,155 @@ const EXPECTED_INDEXES = [
   "idx_customers_type", "idx_orders_customer_id", "product_reviews_product_idx", "redirect_map_source_path_idx",
 ] as const;
 
+interface ColumnContract {
+  table: string;
+  name: string;
+  type: "TEXT" | "INTEGER";
+  notNull: 0 | 1;
+  defaultValue: string | null;
+  primaryKey: 0 | 1;
+}
+
+const TARGET_COLUMN_CONTRACTS: ColumnContract[] = [];
+function targetColumns(
+  table: string,
+  names: readonly string[],
+  type: ColumnContract["type"],
+  notNull: ColumnContract["notNull"] = 0,
+  defaultValue: string | null = null,
+  primaryKey: ColumnContract["primaryKey"] = 0,
+): void {
+  names.forEach((name) => TARGET_COLUMN_CONTRACTS.push({ table, name, type, notNull, defaultValue, primaryKey }));
+}
+
+targetColumns("categories", ["id"], "TEXT", 0, null, 1);
+targetColumns("categories", ["name"], "TEXT", 1);
+targetColumns("categories", ["position"], "INTEGER");
+targetColumns("categories", ["product_count"], "INTEGER", 0, "0");
+targetColumns("categories", ["status"], "TEXT", 0, "'active'");
+targetColumns("categories", ["description", "slug", "parent_id", "path", "external_references", "created_at", "updated_at", "children", "attributes", "tags", "primary_image", "media", "seo", "extensions"], "TEXT");
+
+targetColumns("products", ["id"], "TEXT", 0, null, 1);
+targetColumns("products", ["name"], "TEXT", 1);
+targetColumns("products", ["status"], "TEXT", 0, "'active'");
+targetColumns("products", ["fulfillment_type"], "TEXT", 0, "'physical'");
+targetColumns("products", ["type", "external_references", "created_at", "updated_at", "description", "slug", "brand", "categories", "tags", "options", "default_variant_id", "tax_category", "primary_image", "media", "seo", "rating", "related_products", "extensions"], "TEXT");
+
+targetColumns("product_variants", ["id"], "TEXT", 0, null, 1);
+targetColumns("product_variants", ["product_id", "sku", "option_values", "price"], "TEXT", 1);
+targetColumns("product_variants", ["status"], "TEXT", 0, "'active'");
+targetColumns("product_variants", ["position"], "INTEGER");
+targetColumns("product_variants", ["shipping_required"], "INTEGER", 0, "1");
+targetColumns("product_variants", ["compare_at_price", "cost", "weight", "dimensions", "barcode", "inventory", "tax_category", "media", "attributes", "created_at", "updated_at"], "TEXT");
+
+targetColumns("inventory", ["id"], "TEXT", 0, null, 1);
+targetColumns("inventory", ["sku_id", "location_id", "quantities"], "TEXT", 1);
+targetColumns("inventory", ["status"], "TEXT", 0, "'active'");
+targetColumns("inventory", ["backorderable", "safety_stock", "version"], "INTEGER", 0, "0");
+targetColumns("inventory", ["stock_status", "external_references", "created_at", "updated_at", "policy_id", "backorder_eta", "extensions"], "TEXT");
+
+targetColumns("pages", ["id"], "INTEGER", 0, null, 1);
+targetColumns("pages", ["title", "slug", "content"], "TEXT", 1);
+targetColumns("pages", ["status"], "TEXT", 1, "'draft'");
+targetColumns("pages", ["template"], "TEXT", 0, "'default'");
+targetColumns("pages", ["published_at", "parent_id"], "INTEGER");
+targetColumns("pages", ["sort_order", "show_in_nav", "is_protected"], "INTEGER", 0, "0");
+targetColumns("pages", ["created_at", "updated_at"], "INTEGER", 1, "unixepoch()");
+targetColumns("pages", ["version"], "INTEGER", 1, "1");
+targetColumns("pages", ["excerpt", "meta_title", "meta_description", "meta_keywords", "created_by", "updated_by", "nav_title", "custom_css", "custom_js", "required_roles"], "TEXT");
+
+targetColumns("page_versions", ["id"], "INTEGER", 0, null, 1);
+targetColumns("page_versions", ["page_id", "version"], "INTEGER", 1);
+targetColumns("page_versions", ["title", "content", "created_by"], "TEXT", 1);
+targetColumns("page_versions", ["created_at"], "INTEGER", 1, "unixepoch()");
+targetColumns("page_versions", ["excerpt", "meta_title", "meta_description", "meta_keywords", "change_summary"], "TEXT");
+
+targetColumns("blog_categories", ["id"], "INTEGER", 0, null, 1);
+targetColumns("blog_categories", ["name", "slug"], "TEXT", 1);
+targetColumns("blog_categories", ["description"], "TEXT");
+targetColumns("blog_categories", ["created_at", "updated_at"], "INTEGER", 1, "unixepoch()");
+
+targetColumns("blog_posts", ["id"], "INTEGER", 0, null, 1);
+targetColumns("blog_posts", ["title", "slug", "author"], "TEXT", 1);
+targetColumns("blog_posts", ["tags"], "TEXT", 1, "'[]'");
+targetColumns("blog_posts", ["status"], "TEXT", 1, "'draft'");
+targetColumns("blog_posts", ["html"], "TEXT", 1, "''");
+targetColumns("blog_posts", ["reading_time"], "INTEGER", 1, "1");
+targetColumns("blog_posts", ["category_id", "published_at"], "INTEGER");
+targetColumns("blog_posts", ["created_at", "updated_at"], "INTEGER", 1, "unixepoch()");
+targetColumns("blog_posts", ["excerpt", "cover_image_url", "cover_image_alt", "editor_json", "meta_title", "meta_description", "created_by", "updated_by"], "TEXT");
+
+targetColumns("customers", ["id"], "TEXT", 0, null, 1);
+targetColumns("customers", ["type"], "TEXT", 1);
+targetColumns("customers", ["status"], "TEXT", 0, "'active'");
+targetColumns("customers", ["external_references", "created_at", "updated_at", "person", "company", "contacts", "addresses", "communication_preferences", "segments", "tags", "loyalty", "authentication", "extensions"], "TEXT");
+
+targetColumns("orders", ["id"], "TEXT", 0, null, 1);
+targetColumns("orders", ["total_amount", "currency_code", "items"], "TEXT", 1);
+targetColumns("orders", ["status", "payment_status"], "TEXT", 0, "'pending'");
+targetColumns("orders", ["created_at", "updated_at"], "TEXT", 0, "CURRENT_TIMESTAMP");
+targetColumns("orders", ["customer_id", "shipping_address", "billing_address", "shipping_method", "payment_method", "notes", "shipped_at", "delivered_at", "tracking_number", "external_references", "extensions", "shipping_carrier"], "TEXT");
+
+targetColumns("product_reviews", ["id"], "TEXT", 0, null, 1);
+targetColumns("product_reviews", ["product_id", "order_id", "customer_id"], "TEXT", 1);
+targetColumns("product_reviews", ["rating"], "INTEGER", 1);
+targetColumns("product_reviews", ["status"], "TEXT", 1, "'pending'");
+targetColumns("product_reviews", ["is_verified"], "INTEGER", 0, "1");
+targetColumns("product_reviews", ["submitted_at", "created_at", "updated_at"], "TEXT", 0, "CURRENT_TIMESTAMP");
+targetColumns("product_reviews", ["order_item_id", "title", "body", "automated_moderation", "moderation_notes", "admin_response", "response_author_id", "responded_at", "published_at", "metadata"], "TEXT");
+
+targetColumns("redirect_map", ["id"], "INTEGER", 0, null, 1);
+targetColumns("redirect_map", ["source_path", "target_path"], "TEXT", 1);
+targetColumns("redirect_map", ["status_code"], "INTEGER", 1, "301");
+targetColumns("redirect_map", ["entity_type"], "TEXT");
+targetColumns("redirect_map", ["created_at"], "INTEGER", 1, "unixepoch()");
+
+export const D1_TARGET_COLUMN_COUNT = TARGET_COLUMN_CONTRACTS.length;
+
 function quotedList(values: readonly string[]): string {
   return values.map((value) => `'${value}'`).join(", ");
 }
 
+function quotedValue(value: string | null): string {
+  return value === null ? "NULL" : `'${value.replaceAll("'", "''")}'`;
+}
+
+function columnContractValues(): string {
+  return TARGET_COLUMN_CONTRACTS.map((contract) =>
+    `(${quotedValue(contract.table)}, ${quotedValue(contract.name)}, ${quotedValue(contract.type)}, ` +
+    `${contract.notNull}, ${quotedValue(contract.defaultValue)}, ${contract.primaryKey})`).join(",\n    ");
+}
+
 export const D1_PREFLIGHT_SQL = `
+WITH
+  expected_tables(name) AS (VALUES ${EXPECTED_TABLES.map((table) => `(${quotedValue(table)})`).join(", ")}),
+  expected_columns(table_name, column_name, column_type, is_not_null, default_value, is_primary_key) AS (
+    VALUES ${columnContractValues()}
+  )
 SELECT
   (SELECT COUNT(*) FROM d1_migrations) AS migration_count,
   (SELECT COUNT(*) FROM d1_migrations WHERE name IN (${quotedList(EXPECTED_MIGRATIONS)})) AS expected_migration_count,
   (SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name IN (${quotedList(EXPECTED_TABLES)})) AS table_count,
   (SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name IN (${quotedList(EXPECTED_INDEXES)})) AS index_count,
+  (SELECT COUNT(*) FROM expected_columns) AS target_column_count,
+  (
+    SELECT COUNT(*) FROM expected_columns AS expected
+    JOIN pragma_table_info(expected.table_name) AS actual
+      ON actual.name = expected.column_name
+      AND upper(actual.type) = expected.column_type
+      AND actual."notnull" = expected.is_not_null
+      AND actual.dflt_value IS expected.default_value
+      AND actual.pk = expected.is_primary_key
+  ) AS compatible_target_column_count,
+  (
+    SELECT COUNT(*) FROM expected_tables AS target
+    JOIN pragma_table_info(target.name) AS actual
+    LEFT JOIN expected_columns AS expected
+      ON expected.table_name = target.name AND expected.column_name = actual.name
+    WHERE expected.column_name IS NULL AND actual.pk = 0
+      AND actual."notnull" = 1
+      AND (actual.dflt_value IS NULL OR upper(trim(actual.dflt_value)) = 'NULL')
+  ) AS incompatible_additive_column_count,
   (
     (SELECT COUNT(*) FROM pragma_table_info('categories') WHERE name = 'id' AND pk = 1) +
     (SELECT COUNT(*) FROM pragma_table_info('products') WHERE name = 'id' AND pk = 1) +
@@ -182,6 +332,9 @@ const PREFLIGHT_EXPECTED: Readonly<Record<string, number>> = {
   expected_migration_count: EXPECTED_MIGRATIONS.length,
   table_count: EXPECTED_TABLES.length,
   index_count: EXPECTED_INDEXES.length,
+  target_column_count: D1_TARGET_COLUMN_COUNT,
+  compatible_target_column_count: D1_TARGET_COLUMN_COUNT,
+  incompatible_additive_column_count: 0,
   primary_key_count: EXPECTED_TABLES.length,
   unique_constraint_count: 5,
   foreign_key_count: 6,
@@ -306,6 +459,143 @@ export function createPrivateSqlFiles(): PrivateSqlFiles {
   };
 }
 
+export function createD1ProjectFiles(): D1ProjectFiles {
+  return {
+    realpath,
+    readFile,
+    async stat(path) {
+      const value = await stat(path);
+      return {
+        kind: value.isFile() ? "file" : value.isDirectory() ? "directory" : (() => {
+          throw new Error("D1 project path has an unsupported file type");
+        })(),
+        size: value.size,
+        mode: value.mode,
+      };
+    },
+  };
+}
+
+interface D1ProjectSnapshot {
+  root: string;
+  configPath: string;
+  configBytes: Buffer;
+  configText: string;
+  executablePath: string;
+  executableBytes: Buffer;
+  packageJsonPath: string;
+  packageJsonBytes: Buffer;
+}
+
+const MAX_PACKAGE_JSON_BYTES = 256 * 1024;
+const MAX_WRANGLER_ENTRY_BYTES = 8 * 1024 * 1024;
+
+function exactChild(root: string, path: string): boolean {
+  const child = relative(root, path);
+  return child !== "" && child !== ".." && !child.startsWith(`..${process.platform === "win32" ? "\\" : "/"}`) &&
+    !isAbsolute(child);
+}
+
+async function boundedProjectFile(
+  files: D1ProjectFiles,
+  path: string,
+  maximum: number,
+  executable = false,
+): Promise<Buffer> {
+  const metadata = await files.stat(path);
+  if (metadata.kind !== "file" || metadata.size < 1 || metadata.size > maximum ||
+      (executable && process.platform !== "win32" && (metadata.mode & 0o111) === 0)) {
+    throw new Error("D1 project file does not satisfy the local execution contract");
+  }
+  const bytes = await files.readFile(path);
+  if (bytes.byteLength !== metadata.size || bytes.byteLength > maximum) {
+    throw new Error("D1 project file changed while it was being read");
+  }
+  return Buffer.from(bytes);
+}
+
+function wranglerBin(value: unknown): string {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Local Wrangler package metadata is invalid");
+  }
+  const packageJson = value as Record<string, unknown>;
+  if (packageJson.name !== "wrangler" || typeof packageJson.version !== "string" || !/^\d+\.\d+\.\d+/.test(packageJson.version)) {
+    throw new Error("Local Wrangler package metadata is invalid");
+  }
+  const candidate = typeof packageJson.bin === "string"
+    ? packageJson.bin
+    : packageJson.bin && typeof packageJson.bin === "object" && !Array.isArray(packageJson.bin)
+      ? (packageJson.bin as Record<string, unknown>).wrangler
+      : undefined;
+  if (typeof candidate !== "string" || !candidate || candidate.length > 512 || isAbsolute(candidate) ||
+      candidate.split(/[\\/]/).includes("..") || /[\0\r\n]/.test(candidate)) {
+    throw new Error("Local Wrangler package bin metadata is invalid");
+  }
+  return candidate;
+}
+
+async function loadD1ProjectSnapshot(root: string, files: D1ProjectFiles): Promise<D1ProjectSnapshot> {
+  if (!isAbsolute(root) || root.length > 4_096 || /[\0\r\n]/.test(root)) {
+    throw new Error("D1 project root is invalid");
+  }
+  const canonicalRoot = await files.realpath(root);
+  const rootMetadata = await files.stat(canonicalRoot);
+  if (canonicalRoot !== root || rootMetadata.kind !== "directory") {
+    throw new Error("D1 project root must be an explicit canonical directory");
+  }
+
+  const configPath = join(canonicalRoot, "wrangler.jsonc");
+  const packageRoot = join(canonicalRoot, "node_modules", "wrangler");
+  const packageJsonPath = join(packageRoot, "package.json");
+  const executableShim = join(canonicalRoot, "node_modules", ".bin", process.platform === "win32" ? "wrangler.cmd" : "wrangler");
+  const [canonicalConfig, canonicalPackageRoot, canonicalPackageJson] = await Promise.all([
+    files.realpath(configPath),
+    files.realpath(packageRoot),
+    files.realpath(packageJsonPath),
+  ]);
+  if (canonicalConfig !== configPath || canonicalPackageRoot !== packageRoot || canonicalPackageJson !== packageJsonPath ||
+      !exactChild(canonicalRoot, canonicalPackageRoot)) {
+    throw new Error("Wrangler config and package must be local to the canonical project root");
+  }
+  const [configBytes, packageJsonBytes] = await Promise.all([
+    boundedProjectFile(files, configPath, 1024 * 1024),
+    boundedProjectFile(files, packageJsonPath, MAX_PACKAGE_JSON_BYTES),
+  ]);
+  let packageJson: unknown;
+  try { packageJson = JSON.parse(packageJsonBytes.toString("utf8")); } catch {
+    throw new Error("Local Wrangler package metadata is invalid");
+  }
+  const expectedExecutable = join(packageRoot, wranglerBin(packageJson));
+  const [canonicalShim, canonicalExecutable] = await Promise.all([
+    files.realpath(executableShim),
+    files.realpath(expectedExecutable),
+  ]);
+  if (canonicalShim !== canonicalExecutable || canonicalExecutable !== expectedExecutable ||
+      !exactChild(packageRoot, canonicalExecutable)) {
+    throw new Error("Local Wrangler executable is not owned by the local package");
+  }
+  const executableBytes = await boundedProjectFile(files, canonicalExecutable, MAX_WRANGLER_ENTRY_BYTES, true);
+  return {
+    root: canonicalRoot,
+    configPath,
+    configBytes,
+    configText: configBytes.toString("utf8"),
+    executablePath: canonicalExecutable,
+    executableBytes,
+    packageJsonPath,
+    packageJsonBytes,
+  };
+}
+
+async function verifyD1ProjectSnapshot(snapshot: D1ProjectSnapshot, files: D1ProjectFiles): Promise<void> {
+  const current = await loadD1ProjectSnapshot(snapshot.root, files);
+  if (current.configPath !== snapshot.configPath || current.executablePath !== snapshot.executablePath ||
+      current.packageJsonPath !== snapshot.packageJsonPath || !current.configBytes.equals(snapshot.configBytes) ||
+      !current.packageJsonBytes.equals(snapshot.packageJsonBytes) || !current.executableBytes.equals(snapshot.executableBytes)) {
+    throw new Error("D1 project configuration or local Wrangler changed before execution");
+  }
+}
+
 function dependencies(plan: D1ImportPlan): Array<{ dependency: D1Dependency; count: number }> {
   return D1_DEPENDENCIES.map((dependency) => ({ dependency, count: plan.counts[dependency] }));
 }
@@ -401,8 +691,10 @@ async function checkedRun(
   executable: string,
   args: readonly string[],
   stage: "preflight" | "chunk" | "validation",
+  verifyProject: () => Promise<void>,
 ): Promise<CommandResult> {
   try {
+    await verifyProject();
     const result = await commandRunner.run(executable, args);
     if (result.exitCode !== 0) throw new Error("nonzero");
     return result;
@@ -414,19 +706,10 @@ async function checkedRun(
 export async function runD1Import(options: RunD1ImportOptions): Promise<D1DryRunResult | D1ApplyResult> {
   const plan = buildD1ImportPlan(options.input, { ...options.planOptions, overwrite: options.execution.overwrite });
   assertExecutionGates(options.execution, plan.containsSensitiveRows);
-  if (!options.wranglerConfigPath || options.wranglerConfigPath.startsWith("-") ||
-      options.wranglerConfigPath.length > 4_096 || /[\0\r\n]/.test(options.wranglerConfigPath)) {
-    throw new Error("Wrangler config path is invalid");
-  }
-  const executableName = basename(options.wranglerExecutablePath ?? "");
-  const expectedExecutableDirectory = join(dirname(resolve(options.wranglerConfigPath)), "node_modules", ".bin");
-  if (!isAbsolute(options.wranglerExecutablePath ?? "") ||
-      (executableName !== "wrangler" && executableName !== "wrangler.cmd") ||
-      dirname(options.wranglerExecutablePath) !== expectedExecutableDirectory ||
-      options.wranglerExecutablePath.length > 4_096 || /[\0\r\n]/.test(options.wranglerExecutablePath)) {
-    throw new Error("Local Wrangler executable path is invalid");
-  }
-  const wranglerConfig = parseWranglerJsonc(options.wranglerConfigText);
+  const projectFiles = options.projectFiles ?? createD1ProjectFiles();
+  const project = await loadD1ProjectSnapshot(options.projectRoot, projectFiles);
+  const verifyProject = () => verifyD1ProjectSnapshot(project, projectFiles);
+  const wranglerConfig = parseWranglerJsonc(project.configText);
   const target = resolveDatabaseTarget(wranglerConfig, {
     target: options.execution.target,
     ...(options.wranglerEnvironment ? { environment: options.wranglerEnvironment } : {}),
@@ -446,37 +729,39 @@ export async function runD1Import(options: RunD1ImportOptions): Promise<D1DryRun
   }
 
   assertMediaEvidence(plan.requiredMediaPaths, options.mediaEvidence ?? []);
-  const commandBase = baseArgs(target.databaseName, target.target, options.wranglerConfigPath, target.environment);
+  const commandBase = baseArgs(target.databaseName, target.target, project.configPath, target.environment);
 
   const preflight = await checkedRun(
     options.commandRunner,
-    options.wranglerExecutablePath,
+    project.executablePath,
     [...commandBase, "--command", D1_PREFLIGHT_SQL],
     "preflight",
+    verifyProject,
   );
   try { assertPreflight(preflight.stdout); } catch { throw new Error("D1 preflight failed"); }
 
-  const files = options.privateFiles ?? createPrivateSqlFiles();
+  const privateFiles = options.privateFiles ?? createPrivateSqlFiles();
   let directory: string | undefined;
   let failure: Error | undefined;
   try {
-    directory = await files.createDirectory();
+    directory = await privateFiles.createDirectory();
     for (let index = 0; index < plan.chunks.length; index += 1) {
-      const path = await files.write(directory, `${String(index + 1).padStart(4, "0")}-chunk.sql`, plan.chunks[index]);
-      await checkedRun(options.commandRunner, options.wranglerExecutablePath, [...commandBase, "--file", path], "chunk");
+      const path = await privateFiles.write(directory, `${String(index + 1).padStart(4, "0")}-chunk.sql`, plan.chunks[index]);
+      await checkedRun(options.commandRunner, project.executablePath, [...commandBase, "--file", path], "chunk", verifyProject);
     }
     for (let index = 0; index < plan.validation.length; index += 1) {
       const unit = plan.validation[index];
-      const path = await files.write(
+      const path = await privateFiles.write(
         directory,
         `${String(index + 1).padStart(4, "0")}-validation.sql`,
         `${unit.sql}\n`,
       );
       const result = await checkedRun(
         options.commandRunner,
-        options.wranglerExecutablePath,
+        project.executablePath,
         [...commandBase, "--file", path],
         "validation",
+        verifyProject,
       );
       try { assertValidation(result.stdout); } catch { throw new Error("D1 validation failed"); }
     }
@@ -486,7 +771,7 @@ export async function runD1Import(options: RunD1ImportOptions): Promise<D1DryRun
       : new Error("D1 import failed");
   } finally {
     if (directory) {
-      try { await files.cleanup(directory); } catch {
+      try { await privateFiles.cleanup(directory); } catch {
         failure ??= new Error("D1 private SQL cleanup failed");
       }
     }

--- a/scripts/shopify-migration/adapters/d1/sql.ts
+++ b/scripts/shopify-migration/adapters/d1/sql.ts
@@ -1,0 +1,137 @@
+export type SqlScalar = string | number | boolean | null;
+export type SqlRecord = Readonly<Record<string, SqlScalar>>;
+
+export type ConflictMode = "abort" | "insert-only" | "compare" | "overwrite";
+
+export interface InsertStatementOptions {
+  table: string;
+  row: SqlRecord;
+  conflictColumns?: readonly string[];
+  mode?: ConflictMode;
+  /** A NOT NULL column used to make a compare mismatch abort the import. */
+  guardColumn?: string;
+}
+
+export interface SqlChunkOptions {
+  maxBytes?: number;
+  maxStatements?: number;
+}
+
+export const MAX_D1_STATEMENT_BYTES = 96 * 1024;
+export const DEFAULT_D1_CHUNK_BYTES = 4 * 1024 * 1024;
+export const DEFAULT_D1_CHUNK_STATEMENTS = 500;
+
+const IDENTIFIER = /^[a-z][a-z0-9_]{0,63}$/;
+
+function identifier(value: string): string {
+  if (!IDENTIFIER.test(value)) throw new TypeError(`Unsafe SQL identifier: ${value}`);
+  return `"${value}"`;
+}
+
+function boundedInteger(value: number | undefined, fallback: number, maximum: number, name: string): number {
+  const resolved = value ?? fallback;
+  if (!Number.isSafeInteger(resolved) || resolved < 1 || resolved > maximum) {
+    throw new RangeError(`${name} must be an integer between 1 and ${maximum}`);
+  }
+  return resolved;
+}
+
+export function sqlLiteral(value: SqlScalar): string {
+  if (value === null) return "NULL";
+  if (typeof value === "boolean") return value ? "1" : "0";
+  if (typeof value === "number") {
+    if (!Number.isSafeInteger(value)) throw new TypeError("SQL numeric values must be safe integers");
+    return String(value);
+  }
+  if (typeof value !== "string" || value.includes("\0")) {
+    throw new TypeError("SQL text values must be NUL-free strings");
+  }
+  return `'${value.replaceAll("'", "''")}'`;
+}
+
+function conflictTarget(columns: readonly string[]): string {
+  if (columns.length < 1 || columns.length > 4 || new Set(columns).size !== columns.length) {
+    throw new TypeError("Conflict columns must contain 1-4 distinct identifiers");
+  }
+  return `(${columns.map(identifier).join(", ")})`;
+}
+
+/**
+ * Build one bounded D1 statement. Compare mode is an idempotent
+ * insert-or-compare: an exact rerun is a no-op update, while drift sets a
+ * caller-declared NOT NULL guard column to NULL so the SQL-file import aborts.
+ */
+export function buildInsertStatement(options: InsertStatementOptions): string {
+  const table = identifier(options.table);
+  const entries = Object.entries(options.row);
+  if (entries.length < 1 || entries.length > 64) throw new TypeError("SQL rows must contain 1-64 columns");
+  const columns = entries.map(([column]) => column);
+  if (new Set(columns).size !== columns.length) throw new TypeError("SQL row contains duplicate columns");
+  columns.forEach(identifier);
+
+  const mode = options.mode ?? "abort";
+  const conflictColumns = options.conflictColumns ?? [];
+  const prefix = `INSERT INTO ${table} (${columns.map(identifier).join(", ")}) VALUES (${entries
+    .map(([, value]) => sqlLiteral(value))
+    .join(", ")})`;
+
+  let suffix = "";
+  if (mode !== "abort") {
+    const target = conflictTarget(conflictColumns);
+    for (const column of conflictColumns) {
+      if (!Object.hasOwn(options.row, column)) throw new TypeError(`Conflict column is absent from row: ${column}`);
+    }
+    if (mode === "insert-only") {
+      suffix = ` ON CONFLICT ${target} DO NOTHING`;
+    } else if (mode === "overwrite") {
+      const mutable = columns.filter((column) => !conflictColumns.includes(column));
+      suffix = mutable.length
+        ? ` ON CONFLICT ${target} DO UPDATE SET ${mutable.map((column) => `${identifier(column)} = excluded.${identifier(column)}`).join(", ")}`
+        : ` ON CONFLICT ${target} DO NOTHING`;
+    } else {
+      const guard = options.guardColumn;
+      if (!guard || !Object.hasOwn(options.row, guard) || options.row[guard] === null) {
+        throw new TypeError("Compare mode requires a present, non-null NOT NULL guard column");
+      }
+      const comparisons = columns
+        .map((column) => `${table}.${identifier(column)} IS excluded.${identifier(column)}`)
+        .join(" AND ");
+      suffix = ` ON CONFLICT ${target} DO UPDATE SET ${identifier(guard)} = CASE WHEN ${comparisons} THEN ${table}.${identifier(guard)} ELSE NULL END`;
+    }
+  }
+
+  const statement = `${prefix}${suffix};`;
+  if (Buffer.byteLength(statement, "utf8") > MAX_D1_STATEMENT_BYTES) {
+    throw new RangeError(`SQL statement exceeds the ${MAX_D1_STATEMENT_BYTES}-byte safety limit`);
+  }
+  return statement;
+}
+
+/** D1 SQL imports intentionally omit BEGIN/COMMIT; Wrangler owns file rollback. */
+export function chunkSqlStatements(
+  statements: readonly string[],
+  options: SqlChunkOptions = {},
+): string[] {
+  const maxBytes = boundedInteger(options.maxBytes, DEFAULT_D1_CHUNK_BYTES, 16 * 1024 * 1024, "maxBytes");
+  const maxStatements = boundedInteger(options.maxStatements, DEFAULT_D1_CHUNK_STATEMENTS, 10_000, "maxStatements");
+  const chunks: string[] = [];
+  let current: string[] = [];
+  let currentBytes = 0;
+
+  for (const statement of statements) {
+    if (!statement.endsWith(";") || Buffer.byteLength(statement, "utf8") > MAX_D1_STATEMENT_BYTES) {
+      throw new TypeError("SQL chunks accept only bounded complete statements");
+    }
+    const bytes = Buffer.byteLength(`${statement}\n`, "utf8");
+    if (bytes > maxBytes) throw new RangeError("A SQL statement exceeds the configured chunk byte limit");
+    if (current.length && (current.length >= maxStatements || currentBytes + bytes > maxBytes)) {
+      chunks.push(`${current.join("\n")}\n`);
+      current = [];
+      currentBytes = 0;
+    }
+    current.push(statement);
+    currentBytes += bytes;
+  }
+  if (current.length) chunks.push(`${current.join("\n")}\n`);
+  return chunks;
+}

--- a/scripts/shopify-migration/adapters/media/index.ts
+++ b/scripts/shopify-migration/adapters/media/index.ts
@@ -127,6 +127,7 @@ export async function importMediaPlans(
 export { downloadVerifiedMedia, validateMediaPlan, verifyImageSignature } from "./security.js";
 export {
   createR2S3MediaStore,
+  resolveR2S3Timeouts,
   R2BindingMediaStore,
   R2S3MediaStore,
   wranglerR2GetArguments,
@@ -136,5 +137,7 @@ export type {
   ExpectedMediaObject,
   MediaObjectStore,
   R2S3Credentials,
+  R2S3Timeouts,
+  ResolvedR2S3Timeouts,
   StoredMediaObject,
 } from "./r2.js";

--- a/scripts/shopify-migration/adapters/media/index.ts
+++ b/scripts/shopify-migration/adapters/media/index.ts
@@ -124,7 +124,7 @@ export async function importMediaPlans(
   return results;
 }
 
-export { downloadVerifiedMedia, validateMediaPlan } from "./security.js";
+export { downloadVerifiedMedia, validateMediaPlan, verifyImageSignature } from "./security.js";
 export {
   createR2S3MediaStore,
   R2BindingMediaStore,

--- a/scripts/shopify-migration/adapters/media/index.ts
+++ b/scripts/shopify-migration/adapters/media/index.ts
@@ -4,7 +4,7 @@ import { parseWranglerJsonc, resolveMediaTarget } from "../../lib/wrangler-targe
 import type { MediaRewrite } from "../../transformers/_shared.js";
 import { downloadVerifiedMedia, validateMediaPlan, type MediaDownloadOptions } from "./security.js";
 import {
-  IMMUTABLE_MEDIA_CACHE_CONTROL,
+  REVALIDATING_MEDIA_CACHE_CONTROL,
   storedMediaMatchesExpected,
   type ExpectedMediaObject,
   type MediaObjectStore,
@@ -60,7 +60,7 @@ function describeMedia(plan: MediaRewrite, bytes: Uint8Array): ExpectedMediaObje
   const hash = createHash("sha256").update(bytes);
   return {
     contentType: plan.contentType,
-    cacheControl: IMMUTABLE_MEDIA_CACHE_CONTROL,
+    cacheControl: REVALIDATING_MEDIA_CACHE_CONTROL,
     byteLength: bytes.byteLength,
     sha256: hash.copy().digest("hex"),
     sha256Base64: hash.digest("base64"),

--- a/scripts/shopify-migration/adapters/media/index.ts
+++ b/scripts/shopify-migration/adapters/media/index.ts
@@ -1,0 +1,76 @@
+import type { ExecutionPlan } from "../../lib/config.js";
+import { parseWranglerJsonc, resolveMediaTarget } from "../../lib/wrangler-target.js";
+import type { MediaRewrite } from "../../transformers/_shared.js";
+import { downloadVerifiedMedia, validateMediaPlan, type MediaDownloadOptions } from "./security.js";
+import { IMMUTABLE_MEDIA_CACHE_CONTROL, type MediaObjectStore } from "./r2.js";
+
+export interface MediaImportResult {
+  objectKey: string;
+  status: "planned" | "written" | "exists";
+  bytes: number;
+}
+
+export interface MediaImportOptions {
+  execution: ExecutionPlan;
+  wranglerConfigText: string;
+  wranglerEnvironment?: string;
+  allowedHosts: readonly string[];
+  store: MediaObjectStore;
+  download?: Omit<MediaDownloadOptions, "allowedHosts">;
+}
+
+function assertExecution(execution: ExecutionPlan): void {
+  if (execution.dryRun === execution.apply) throw new Error("Migration execution must be exactly one of dry-run or apply");
+  if (execution.target === "preview" && execution.apply && !execution.confirmedPreview) {
+    throw new Error("Preview media writes require explicit preview confirmation");
+  }
+  if (execution.target === "production" && execution.apply && !execution.confirmedProduction) {
+    throw new Error("Production media writes require explicit production confirmation");
+  }
+  if (execution.overwrite && !execution.confirmedOverwrite) {
+    throw new Error("Media overwrite requires explicit overwrite confirmation");
+  }
+}
+
+export async function importMediaPlans(
+  plans: readonly MediaRewrite[],
+  options: MediaImportOptions,
+): Promise<MediaImportResult[]> {
+  assertExecution(options.execution);
+  const target = resolveMediaTarget(parseWranglerJsonc(options.wranglerConfigText), {
+    target: options.execution.target,
+    environment: options.wranglerEnvironment,
+  });
+  const objectKeys = new Set<string>();
+  for (const plan of plans) {
+    validateMediaPlan(plan, options.allowedHosts);
+    if (objectKeys.has(plan.objectKey)) throw new Error(`Duplicate media object key in import plan: ${plan.objectKey}`);
+    objectKeys.add(plan.objectKey);
+  }
+
+  if (options.execution.dryRun) {
+    return plans.map((plan) => ({ objectKey: plan.objectKey, status: "planned", bytes: 0 }));
+  }
+
+  const results: MediaImportResult[] = [];
+  for (const plan of plans) {
+    if (!options.execution.overwrite && await options.store.head(target.bucketName, plan.objectKey)) {
+      results.push({ objectKey: plan.objectKey, status: "exists", bytes: 0 });
+      continue;
+    }
+    const media = await downloadVerifiedMedia(plan, {
+      ...options.download,
+      allowedHosts: options.allowedHosts,
+    });
+    const status = await options.store.put(target.bucketName, media.objectKey, media.bytes, {
+      contentType: media.contentType,
+      cacheControl: IMMUTABLE_MEDIA_CACHE_CONTROL,
+      overwrite: options.execution.overwrite,
+    });
+    results.push({ objectKey: media.objectKey, status, bytes: status === "written" ? media.bytes.byteLength : 0 });
+  }
+  return results;
+}
+
+export { downloadVerifiedMedia, validateMediaPlan } from "./security.js";
+export { R2BindingMediaStore, wranglerR2GetArguments, wranglerR2PutArguments } from "./r2.js";

--- a/scripts/shopify-migration/adapters/media/index.ts
+++ b/scripts/shopify-migration/adapters/media/index.ts
@@ -1,14 +1,34 @@
+import { createHash } from "node:crypto";
 import type { ExecutionPlan } from "../../lib/config.js";
 import { parseWranglerJsonc, resolveMediaTarget } from "../../lib/wrangler-target.js";
 import type { MediaRewrite } from "../../transformers/_shared.js";
 import { downloadVerifiedMedia, validateMediaPlan, type MediaDownloadOptions } from "./security.js";
-import { IMMUTABLE_MEDIA_CACHE_CONTROL, type MediaObjectStore } from "./r2.js";
+import {
+  IMMUTABLE_MEDIA_CACHE_CONTROL,
+  storedMediaMatchesExpected,
+  type ExpectedMediaObject,
+  type MediaObjectStore,
+} from "./r2.js";
 
-export interface MediaImportResult {
+export interface PlannedMediaImportResult {
   objectKey: string;
-  status: "planned" | "written" | "exists";
-  bytes: number;
+  publicPath: string;
+  contentType: MediaRewrite["contentType"];
+  status: "planned";
+  byteLength: null;
+  sha256: null;
 }
+
+export interface AppliedMediaImportResult {
+  objectKey: string;
+  publicPath: string;
+  contentType: MediaRewrite["contentType"];
+  status: "written" | "verified-existing";
+  byteLength: number;
+  sha256: string;
+}
+
+export type MediaImportResult = PlannedMediaImportResult | AppliedMediaImportResult;
 
 export interface MediaImportOptions {
   execution: ExecutionPlan;
@@ -32,6 +52,22 @@ function assertExecution(execution: ExecutionPlan): void {
   }
 }
 
+export function fingerprintMediaSource(sourceUrl: string): string {
+  return createHash("sha256").update(sourceUrl, "utf8").digest("hex");
+}
+
+function describeMedia(plan: MediaRewrite, bytes: Uint8Array): ExpectedMediaObject {
+  const hash = createHash("sha256").update(bytes);
+  return {
+    contentType: plan.contentType,
+    cacheControl: IMMUTABLE_MEDIA_CACHE_CONTROL,
+    byteLength: bytes.byteLength,
+    sha256: hash.copy().digest("hex"),
+    sha256Base64: hash.digest("base64"),
+    sourceFingerprint: fingerprintMediaSource(plan.sourceUrl),
+  };
+}
+
 export async function importMediaPlans(
   plans: readonly MediaRewrite[],
   options: MediaImportOptions,
@@ -49,28 +85,56 @@ export async function importMediaPlans(
   }
 
   if (options.execution.dryRun) {
-    return plans.map((plan) => ({ objectKey: plan.objectKey, status: "planned", bytes: 0 }));
+    return plans.map((plan) => ({
+      objectKey: plan.objectKey,
+      publicPath: plan.publicPath,
+      contentType: plan.contentType,
+      status: "planned" as const,
+      byteLength: null,
+      sha256: null,
+    }));
   }
 
   const results: MediaImportResult[] = [];
   for (const plan of plans) {
-    if (!options.execution.overwrite && await options.store.head(target.bucketName, plan.objectKey)) {
-      results.push({ objectKey: plan.objectKey, status: "exists", bytes: 0 });
-      continue;
-    }
     const media = await downloadVerifiedMedia(plan, {
       ...options.download,
       allowedHosts: options.allowedHosts,
     });
+    const descriptor = describeMedia(plan, media.bytes);
     const status = await options.store.put(target.bucketName, media.objectKey, media.bytes, {
-      contentType: media.contentType,
-      cacheControl: IMMUTABLE_MEDIA_CACHE_CONTROL,
+      ...descriptor,
       overwrite: options.execution.overwrite,
     });
-    results.push({ objectKey: media.objectKey, status, bytes: status === "written" ? media.bytes.byteLength : 0 });
+    if (status === "exists") {
+      const stored = await options.store.inspect(target.bucketName, media.objectKey);
+      if (!storedMediaMatchesExpected(stored, descriptor)) {
+        throw new Error("Existing media object does not match the verified import; explicit overwrite review is required");
+      }
+    }
+    results.push({
+      objectKey: media.objectKey,
+      publicPath: media.publicPath,
+      contentType: media.contentType,
+      status: status === "written" ? "written" : "verified-existing",
+      byteLength: media.bytes.byteLength,
+      sha256: descriptor.sha256,
+    });
   }
   return results;
 }
 
 export { downloadVerifiedMedia, validateMediaPlan } from "./security.js";
-export { R2BindingMediaStore, wranglerR2GetArguments, wranglerR2PutArguments } from "./r2.js";
+export {
+  createR2S3MediaStore,
+  R2BindingMediaStore,
+  R2S3MediaStore,
+  wranglerR2GetArguments,
+  wranglerR2PutArguments,
+} from "./r2.js";
+export type {
+  ExpectedMediaObject,
+  MediaObjectStore,
+  R2S3Credentials,
+  StoredMediaObject,
+} from "./r2.js";

--- a/scripts/shopify-migration/adapters/media/r2.ts
+++ b/scripts/shopify-migration/adapters/media/r2.ts
@@ -8,7 +8,8 @@ import {
 import type { WranglerTarget } from "../../lib/wrangler-target.js";
 import type { MediaContentType } from "./security.js";
 
-export const IMMUTABLE_MEDIA_CACHE_CONTROL = "public, max-age=31536000, immutable";
+/** Position-derived media keys are overwriteable only with confirmation, so clients must revalidate them. */
+export const REVALIDATING_MEDIA_CACHE_CONTROL = "public, max-age=0, must-revalidate";
 export const MEDIA_IMPORTER_VERSION = "mercora-shopify-migration-v1";
 
 const METADATA_IMPORTER = "mercora-importer";
@@ -153,7 +154,7 @@ export function wranglerR2PutArguments(options: {
   return [
     "r2", "object", "put", safeObjectPath(options.bucketName, options.objectKey), "--pipe",
     "--content-type", options.contentType,
-    "--cache-control", IMMUTABLE_MEDIA_CACHE_CONTROL,
+    "--cache-control", REVALIDATING_MEDIA_CACHE_CONTROL,
     ...modeArguments(options.target), "--config", configArgument(options.configPath),
     ...environmentArguments(options.environment),
   ];

--- a/scripts/shopify-migration/adapters/media/r2.ts
+++ b/scripts/shopify-migration/adapters/media/r2.ts
@@ -1,0 +1,106 @@
+import type { WranglerTarget } from "../../lib/wrangler-target.js";
+import type { MediaContentType } from "./security.js";
+
+export const IMMUTABLE_MEDIA_CACHE_CONTROL = "public, max-age=31536000, immutable";
+
+export interface MediaObjectStore {
+  head(bucketName: string, objectKey: string): Promise<boolean>;
+  put(
+    bucketName: string,
+    objectKey: string,
+    bytes: Uint8Array,
+    options: { contentType: MediaContentType; cacheControl: string; overwrite: boolean },
+  ): Promise<"written" | "exists">;
+}
+
+function safeObjectPath(bucketName: string, objectKey: string): string {
+  if (!/^[a-z0-9][a-z0-9_-]{1,126}[a-z0-9]$/i.test(bucketName)) throw new Error("R2 bucket name is invalid");
+  if (!/^(?:products|categories|blog|pages)\/[A-Za-z0-9][A-Za-z0-9_-]{0,127}\/(?:cover\/|inline\/)?[1-9][0-9]{0,5}\.(?:jpe?g|png|webp)$/i.test(objectKey)) {
+    throw new Error("R2 object key is invalid");
+  }
+  return `${bucketName}/${objectKey}`;
+}
+
+function modeArguments(target: WranglerTarget): string[] {
+  return target === "local" ? ["--local"] : ["--remote"];
+}
+
+function environmentArguments(environment?: string): string[] {
+  if (!environment) return [];
+  if (!/^[a-z][a-z0-9_-]{0,62}$/i.test(environment)) throw new Error("Wrangler environment is invalid");
+  return ["--env", environment];
+}
+
+function configArgument(value: string): string {
+  if (!value || value.startsWith("-") || value.length > 4_096 || /[\0\r\n]/u.test(value)) {
+    throw new Error("Wrangler config path is invalid");
+  }
+  return value;
+}
+
+export function wranglerR2GetArguments(options: {
+  bucketName: string;
+  objectKey: string;
+  target: WranglerTarget;
+  environment?: string;
+  configPath: string;
+}): string[] {
+  return [
+    "r2", "object", "get", safeObjectPath(options.bucketName, options.objectKey), "--pipe",
+    ...modeArguments(options.target), "--config", configArgument(options.configPath),
+    ...environmentArguments(options.environment),
+  ];
+}
+
+/** Wrangler has no conditional object-put flag, so this path is overwrite-only. */
+export function wranglerR2PutArguments(options: {
+  bucketName: string;
+  objectKey: string;
+  target: WranglerTarget;
+  environment?: string;
+  configPath: string;
+  contentType: MediaContentType;
+  overwriteConfirmed: boolean;
+}): string[] {
+  if (!options.overwriteConfirmed) {
+    throw new Error("Wrangler R2 put cannot guarantee create-only writes; explicit overwrite confirmation is required");
+  }
+  return [
+    "r2", "object", "put", safeObjectPath(options.bucketName, options.objectKey), "--pipe",
+    "--content-type", options.contentType,
+    "--cache-control", IMMUTABLE_MEDIA_CACHE_CONTROL,
+    ...modeArguments(options.target), "--config", configArgument(options.configPath),
+    ...environmentArguments(options.environment),
+  ];
+}
+
+/** Atomic R2-binding adapter; failed If-None-Match returns null instead of overwriting. */
+export class R2BindingMediaStore implements MediaObjectStore {
+  constructor(private readonly bucketName: string, private readonly bucket: R2Bucket) {}
+
+  private assertBucket(bucketName: string): void {
+    if (bucketName !== this.bucketName) throw new Error("Resolved MEDIA bucket does not match the bound R2 adapter");
+  }
+
+  async head(bucketName: string, objectKey: string): Promise<boolean> {
+    this.assertBucket(bucketName);
+    safeObjectPath(bucketName, objectKey);
+    return (await this.bucket.head(objectKey)) !== null;
+  }
+
+  async put(
+    bucketName: string,
+    objectKey: string,
+    bytes: Uint8Array,
+    options: { contentType: MediaContentType; cacheControl: string; overwrite: boolean },
+  ): Promise<"written" | "exists"> {
+    this.assertBucket(bucketName);
+    safeObjectPath(bucketName, objectKey);
+    const body = new Uint8Array(bytes);
+    const result = await this.bucket.put(objectKey, body, {
+      ...(options.overwrite ? {} : { onlyIf: { etagDoesNotMatch: "*" } }),
+      httpMetadata: { contentType: options.contentType, cacheControl: options.cacheControl },
+    });
+    return result === null ? "exists" : "written";
+  }
+}

--- a/scripts/shopify-migration/adapters/media/r2.ts
+++ b/scripts/shopify-migration/adapters/media/r2.ts
@@ -1,16 +1,101 @@
+import {
+  HeadObjectCommand,
+  PutObjectCommand,
+  S3Client,
+  type HeadObjectCommandOutput,
+  type PutObjectCommandOutput,
+} from "@aws-sdk/client-s3";
 import type { WranglerTarget } from "../../lib/wrangler-target.js";
 import type { MediaContentType } from "./security.js";
 
 export const IMMUTABLE_MEDIA_CACHE_CONTROL = "public, max-age=31536000, immutable";
+export const MEDIA_IMPORTER_VERSION = "mercora-shopify-migration-v1";
+
+const METADATA_IMPORTER = "mercora-importer";
+const METADATA_SOURCE_FINGERPRINT = "mercora-source-sha256";
+const METADATA_CONTENT_SHA256 = "mercora-content-sha256";
+const METADATA_BYTE_LENGTH = "mercora-byte-length";
+
+export interface ExpectedMediaObject {
+  contentType: MediaContentType;
+  cacheControl: string;
+  byteLength: number;
+  sha256: string;
+  sha256Base64: string;
+  sourceFingerprint: string;
+}
+
+/** Metadata read from storage. Optional fields are never assumed to be trustworthy. */
+export interface StoredMediaObject {
+  contentType?: string;
+  cacheControl?: string;
+  byteLength: number;
+  sha256?: string;
+  importer?: string;
+  sourceFingerprint?: string;
+  importerContentSha256?: string;
+  importerByteLength?: string;
+}
 
 export interface MediaObjectStore {
-  head(bucketName: string, objectKey: string): Promise<boolean>;
+  inspect(bucketName: string, objectKey: string): Promise<StoredMediaObject | null>;
   put(
     bucketName: string,
     objectKey: string,
     bytes: Uint8Array,
-    options: { contentType: MediaContentType; cacheControl: string; overwrite: boolean },
+    options: ExpectedMediaObject & { overwrite: boolean },
   ): Promise<"written" | "exists">;
+}
+
+export function storedMediaMatchesExpected(
+  stored: StoredMediaObject | null,
+  expected: ExpectedMediaObject,
+): boolean {
+  return stored !== null &&
+    stored.contentType === expected.contentType &&
+    stored.cacheControl === expected.cacheControl &&
+    stored.byteLength === expected.byteLength &&
+    stored.sha256 === expected.sha256 &&
+    stored.importer === MEDIA_IMPORTER_VERSION &&
+    stored.sourceFingerprint === expected.sourceFingerprint &&
+    stored.importerContentSha256 === expected.sha256 &&
+    stored.importerByteLength === String(expected.byteLength);
+}
+
+function customMetadata(expected: ExpectedMediaObject): Record<string, string> {
+  return {
+    [METADATA_IMPORTER]: MEDIA_IMPORTER_VERSION,
+    [METADATA_SOURCE_FINGERPRINT]: expected.sourceFingerprint,
+    [METADATA_CONTENT_SHA256]: expected.sha256,
+    [METADATA_BYTE_LENGTH]: String(expected.byteLength),
+  };
+}
+
+function bytesToHex(value: ArrayBuffer | Uint8Array): string {
+  return Array.from(value instanceof Uint8Array ? value : new Uint8Array(value), (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+function hexToBytes(value: string): Uint8Array {
+  if (!/^[a-f0-9]{64}$/u.test(value)) throw new Error("Media checksum is invalid");
+  return Uint8Array.from(value.match(/../gu) ?? [], (pair) => Number.parseInt(pair, 16));
+}
+
+function base64ToHex(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  try {
+    const decoded = Buffer.from(value, "base64");
+    return decoded.byteLength === 32 ? bytesToHex(decoded) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function metadataValue(metadata: Record<string, string> | undefined, key: string): string | undefined {
+  if (!metadata) return undefined;
+  const exact = metadata[key];
+  if (exact !== undefined) return exact;
+  const entry = Object.entries(metadata).find(([candidate]) => candidate.toLowerCase() === key);
+  return entry?.[1];
 }
 
 function safeObjectPath(bucketName: string, objectKey: string): string {
@@ -74,7 +159,7 @@ export function wranglerR2PutArguments(options: {
   ];
 }
 
-/** Atomic R2-binding adapter; failed If-None-Match returns null instead of overwriting. */
+/** Atomic Workers-binding adapter; failed If-None-Match returns exists instead of overwriting. */
 export class R2BindingMediaStore implements MediaObjectStore {
   constructor(private readonly bucketName: string, private readonly bucket: R2Bucket) {}
 
@@ -82,17 +167,28 @@ export class R2BindingMediaStore implements MediaObjectStore {
     if (bucketName !== this.bucketName) throw new Error("Resolved MEDIA bucket does not match the bound R2 adapter");
   }
 
-  async head(bucketName: string, objectKey: string): Promise<boolean> {
+  async inspect(bucketName: string, objectKey: string): Promise<StoredMediaObject | null> {
     this.assertBucket(bucketName);
     safeObjectPath(bucketName, objectKey);
-    return (await this.bucket.head(objectKey)) !== null;
+    const object = await this.bucket.head(objectKey);
+    if (!object) return null;
+    return {
+      contentType: object.httpMetadata?.contentType,
+      cacheControl: object.httpMetadata?.cacheControl,
+      byteLength: object.size,
+      sha256: object.checksums.sha256 ? bytesToHex(object.checksums.sha256) : undefined,
+      importer: object.customMetadata?.[METADATA_IMPORTER],
+      sourceFingerprint: object.customMetadata?.[METADATA_SOURCE_FINGERPRINT],
+      importerContentSha256: object.customMetadata?.[METADATA_CONTENT_SHA256],
+      importerByteLength: object.customMetadata?.[METADATA_BYTE_LENGTH],
+    };
   }
 
   async put(
     bucketName: string,
     objectKey: string,
     bytes: Uint8Array,
-    options: { contentType: MediaContentType; cacheControl: string; overwrite: boolean },
+    options: ExpectedMediaObject & { overwrite: boolean },
   ): Promise<"written" | "exists"> {
     this.assertBucket(bucketName);
     safeObjectPath(bucketName, objectKey);
@@ -100,7 +196,121 @@ export class R2BindingMediaStore implements MediaObjectStore {
     const result = await this.bucket.put(objectKey, body, {
       ...(options.overwrite ? {} : { onlyIf: { etagDoesNotMatch: "*" } }),
       httpMetadata: { contentType: options.contentType, cacheControl: options.cacheControl },
+      customMetadata: customMetadata(options),
+      sha256: hexToBytes(options.sha256),
     });
     return result === null ? "exists" : "written";
   }
+}
+
+export interface S3CommandSender {
+  send(command: HeadObjectCommand): Promise<HeadObjectCommandOutput>;
+  send(command: PutObjectCommand): Promise<PutObjectCommandOutput>;
+}
+
+function errorStatus(error: unknown): number | undefined {
+  if (!error || typeof error !== "object") return undefined;
+  const metadata = "$metadata" in error ? error.$metadata : undefined;
+  if (!metadata || typeof metadata !== "object" || !("httpStatusCode" in metadata)) return undefined;
+  return typeof metadata.httpStatusCode === "number" ? metadata.httpStatusCode : undefined;
+}
+
+function errorName(error: unknown): string | undefined {
+  return error && typeof error === "object" && "name" in error && typeof error.name === "string" ? error.name : undefined;
+}
+
+function isConditionalWriteConflict(error: unknown): boolean {
+  const status = errorStatus(error);
+  const name = errorName(error);
+  return status === 409 || status === 412 || name === "ConditionalRequestConflict" || name === "PreconditionFailed";
+}
+
+/** Node operator adapter for R2's S3-compatible API. The bucket must come from canonical Wrangler resolution. */
+export class R2S3MediaStore implements MediaObjectStore {
+  constructor(private readonly bucketName: string, private readonly client: S3CommandSender) {
+    safeObjectPath(bucketName, "pages/validation/1.jpg");
+  }
+
+  private assertBucket(bucketName: string): void {
+    if (bucketName !== this.bucketName) throw new Error("Resolved MEDIA bucket does not match the S3 R2 adapter");
+  }
+
+  async inspect(bucketName: string, objectKey: string): Promise<StoredMediaObject | null> {
+    this.assertBucket(bucketName);
+    safeObjectPath(bucketName, objectKey);
+    let response: HeadObjectCommandOutput;
+    try {
+      response = await this.client.send(new HeadObjectCommand({
+        Bucket: bucketName,
+        Key: objectKey,
+        ChecksumMode: "ENABLED",
+      }));
+    } catch (error) {
+      const status = errorStatus(error);
+      const name = errorName(error);
+      if (status === 404 || name === "NotFound" || name === "NoSuchKey") return null;
+      throw new Error("R2 object inspection failed");
+    }
+    return {
+      contentType: response.ContentType,
+      cacheControl: response.CacheControl,
+      byteLength: response.ContentLength ?? -1,
+      sha256: base64ToHex(response.ChecksumSHA256),
+      importer: metadataValue(response.Metadata, METADATA_IMPORTER),
+      sourceFingerprint: metadataValue(response.Metadata, METADATA_SOURCE_FINGERPRINT),
+      importerContentSha256: metadataValue(response.Metadata, METADATA_CONTENT_SHA256),
+      importerByteLength: metadataValue(response.Metadata, METADATA_BYTE_LENGTH),
+    };
+  }
+
+  async put(
+    bucketName: string,
+    objectKey: string,
+    bytes: Uint8Array,
+    options: ExpectedMediaObject & { overwrite: boolean },
+  ): Promise<"written" | "exists"> {
+    this.assertBucket(bucketName);
+    safeObjectPath(bucketName, objectKey);
+    try {
+      await this.client.send(new PutObjectCommand({
+        Bucket: bucketName,
+        Key: objectKey,
+        Body: new Uint8Array(bytes),
+        ContentLength: bytes.byteLength,
+        ContentType: options.contentType,
+        CacheControl: options.cacheControl,
+        ChecksumSHA256: options.sha256Base64,
+        Metadata: customMetadata(options),
+        ...(options.overwrite ? {} : { IfNoneMatch: "*" }),
+      }));
+      return "written";
+    } catch (error) {
+      if (!options.overwrite && isConditionalWriteConflict(error)) return "exists";
+      throw new Error("R2 object write failed");
+    }
+  }
+}
+
+export interface R2S3Credentials {
+  bucketName: string;
+  accountId: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+}
+
+/** Builds the official S3 client without placing credentials in argv, object metadata, or errors. */
+export function createR2S3MediaStore(options: R2S3Credentials): R2S3MediaStore {
+  if (!/^[a-f0-9]{32}$/iu.test(options.accountId)) throw new Error("Cloudflare account ID is invalid");
+  if (!options.accessKeyId || options.accessKeyId.length > 512 || /[\0\r\n]/u.test(options.accessKeyId)) {
+    throw new Error("R2 access key ID is invalid");
+  }
+  if (!options.secretAccessKey || options.secretAccessKey.length > 2_048 || /[\0\r\n]/u.test(options.secretAccessKey)) {
+    throw new Error("R2 secret access key is invalid");
+  }
+  const client = new S3Client({
+    region: "auto",
+    endpoint: `https://${options.accountId.toLowerCase()}.r2.cloudflarestorage.com`,
+    credentials: { accessKeyId: options.accessKeyId, secretAccessKey: options.secretAccessKey },
+  });
+  return new R2S3MediaStore(options.bucketName, client);
 }

--- a/scripts/shopify-migration/adapters/media/r2.ts
+++ b/scripts/shopify-migration/adapters/media/r2.ts
@@ -5,6 +5,7 @@ import {
   type HeadObjectCommandOutput,
   type PutObjectCommandOutput,
 } from "@aws-sdk/client-s3";
+import { NodeHttpHandler } from "@smithy/node-http-handler";
 import type { WranglerTarget } from "../../lib/wrangler-target.js";
 import type { MediaContentType } from "./security.js";
 
@@ -205,8 +206,41 @@ export class R2BindingMediaStore implements MediaObjectStore {
 }
 
 export interface S3CommandSender {
-  send(command: HeadObjectCommand): Promise<HeadObjectCommandOutput>;
-  send(command: PutObjectCommand): Promise<PutObjectCommandOutput>;
+  send(command: HeadObjectCommand, options?: { abortSignal?: AbortSignal }): Promise<HeadObjectCommandOutput>;
+  send(command: PutObjectCommand, options?: { abortSignal?: AbortSignal }): Promise<PutObjectCommandOutput>;
+}
+
+const MAX_R2_TIMEOUT_MS = 120_000;
+
+function boundedR2Timeout(value: number | undefined, fallback: number, name: string): number {
+  const resolved = value ?? fallback;
+  if (!Number.isSafeInteger(resolved) || resolved < 1 || resolved > MAX_R2_TIMEOUT_MS) {
+    throw new TypeError(`${name} must be an integer between 1 and ${MAX_R2_TIMEOUT_MS} milliseconds`);
+  }
+  return resolved;
+}
+
+export interface R2S3Timeouts {
+  operationTimeoutMs?: number;
+  connectionTimeoutMs?: number;
+  requestTimeoutMs?: number;
+  socketTimeoutMs?: number;
+}
+
+export interface ResolvedR2S3Timeouts {
+  operationTimeoutMs: number;
+  connectionTimeoutMs: number;
+  requestTimeoutMs: number;
+  socketTimeoutMs: number;
+}
+
+export function resolveR2S3Timeouts(options: R2S3Timeouts = {}): ResolvedR2S3Timeouts {
+  return {
+    operationTimeoutMs: boundedR2Timeout(options.operationTimeoutMs, 60_000, "operationTimeoutMs"),
+    connectionTimeoutMs: boundedR2Timeout(options.connectionTimeoutMs, 10_000, "connectionTimeoutMs"),
+    requestTimeoutMs: boundedR2Timeout(options.requestTimeoutMs, 30_000, "requestTimeoutMs"),
+    socketTimeoutMs: boundedR2Timeout(options.socketTimeoutMs, 30_000, "socketTimeoutMs"),
+  };
 }
 
 function errorStatus(error: unknown): number | undefined {
@@ -228,12 +262,35 @@ function isConditionalWriteConflict(error: unknown): boolean {
 
 /** Node operator adapter for R2's S3-compatible API. The bucket must come from canonical Wrangler resolution. */
 export class R2S3MediaStore implements MediaObjectStore {
-  constructor(private readonly bucketName: string, private readonly client: S3CommandSender) {
+  private readonly operationTimeoutMs: number;
+
+  constructor(
+    private readonly bucketName: string,
+    private readonly client: S3CommandSender,
+    timeouts: Pick<R2S3Timeouts, "operationTimeoutMs"> = {},
+  ) {
     safeObjectPath(bucketName, "pages/validation/1.jpg");
+    this.operationTimeoutMs = resolveR2S3Timeouts(timeouts).operationTimeoutMs;
   }
 
   private assertBucket(bucketName: string): void {
     if (bucketName !== this.bucketName) throw new Error("Resolved MEDIA bucket does not match the S3 R2 adapter");
+  }
+
+  private sendWithTimeout(command: HeadObjectCommand): Promise<HeadObjectCommandOutput>;
+  private sendWithTimeout(command: PutObjectCommand): Promise<PutObjectCommandOutput>;
+  private async sendWithTimeout(
+    command: HeadObjectCommand | PutObjectCommand,
+  ): Promise<HeadObjectCommandOutput | PutObjectCommandOutput> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.operationTimeoutMs);
+    try {
+      return command instanceof HeadObjectCommand
+        ? await this.client.send(command, { abortSignal: controller.signal })
+        : await this.client.send(command, { abortSignal: controller.signal });
+    } finally {
+      clearTimeout(timer);
+    }
   }
 
   async inspect(bucketName: string, objectKey: string): Promise<StoredMediaObject | null> {
@@ -241,7 +298,7 @@ export class R2S3MediaStore implements MediaObjectStore {
     safeObjectPath(bucketName, objectKey);
     let response: HeadObjectCommandOutput;
     try {
-      response = await this.client.send(new HeadObjectCommand({
+      response = await this.sendWithTimeout(new HeadObjectCommand({
         Bucket: bucketName,
         Key: objectKey,
         ChecksumMode: "ENABLED",
@@ -273,7 +330,7 @@ export class R2S3MediaStore implements MediaObjectStore {
     this.assertBucket(bucketName);
     safeObjectPath(bucketName, objectKey);
     try {
-      await this.client.send(new PutObjectCommand({
+      await this.sendWithTimeout(new PutObjectCommand({
         Bucket: bucketName,
         Key: objectKey,
         Body: new Uint8Array(bytes),
@@ -297,6 +354,7 @@ export interface R2S3Credentials {
   accountId: string;
   accessKeyId: string;
   secretAccessKey: string;
+  timeouts?: R2S3Timeouts;
 }
 
 /** Builds the official S3 client without placing credentials in argv, object metadata, or errors. */
@@ -308,10 +366,17 @@ export function createR2S3MediaStore(options: R2S3Credentials): R2S3MediaStore {
   if (!options.secretAccessKey || options.secretAccessKey.length > 2_048 || /[\0\r\n]/u.test(options.secretAccessKey)) {
     throw new Error("R2 secret access key is invalid");
   }
+  const timeouts = resolveR2S3Timeouts(options.timeouts);
   const client = new S3Client({
     region: "auto",
     endpoint: `https://${options.accountId.toLowerCase()}.r2.cloudflarestorage.com`,
     credentials: { accessKeyId: options.accessKeyId, secretAccessKey: options.secretAccessKey },
+    requestHandler: new NodeHttpHandler({
+      connectionTimeout: timeouts.connectionTimeoutMs,
+      requestTimeout: timeouts.requestTimeoutMs,
+      socketTimeout: timeouts.socketTimeoutMs,
+      throwOnRequestTimeout: true,
+    }),
   });
-  return new R2S3MediaStore(options.bucketName, client);
+  return new R2S3MediaStore(options.bucketName, client, timeouts);
 }

--- a/scripts/shopify-migration/adapters/media/security.ts
+++ b/scripts/shopify-migration/adapters/media/security.ts
@@ -237,6 +237,45 @@ function ascii(bytes: Uint8Array, start: number, end: number): string {
   return String.fromCharCode(...bytes.slice(start, end));
 }
 
+function isVp8Payload(bytes: Uint8Array, view: DataView, dataStart: number, chunkLength: number): boolean {
+  return chunkLength >= 10 && bytes[dataStart + 3] === 0x9d && bytes[dataStart + 4] === 0x01 &&
+    bytes[dataStart + 5] === 0x2a && hasBoundedDimensions(
+    view.getUint16(dataStart + 6, true) & 0x3fff,
+    view.getUint16(dataStart + 8, true) & 0x3fff,
+  );
+}
+
+function isVp8lPayload(bytes: Uint8Array, view: DataView, dataStart: number, chunkLength: number): boolean {
+  if (chunkLength < 5 || bytes[dataStart] !== 0x2f) return false;
+  const dimensions = view.getUint32(dataStart + 1, true);
+  return hasBoundedDimensions((dimensions & 0x3fff) + 1, ((dimensions >>> 14) & 0x3fff) + 1);
+}
+
+function readUint24LittleEndian(bytes: Uint8Array, offset: number): number {
+  return bytes[offset] | bytes[offset + 1] << 8 | bytes[offset + 2] << 16;
+}
+
+function hasValidAnimatedFrame(bytes: Uint8Array, view: DataView, dataStart: number, dataEnd: number): boolean {
+  if (dataEnd - dataStart < 24 || !hasBoundedDimensions(
+    readUint24LittleEndian(bytes, dataStart + 6) + 1,
+    readUint24LittleEndian(bytes, dataStart + 9) + 1,
+  )) return false;
+  let offset = dataStart + 16;
+  let sawPayload = false;
+  while (offset + 8 <= dataEnd) {
+    const type = ascii(bytes, offset, offset + 4);
+    const length = view.getUint32(offset + 4, true);
+    const payloadStart = offset + 8;
+    const payloadEnd = payloadStart + length;
+    const chunkEnd = payloadEnd + (length % 2);
+    if (payloadEnd < payloadStart || chunkEnd > dataEnd) return false;
+    if (type === "VP8 ") sawPayload ||= isVp8Payload(bytes, view, payloadStart, length);
+    if (type === "VP8L") sawPayload ||= isVp8lPayload(bytes, view, payloadStart, length);
+    offset = chunkEnd;
+  }
+  return sawPayload && offset === dataEnd;
+}
+
 function isWebp(bytes: Uint8Array): boolean {
   if (bytes.length < 20 || ascii(bytes, 0, 4) !== "RIFF" || ascii(bytes, 8, 12) !== "WEBP") return false;
   const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
@@ -244,6 +283,8 @@ function isWebp(bytes: Uint8Array): boolean {
   let offset = 12;
   let chunkIndex = 0;
   let sawImageHeader = false;
+  let requiresExtendedPayload = false;
+  let sawPayload = false;
   while (offset + 8 <= bytes.length) {
     const chunk = ascii(bytes, offset, offset + 4);
     const chunkLength = view.getUint32(offset + 4, true);
@@ -253,27 +294,28 @@ function isWebp(bytes: Uint8Array): boolean {
     if (dataEnd < dataStart || chunkEnd > bytes.length) return false;
     if (chunkIndex === 0) {
       if (chunk === "VP8 ") {
-        if (chunkLength < 10 || bytes[dataStart + 3] !== 0x9d || bytes[dataStart + 4] !== 0x01 ||
-          bytes[dataStart + 5] !== 0x2a || !hasBoundedDimensions(
-          view.getUint16(dataStart + 6, true) & 0x3fff,
-          view.getUint16(dataStart + 8, true) & 0x3fff,
-        )) return false;
+        if (!isVp8Payload(bytes, view, dataStart, chunkLength)) return false;
+        sawPayload = true;
       } else if (chunk === "VP8L") {
-        if (chunkLength < 5 || bytes[dataStart] !== 0x2f) return false;
-        const dimensions = view.getUint32(dataStart + 1, true);
-        if (!hasBoundedDimensions((dimensions & 0x3fff) + 1, ((dimensions >>> 14) & 0x3fff) + 1)) return false;
+        if (!isVp8lPayload(bytes, view, dataStart, chunkLength)) return false;
+        sawPayload = true;
       } else if (chunk === "VP8X") {
         if (chunkLength !== 10) return false;
-        const width = bytes[dataStart + 4] | bytes[dataStart + 5] << 8 | bytes[dataStart + 6] << 16;
-        const height = bytes[dataStart + 7] | bytes[dataStart + 8] << 8 | bytes[dataStart + 9] << 16;
+        const width = readUint24LittleEndian(bytes, dataStart + 4);
+        const height = readUint24LittleEndian(bytes, dataStart + 7);
         if (!hasBoundedDimensions(width + 1, height + 1)) return false;
+        requiresExtendedPayload = true;
       } else return false;
       sawImageHeader = true;
+    } else if (requiresExtendedPayload) {
+      if (chunk === "VP8 ") sawPayload ||= isVp8Payload(bytes, view, dataStart, chunkLength);
+      if (chunk === "VP8L") sawPayload ||= isVp8lPayload(bytes, view, dataStart, chunkLength);
+      if (chunk === "ANMF") sawPayload ||= hasValidAnimatedFrame(bytes, view, dataStart, dataEnd);
     }
     offset = chunkEnd;
     chunkIndex += 1;
   }
-  return sawImageHeader && offset === bytes.length;
+  return sawImageHeader && sawPayload && offset === bytes.length;
 }
 
 export function verifyImageSignature(bytes: Uint8Array, contentType: MediaContentType): void {

--- a/scripts/shopify-migration/adapters/media/security.ts
+++ b/scripts/shopify-migration/adapters/media/security.ts
@@ -26,6 +26,11 @@ export interface VerifiedMedia {
 }
 
 const blockedAddresses = new BlockList();
+const MYSHOPIFY_HOST = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.myshopify\.com$/u;
+
+function isShopifyAssetHost(hostname: string): boolean {
+  return hostname === "cdn.shopify.com" || MYSHOPIFY_HOST.test(hostname);
+}
 for (const [address, prefix] of [
   ["0.0.0.0", 8], ["10.0.0.0", 8], ["100.64.0.0", 10], ["127.0.0.0", 8],
   ["169.254.0.0", 16], ["172.16.0.0", 12], ["192.0.0.0", 24], ["192.0.2.0", 24],
@@ -67,8 +72,12 @@ function allowedHostnames(hosts: readonly string[]): ReadonlySet<string> {
   for (const raw of hosts) {
     if (!raw || raw.includes("://") || /[/\\@:#?%\[\]*]/u.test(raw)) throw new Error("Invalid allowed media hostname");
     const hostname = new URL(`https://${raw}`).hostname.toLowerCase();
-    if (hostname !== raw.toLowerCase() || isIP(hostname) !== 0 || !/^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/u.test(hostname)) {
-      throw new Error("Invalid allowed media hostname");
+    if (
+      hostname !== raw.toLowerCase() || isIP(hostname) !== 0 ||
+      !/^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/u.test(hostname) ||
+      !isShopifyAssetHost(hostname)
+    ) {
+      throw new Error("Invalid or non-Shopify allowed media hostname");
     }
     result.add(hostname);
   }
@@ -81,7 +90,8 @@ function mediaUrl(value: string, allowed: ReadonlySet<string>): URL {
   const hostname = url.hostname.toLowerCase();
   if (
     url.protocol !== "https:" || url.username || url.password || url.port || url.hash ||
-    isIP(hostname) !== 0 || !allowed.has(hostname)
+    isIP(hostname) !== 0 || !allowed.has(hostname) || !isShopifyAssetHost(hostname) ||
+    (MYSHOPIFY_HOST.test(hostname) && !url.pathname.startsWith("/cdn/"))
   ) throw new Error("Media URL is not an allowed exact HTTPS origin");
   return url;
 }

--- a/scripts/shopify-migration/adapters/media/security.ts
+++ b/scripts/shopify-migration/adapters/media/security.ts
@@ -1,0 +1,284 @@
+import { lookup } from "node:dns/promises";
+import { BlockList, isIP } from "node:net";
+import type { MediaRewrite } from "../../transformers/_shared.js";
+
+export const DEFAULT_MAX_MEDIA_BYTES = 15 * 1024 * 1024;
+export const DEFAULT_MEDIA_TIMEOUT_MS = 15_000;
+export const DEFAULT_MAX_REDIRECTS = 4;
+
+export type MediaContentType = "image/jpeg" | "image/png" | "image/webp";
+export type HostResolver = (hostname: string) => Promise<readonly string[]>;
+
+export interface MediaDownloadOptions {
+  allowedHosts: readonly string[];
+  fetcher?: typeof fetch;
+  resolveHost?: HostResolver;
+  maxBytes?: number;
+  timeoutMs?: number;
+  maxRedirects?: number;
+}
+
+export interface VerifiedMedia {
+  bytes: Uint8Array;
+  contentType: MediaContentType;
+  objectKey: string;
+  publicPath: string;
+}
+
+const blockedAddresses = new BlockList();
+for (const [address, prefix] of [
+  ["0.0.0.0", 8], ["10.0.0.0", 8], ["100.64.0.0", 10], ["127.0.0.0", 8],
+  ["169.254.0.0", 16], ["172.16.0.0", 12], ["192.0.0.0", 24], ["192.0.2.0", 24],
+  ["192.88.99.0", 24], ["192.168.0.0", 16], ["198.18.0.0", 15], ["198.51.100.0", 24],
+  ["203.0.113.0", 24], ["224.0.0.0", 4], ["240.0.0.0", 4],
+] as const) blockedAddresses.addSubnet(address, prefix, "ipv4");
+for (const [address, prefix] of [
+  ["::", 128], ["::1", 128], ["100::", 64], ["2001::", 23],
+  ["2001:db8::", 32], ["2002::", 16], ["fc00::", 7], ["fe80::", 10], ["fec0::", 10], ["ff00::", 8],
+] as const) blockedAddresses.addSubnet(address, prefix, "ipv6");
+
+function positiveInteger(value: number | undefined, fallback: number, maximum: number, field: string): number {
+  const actual = value ?? fallback;
+  if (!Number.isSafeInteger(actual) || actual < 1 || actual > maximum) {
+    throw new Error(`${field} must be an integer between 1 and ${maximum}`);
+  }
+  return actual;
+}
+
+export async function resolvePublicAddresses(hostname: string): Promise<readonly string[]> {
+  return (await lookup(hostname, { all: true, verbatim: true })).map(({ address }) => address);
+}
+
+export function assertPublicAddresses(addresses: readonly string[]): void {
+  if (addresses.length === 0) throw new Error("Media hostname did not resolve");
+  for (const address of addresses) {
+    const family = isIP(address);
+    if (family === 0 || address.toLowerCase().startsWith("::ffff:") || blockedAddresses.check(address, family === 4 ? "ipv4" : "ipv6")) {
+      throw new Error("Media hostname resolved to a non-public address");
+    }
+  }
+}
+
+function allowedHostnames(hosts: readonly string[]): ReadonlySet<string> {
+  if (!Array.isArray(hosts) || hosts.length === 0 || hosts.length > 16) {
+    throw new Error("Media import requires 1-16 exact allowed hostnames");
+  }
+  const result = new Set<string>();
+  for (const raw of hosts) {
+    if (!raw || raw.includes("://") || /[/\\@:#?%\[\]*]/u.test(raw)) throw new Error("Invalid allowed media hostname");
+    const hostname = new URL(`https://${raw}`).hostname.toLowerCase();
+    if (hostname !== raw.toLowerCase() || isIP(hostname) !== 0 || !/^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/u.test(hostname)) {
+      throw new Error("Invalid allowed media hostname");
+    }
+    result.add(hostname);
+  }
+  return result;
+}
+
+function mediaUrl(value: string, allowed: ReadonlySet<string>): URL {
+  if (value.length > 2_048) throw new Error("Media URL is too long");
+  const url = new URL(value);
+  const hostname = url.hostname.toLowerCase();
+  if (
+    url.protocol !== "https:" || url.username || url.password || url.port || url.hash ||
+    isIP(hostname) !== 0 || !allowed.has(hostname)
+  ) throw new Error("Media URL is not an allowed exact HTTPS origin");
+  return url;
+}
+
+async function resolveWithTimeout(resolver: HostResolver, hostname: string, timeoutMs: number): Promise<readonly string[]> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      resolver(hostname),
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => reject(new Error("Media DNS resolution timed out")), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
+function expectedPlanShape(plan: MediaRewrite): { contentType: MediaContentType; extension: string } {
+  if (plan.requiredBeforePersistence !== true) throw new Error("Media rewrite must be completed before record persistence");
+  const rolePath = plan.role === "product" ? "products"
+    : plan.role === "category" ? "categories"
+      : plan.role === "page-inline" ? "pages"
+        : "blog";
+  const roleSegment = plan.role === "page-inline" || plan.role === "blog-inline" ? "/inline"
+    : plan.role === "blog-cover" ? "/cover"
+      : "";
+  if (!/^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$/.test(plan.ownerId)) throw new Error("Media owner ID is unsafe");
+  const match = /\/([1-9][0-9]{0,5})\.(jpe?g|png|webp)$/i.exec(plan.objectKey);
+  if (!match) throw new Error("Media object key has an unsupported or unsafe extension");
+  if (plan.objectKey !== plan.objectKey.toLowerCase()) throw new Error("Media object key must be canonical lowercase");
+  const extension = match[2].toLowerCase();
+  const expectedPrefix = `${rolePath}/${plan.ownerId}${roleSegment}/`;
+  if (!plan.objectKey.startsWith(expectedPrefix) || plan.objectKey !== `${expectedPrefix}${match[1]}.${match[2]}`) {
+    throw new Error("Media object key does not match its deterministic role and owner path");
+  }
+  if (plan.publicPath !== `/media/${plan.objectKey}`) throw new Error("Media public path does not match its object key");
+  const contentType: MediaContentType = extension === "jpg" || extension === "jpeg" ? "image/jpeg"
+    : extension === "png" ? "image/png"
+      : "image/webp";
+  if (plan.contentType !== contentType) throw new Error("Media plan extension and content type disagree");
+  return { contentType, extension };
+}
+
+export function validateMediaPlan(plan: MediaRewrite, allowedHosts: readonly string[]): URL {
+  const allowed = allowedHostnames(allowedHosts);
+  expectedPlanShape(plan);
+  const url = mediaUrl(plan.sourceUrl, allowed);
+  if (plan.sourceHost.toLowerCase() !== url.hostname.toLowerCase()) throw new Error("Media plan source host does not match its URL");
+  return url;
+}
+
+function isPng(bytes: Uint8Array): boolean {
+  const signature = [137, 80, 78, 71, 13, 10, 26, 10];
+  return bytes.length >= 33 && signature.every((byte, index) => bytes[index] === byte) &&
+    bytes[8] === 0 && bytes[9] === 0 && bytes[10] === 0 && bytes[11] === 13 &&
+    String.fromCharCode(...bytes.slice(12, 16)) === "IHDR" &&
+    bytes.slice(16, 20).some((byte) => byte !== 0) && bytes.slice(20, 24).some((byte) => byte !== 0) &&
+    bytes[26] === 0 && bytes[27] === 0 && bytes[28] <= 1;
+}
+
+function isJpeg(bytes: Uint8Array): boolean {
+  if (bytes.length < 12 || bytes[0] !== 0xff || bytes[1] !== 0xd8) return false;
+  let offset = 2;
+  let dimensions = false;
+  while (offset + 1 < bytes.length) {
+    if (bytes[offset] !== 0xff) return false;
+    while (bytes[offset] === 0xff) offset += 1;
+    const marker = bytes[offset++];
+    if (marker === 0xd9) return dimensions;
+    if (marker === 0xda) {
+      for (let index = offset; index + 1 < bytes.length; index += 1) {
+        if (bytes[index] === 0xff && bytes[index + 1] === 0xd9) return dimensions;
+      }
+      return false;
+    }
+    if (offset + 1 >= bytes.length) return false;
+    const length = (bytes[offset] << 8) | bytes[offset + 1];
+    if (length < 2 || offset + length > bytes.length) return false;
+    if ([0xc0, 0xc1, 0xc2, 0xc3, 0xc5, 0xc6, 0xc7, 0xc9, 0xca, 0xcb, 0xcd, 0xce, 0xcf].includes(marker)) {
+      if (length < 8 || bytes[offset + 3] === 0 && bytes[offset + 4] === 0 || bytes[offset + 5] === 0 && bytes[offset + 6] === 0) return false;
+      dimensions = true;
+    }
+    offset += length;
+  }
+  return false;
+}
+
+function ascii(bytes: Uint8Array, start: number, end: number): string {
+  return String.fromCharCode(...bytes.slice(start, end));
+}
+
+function isWebp(bytes: Uint8Array): boolean {
+  if (bytes.length < 20 || ascii(bytes, 0, 4) !== "RIFF" || ascii(bytes, 8, 12) !== "WEBP") return false;
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  if (view.getUint32(4, true) + 8 !== bytes.length) return false;
+  const chunk = ascii(bytes, 12, 16);
+  const chunkLength = view.getUint32(16, true);
+  return ["VP8 ", "VP8L", "VP8X"].includes(chunk) && 20 + chunkLength + (chunkLength % 2) <= bytes.length;
+}
+
+export function verifyImageSignature(bytes: Uint8Array, contentType: MediaContentType): void {
+  const valid = contentType === "image/jpeg" ? isJpeg(bytes)
+    : contentType === "image/png" ? isPng(bytes)
+      : isWebp(bytes);
+  if (!valid) throw new Error("Downloaded media signature does not match its declared image type");
+}
+
+async function boundedBody(response: Response, maxBytes: number, expired: Promise<never>): Promise<Uint8Array> {
+  if (!response.body) throw new Error("Media response has no body");
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let length = 0;
+  try {
+    while (true) {
+      const { done, value } = await Promise.race([reader.read(), expired]);
+      if (done) break;
+      length += value.byteLength;
+      if (length > maxBytes) {
+        await reader.cancel();
+        throw new Error(`Media response exceeds ${maxBytes} bytes`);
+      }
+      chunks.push(value);
+    }
+  } catch (error) {
+    await reader.cancel().catch(() => undefined);
+    throw error;
+  } finally {
+    reader.releaseLock();
+  }
+  const bytes = new Uint8Array(length);
+  let offset = 0;
+  for (const chunk of chunks) { bytes.set(chunk, offset); offset += chunk.byteLength; }
+  return bytes;
+}
+
+export async function downloadVerifiedMedia(plan: MediaRewrite, options: MediaDownloadOptions): Promise<VerifiedMedia> {
+  const maxBytes = positiveInteger(options.maxBytes, DEFAULT_MAX_MEDIA_BYTES, 100 * 1024 * 1024, "maxBytes");
+  const timeoutMs = positiveInteger(options.timeoutMs, DEFAULT_MEDIA_TIMEOUT_MS, 120_000, "timeoutMs");
+  const maxRedirects = positiveInteger((options.maxRedirects ?? DEFAULT_MAX_REDIRECTS) + 1, DEFAULT_MAX_REDIRECTS + 1, 11, "maxRedirects") - 1;
+  const allowed = allowedHostnames(options.allowedHosts);
+  const expected = expectedPlanShape(plan);
+  let url = mediaUrl(plan.sourceUrl, allowed);
+  if (plan.sourceHost.toLowerCase() !== url.hostname) throw new Error("Media plan source host does not match its URL");
+  const resolver = options.resolveHost ?? resolvePublicAddresses;
+  const fetcher = options.fetcher ?? fetch;
+
+  for (let redirects = 0; ; redirects += 1) {
+    assertPublicAddresses(await resolveWithTimeout(resolver, url.hostname, timeoutMs));
+    const controller = new AbortController();
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    const expired = new Promise<never>((_, reject) => {
+      timeout = setTimeout(() => {
+        controller.abort();
+        reject(new Error("Media download timed out"));
+      }, timeoutMs);
+    });
+    try {
+      const request = fetcher(url, {
+        method: "GET",
+        redirect: "manual",
+        signal: controller.signal,
+        headers: { Accept: "image/jpeg, image/png, image/webp" },
+      });
+      void request.then((lateResponse) => {
+        if (controller.signal.aborted) void lateResponse.body?.cancel().catch(() => undefined);
+      }).catch(() => undefined);
+      const response = await Promise.race([
+        request,
+        expired,
+      ]);
+      if ([301, 302, 303, 307, 308].includes(response.status)) {
+        await response.body?.cancel();
+        if (redirects >= maxRedirects) throw new Error("Media redirect limit exceeded");
+        const location = response.headers.get("location");
+        if (!location) throw new Error("Media redirect has no Location header");
+        url = mediaUrl(new URL(location, url).href, allowed);
+        continue;
+      }
+      if (!response.ok) { await response.body?.cancel(); throw new Error(`Media download failed with HTTP ${response.status}`); }
+      if (response.headers.get("content-encoding") && response.headers.get("content-encoding") !== "identity") {
+        await response.body?.cancel();
+        throw new Error("Encoded media responses are not accepted");
+      }
+      const contentType = response.headers.get("content-type")?.split(";", 1)[0].trim().toLowerCase();
+      if (contentType !== expected.contentType) { await response.body?.cancel(); throw new Error("Media Content-Type does not match its plan"); }
+      const declaredLength = response.headers.get("content-length");
+      if (declaredLength && (!/^(?:0|[1-9][0-9]*)$/.test(declaredLength) || Number(declaredLength) > maxBytes)) {
+        await response.body?.cancel();
+        throw new Error("Media Content-Length is invalid or exceeds the byte limit");
+      }
+      const bytes = await boundedBody(response, maxBytes, expired);
+      if (declaredLength && Number(declaredLength) !== bytes.byteLength) throw new Error("Media Content-Length does not match the response body");
+      verifyImageSignature(bytes, expected.contentType);
+      return { bytes, contentType: expected.contentType, objectKey: plan.objectKey, publicPath: plan.publicPath };
+    } finally {
+      if (timeout) clearTimeout(timeout);
+    }
+  }
+}

--- a/scripts/shopify-migration/adapters/media/security.ts
+++ b/scripts/shopify-migration/adapters/media/security.ts
@@ -144,13 +144,58 @@ export function validateMediaPlan(plan: MediaRewrite, allowedHosts: readonly str
   return url;
 }
 
+function crc32(bytes: Uint8Array): number {
+  let crc = 0xffffffff;
+  for (const byte of bytes) {
+    crc ^= byte;
+    for (let bit = 0; bit < 8; bit += 1) crc = (crc >>> 1) ^ (crc & 1 ? 0xedb88320 : 0);
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+const MAX_IMAGE_DIMENSION = 16_384;
+const MAX_IMAGE_PIXELS = 40_000_000;
+
+function hasBoundedDimensions(width: number, height: number): boolean {
+  return Number.isSafeInteger(width) && Number.isSafeInteger(height) &&
+    width > 0 && height > 0 && width <= MAX_IMAGE_DIMENSION && height <= MAX_IMAGE_DIMENSION &&
+    width * height <= MAX_IMAGE_PIXELS;
+}
+
 function isPng(bytes: Uint8Array): boolean {
   const signature = [137, 80, 78, 71, 13, 10, 26, 10];
-  return bytes.length >= 33 && signature.every((byte, index) => bytes[index] === byte) &&
-    bytes[8] === 0 && bytes[9] === 0 && bytes[10] === 0 && bytes[11] === 13 &&
-    String.fromCharCode(...bytes.slice(12, 16)) === "IHDR" &&
-    bytes.slice(16, 20).some((byte) => byte !== 0) && bytes.slice(20, 24).some((byte) => byte !== 0) &&
-    bytes[26] === 0 && bytes[27] === 0 && bytes[28] <= 1;
+  if (bytes.length < 57 || !signature.every((byte, index) => bytes[index] === byte)) return false;
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  let offset = 8;
+  let chunkIndex = 0;
+  let sawIdat = false;
+  while (offset + 12 <= bytes.length) {
+    const length = view.getUint32(offset);
+    const typeStart = offset + 4;
+    const dataStart = typeStart + 4;
+    const dataEnd = dataStart + length;
+    const chunkEnd = dataEnd + 4;
+    if (dataEnd < dataStart || chunkEnd > bytes.length) return false;
+    const type = ascii(bytes, typeStart, dataStart);
+    if (view.getUint32(dataEnd) !== crc32(bytes.subarray(typeStart, dataEnd))) return false;
+    if (chunkIndex === 0) {
+      if (type !== "IHDR" || length !== 13) return false;
+      const width = view.getUint32(dataStart);
+      const height = view.getUint32(dataStart + 4);
+      const bitDepth = bytes[dataStart + 8];
+      const colorType = bytes[dataStart + 9];
+      const permittedDepths: Record<number, readonly number[]> = {
+        0: [1, 2, 4, 8, 16], 2: [8, 16], 3: [1, 2, 4, 8], 4: [8, 16], 6: [8, 16],
+      };
+      if (!hasBoundedDimensions(width, height) || !permittedDepths[colorType]?.includes(bitDepth) ||
+        bytes[dataStart + 10] !== 0 || bytes[dataStart + 11] !== 0 || bytes[dataStart + 12] > 1) return false;
+    } else if (type === "IHDR") return false;
+    if (type === "IDAT") sawIdat = true;
+    if (type === "IEND") return length === 0 && sawIdat && chunkEnd === bytes.length;
+    offset = chunkEnd;
+    chunkIndex += 1;
+  }
+  return false;
 }
 
 function isJpeg(bytes: Uint8Array): boolean {
@@ -161,18 +206,26 @@ function isJpeg(bytes: Uint8Array): boolean {
     if (bytes[offset] !== 0xff) return false;
     while (bytes[offset] === 0xff) offset += 1;
     const marker = bytes[offset++];
-    if (marker === 0xd9) return dimensions;
+    if (marker === 0xd9) return dimensions && offset === bytes.length;
     if (marker === 0xda) {
-      for (let index = offset; index + 1 < bytes.length; index += 1) {
-        if (bytes[index] === 0xff && bytes[index + 1] === 0xd9) return dimensions;
+      if (offset + 1 >= bytes.length) return false;
+      const scanHeaderLength = (bytes[offset] << 8) | bytes[offset + 1];
+      if (scanHeaderLength < 2 || offset + scanHeaderLength > bytes.length) return false;
+      for (let index = offset + scanHeaderLength; index + 1 < bytes.length; index += 1) {
+        if (bytes[index] === 0xff && bytes[index + 1] === 0x00) { index += 1; continue; }
+        if (bytes[index] === 0xff && bytes[index + 1] === 0xd9) return dimensions && index + 2 === bytes.length;
       }
       return false;
     }
+    if (marker === 0x01 || marker >= 0xd0 && marker <= 0xd7) continue;
     if (offset + 1 >= bytes.length) return false;
     const length = (bytes[offset] << 8) | bytes[offset + 1];
     if (length < 2 || offset + length > bytes.length) return false;
     if ([0xc0, 0xc1, 0xc2, 0xc3, 0xc5, 0xc6, 0xc7, 0xc9, 0xca, 0xcb, 0xcd, 0xce, 0xcf].includes(marker)) {
-      if (length < 8 || bytes[offset + 3] === 0 && bytes[offset + 4] === 0 || bytes[offset + 5] === 0 && bytes[offset + 6] === 0) return false;
+      if (length < 8 || !hasBoundedDimensions(
+        (bytes[offset + 5] << 8) | bytes[offset + 6],
+        (bytes[offset + 3] << 8) | bytes[offset + 4],
+      )) return false;
       dimensions = true;
     }
     offset += length;
@@ -188,9 +241,39 @@ function isWebp(bytes: Uint8Array): boolean {
   if (bytes.length < 20 || ascii(bytes, 0, 4) !== "RIFF" || ascii(bytes, 8, 12) !== "WEBP") return false;
   const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
   if (view.getUint32(4, true) + 8 !== bytes.length) return false;
-  const chunk = ascii(bytes, 12, 16);
-  const chunkLength = view.getUint32(16, true);
-  return ["VP8 ", "VP8L", "VP8X"].includes(chunk) && 20 + chunkLength + (chunkLength % 2) <= bytes.length;
+  let offset = 12;
+  let chunkIndex = 0;
+  let sawImageHeader = false;
+  while (offset + 8 <= bytes.length) {
+    const chunk = ascii(bytes, offset, offset + 4);
+    const chunkLength = view.getUint32(offset + 4, true);
+    const dataStart = offset + 8;
+    const dataEnd = dataStart + chunkLength;
+    const chunkEnd = dataEnd + (chunkLength % 2);
+    if (dataEnd < dataStart || chunkEnd > bytes.length) return false;
+    if (chunkIndex === 0) {
+      if (chunk === "VP8 ") {
+        if (chunkLength < 10 || bytes[dataStart + 3] !== 0x9d || bytes[dataStart + 4] !== 0x01 ||
+          bytes[dataStart + 5] !== 0x2a || !hasBoundedDimensions(
+          view.getUint16(dataStart + 6, true) & 0x3fff,
+          view.getUint16(dataStart + 8, true) & 0x3fff,
+        )) return false;
+      } else if (chunk === "VP8L") {
+        if (chunkLength < 5 || bytes[dataStart] !== 0x2f) return false;
+        const dimensions = view.getUint32(dataStart + 1, true);
+        if (!hasBoundedDimensions((dimensions & 0x3fff) + 1, ((dimensions >>> 14) & 0x3fff) + 1)) return false;
+      } else if (chunk === "VP8X") {
+        if (chunkLength !== 10) return false;
+        const width = bytes[dataStart + 4] | bytes[dataStart + 5] << 8 | bytes[dataStart + 6] << 16;
+        const height = bytes[dataStart + 7] | bytes[dataStart + 8] << 8 | bytes[dataStart + 9] << 16;
+        if (!hasBoundedDimensions(width + 1, height + 1)) return false;
+      } else return false;
+      sawImageHeader = true;
+    }
+    offset = chunkEnd;
+    chunkIndex += 1;
+  }
+  return sawImageHeader && offset === bytes.length;
 }
 
 export function verifyImageSignature(bytes: Uint8Array, contentType: MediaContentType): void {

--- a/scripts/shopify-migration/cli.ts
+++ b/scripts/shopify-migration/cli.ts
@@ -2,7 +2,13 @@ import { lstatSync, readFileSync, realpathSync } from "node:fs";
 import { isAbsolute, join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 
-import { provisionClerkCustomers, type ClerkMigrationClient } from "./adapters/clerk/index.js";
+import {
+  ClerkRetryableRequestError,
+  provisionClerkCustomers,
+  type ClerkMigrationClient,
+  type ClerkMigrationUser,
+  type ClerkRequestContext,
+} from "./adapters/clerk/index.js";
 import { createNodeCommandRunner, runD1Import } from "./adapters/d1/index.js";
 import { createR2S3MediaStore, importMediaPlans } from "./adapters/media/index.js";
 import { extractFileRecords } from "./extractors/file-based/index.js";
@@ -190,7 +196,7 @@ function emptySensitive(): Pick<MigrationSourceBundle, "customers" | "orders" | 
   return { customers: [], orders: [], judgeMeRows: [] };
 }
 
-function fileSource(config: MigrationConfig, parsed: ParsedMigrationCli): MigrationSource {
+export function createFileMigrationSource(config: MigrationConfig, parsed: ParsedMigrationCli): MigrationSource {
   const root = config.inputRoot!;
   return {
     async extract(includeSensitive) {
@@ -223,7 +229,7 @@ function fileSource(config: MigrationConfig, parsed: ParsedMigrationCli): Migrat
   };
 }
 
-function apiSource(config: MigrationConfig, parsed: ParsedMigrationCli): MigrationSource {
+export function createShopifyApiMigrationSource(config: MigrationConfig, parsed: ParsedMigrationCli): MigrationSource {
   const shopify = config.shopify!;
   return {
     async extract(includeSensitive) {
@@ -293,6 +299,155 @@ function canonicalProjectConfig(projectRoot: string): { projectRoot: string; tex
   return { projectRoot: canonicalRoot, text: readFileSync(configPath, "utf8") };
 }
 
+const CLERK_USERS_URL = "https://api.clerk.com/v1/users";
+const MAX_CLERK_RESPONSE_BYTES = 1024 * 1024;
+
+function retryAfterMilliseconds(value: string | null): number | undefined {
+  if (!value) return undefined;
+  const seconds = Number(value);
+  if (Number.isFinite(seconds) && seconds >= 0) return Math.ceil(seconds * 1_000);
+  const date = Date.parse(value);
+  return Number.isFinite(date) ? Math.max(0, date - Date.now()) : undefined;
+}
+
+async function boundedClerkJson(response: Response): Promise<unknown> {
+  const declared = response.headers.get("content-length");
+  if (declared !== null && (!/^(?:0|[1-9][0-9]*)$/u.test(declared) || Number(declared) > MAX_CLERK_RESPONSE_BYTES)) {
+    void response.body?.cancel();
+    throw new Error("Clerk migration response exceeds its safety limit");
+  }
+  if (!response.body) throw new Error("Clerk migration response body is missing");
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let length = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    length += value.byteLength;
+    if (length > MAX_CLERK_RESPONSE_BYTES) {
+      await reader.cancel();
+      throw new Error("Clerk migration response exceeds its safety limit");
+    }
+    chunks.push(value);
+  }
+  const bytes = new Uint8Array(length);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  try {
+    return JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(bytes));
+  } catch {
+    throw new Error("Clerk migration response is invalid");
+  }
+}
+
+async function clerkRequest(
+  secretKey: string,
+  fetchImplementation: typeof fetch,
+  url: URL,
+  init: RequestInit & { signal: AbortSignal },
+): Promise<unknown> {
+  let response: Response;
+  try {
+    response = await fetchImplementation(url, {
+      ...init,
+      redirect: "error",
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${secretKey}`,
+        ...(init.body ? { "Content-Type": "application/json" } : {}),
+      },
+    });
+  } catch (error) {
+    if (error && typeof error === "object") {
+      const shaped = error as { clerkError?: unknown; status?: unknown; retryAfter?: unknown };
+      const status = typeof shaped.status === "number" ? shaped.status : undefined;
+      if (
+        shaped.clerkError === true && status !== undefined && (status === 429 || status >= 500) &&
+        (shaped.retryAfter === undefined || (typeof shaped.retryAfter === "number" && Number.isFinite(shaped.retryAfter)))
+      ) {
+        const retryAfter = typeof shaped.retryAfter === "number" && shaped.retryAfter >= 0
+          ? Math.ceil(shaped.retryAfter * 1_000)
+          : undefined;
+        throw new ClerkRetryableRequestError(retryAfter);
+      }
+      if (shaped.clerkError === true && status !== undefined) {
+        throw new Error("Clerk migration request was rejected");
+      }
+    }
+    throw new ClerkRetryableRequestError();
+  }
+  if (response.status === 429 || response.status >= 500) {
+    void response.body?.cancel();
+    throw new ClerkRetryableRequestError(retryAfterMilliseconds(response.headers.get("retry-after")));
+  }
+  if (!response.ok) {
+    void response.body?.cancel();
+    throw new Error("Clerk migration request was rejected");
+  }
+  return await boundedClerkJson(response);
+}
+
+function clerkUser(value: unknown): ClerkMigrationUser {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Clerk migration user response is invalid");
+  }
+  const record = value as { id?: unknown; external_id?: unknown };
+  if (
+    typeof record.id !== "string" ||
+    (record.external_id !== null && record.external_id !== undefined && typeof record.external_id !== "string")
+  ) {
+    throw new Error("Clerk migration user response is invalid");
+  }
+  return { id: record.id, externalId: typeof record.external_id === "string" ? record.external_id : null };
+}
+
+/** Minimal abortable Clerk Backend API client for migration-only user calls. */
+export function createClerkRestMigrationClient(
+  secretKey: string,
+  fetchImplementation: typeof fetch = fetch,
+): ClerkMigrationClient {
+  if (!secretKey || secretKey.length > 2_048 || /[\0\r\n]/u.test(secretKey)) {
+    throw new Error("CLERK_SECRET_KEY is invalid");
+  }
+  const contextSignal = (context: ClerkRequestContext | undefined): AbortSignal => {
+    if (!context?.signal) throw new Error("Clerk migration requests require a bounded abort signal");
+    return context.signal;
+  };
+  return {
+    users: {
+      async getUserList(params, context) {
+        const url = new URL(CLERK_USERS_URL);
+        params.externalId?.forEach((value) => url.searchParams.append("external_id", value));
+        params.emailAddress?.forEach((value) => url.searchParams.append("email_address", value));
+        url.searchParams.set("limit", String(params.limit));
+        const value = await clerkRequest(secretKey, fetchImplementation, url, {
+          method: "GET",
+          signal: contextSignal(context),
+        });
+        if (!Array.isArray(value)) throw new Error("Clerk migration user list is invalid");
+        return { data: value.map(clerkUser) };
+      },
+      async createUser(params, context) {
+        const value = await clerkRequest(secretKey, fetchImplementation, new URL(CLERK_USERS_URL), {
+          method: "POST",
+          signal: contextSignal(context),
+          body: JSON.stringify({
+            email_address: [...params.emailAddress],
+            ...(params.firstName ? { first_name: params.firstName } : {}),
+            ...(params.lastName ? { last_name: params.lastName } : {}),
+            external_id: params.externalId,
+            skip_legal_checks: params.skipLegalChecks,
+          }),
+        });
+        return clerkUser(value);
+      },
+    },
+  };
+}
+
 function defaultFactories(env: Environment): MigrationApplyFactories {
   return {
     createMediaStore(bucketName) {
@@ -304,25 +459,7 @@ function defaultFactories(env: Environment): MigrationApplyFactories {
       });
     },
     async createClerkClient(): Promise<ClerkMigrationClient> {
-      required(env.CLERK_SECRET_KEY, "CLERK_SECRET_KEY");
-      const { clerkClient } = await import("@clerk/nextjs/server");
-      const client = await clerkClient();
-      return {
-        users: {
-          async getUserList(params) {
-            const response = await client.users.getUserList({
-              ...(params.externalId ? { externalId: [...params.externalId] } : {}),
-              ...(params.emailAddress ? { emailAddress: [...params.emailAddress] } : {}),
-              limit: params.limit,
-            });
-            return { data: response.data.map((user) => ({ id: user.id, externalId: user.externalId })) };
-          },
-          async createUser(params) {
-            const user = await client.users.createUser({ ...params, emailAddress: [...params.emailAddress] });
-            return { id: user.id, externalId: user.externalId };
-          },
-        },
-      };
+      return createClerkRestMigrationClient(required(env.CLERK_SECRET_KEY, "CLERK_SECRET_KEY"));
     },
     createCommandRunner: () => createNodeCommandRunner(),
   };
@@ -341,7 +478,9 @@ export async function runMigrationCli(dependencies: MigrationCliDependencies = {
     ? keyedRows(readJsonFile<VerifiedPurchaseRow>(inputRoot!, parsed.verifiedPurchasesFile), "Verified purchases")
     : undefined;
   const source = dependencies.createSource?.(parsed.config, parsed)
-    ?? (parsed.config.sourceMode === "file" ? fileSource(parsed.config, parsed) : apiSource(parsed.config, parsed));
+    ?? (parsed.config.sourceMode === "file"
+      ? createFileMigrationSource(parsed.config, parsed)
+      : createShopifyApiMigrationSource(parsed.config, parsed));
   const report = await orchestrateMigration({
     config: parsed.config,
     domain: {

--- a/scripts/shopify-migration/cli.ts
+++ b/scripts/shopify-migration/cli.ts
@@ -1,0 +1,386 @@
+import { lstatSync, readFileSync, realpathSync } from "node:fs";
+import { isAbsolute, join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { clerkClient } from "@clerk/nextjs/server";
+
+import { provisionClerkCustomers, type ClerkMigrationClient } from "./adapters/clerk/index.js";
+import { createNodeCommandRunner, runD1Import } from "./adapters/d1/index.js";
+import { createR2S3MediaStore, importMediaPlans } from "./adapters/media/index.js";
+import { extractFileRecords } from "./extractors/file-based/index.js";
+import { extractFromShopifyApi } from "./extractors/shopify-api/index.js";
+import { parseMigrationConfig, type Environment, type MigrationConfig } from "./lib/config.js";
+import { readCsvFile, readJsonFile } from "./lib/file-reader.js";
+import { writeManifest } from "./lib/id-map.js";
+import { ShopifyClient } from "./lib/shopify-api.js";
+import type {
+  JudgeMeFileRow,
+  ShopifyArticle,
+  ShopifyBlog,
+  ShopifyCollect,
+  ShopifyCollection,
+  ShopifyCustomer,
+  ShopifyOrder,
+  ShopifyPage,
+  ShopifyProduct,
+  ShopifyRedirect,
+} from "./lib/types.js";
+import {
+  orchestrateMigration,
+  type MigrationApplyFactories,
+  type MigrationDomainOptions,
+  type MigrationRunReport,
+  type MigrationSource,
+  type MigrationSourceBundle,
+} from "./orchestrator.js";
+import type { ImportedReviewAttribution, VerifiedReviewProvenance } from "./transformers/sensitive/index.js";
+
+const EXTRA_VALUE_FLAGS = new Set([
+  "--currency",
+  "--inventory-location-id",
+  "--fulfillment-type",
+  "--actor-id",
+  "--fallback-author",
+  "--media-host",
+  "--unresolved-customer",
+  "--project-root",
+  "--expected-database-name",
+  "--judge-me-file",
+  "--review-attributions",
+  "--verified-purchases",
+]);
+
+interface ReviewAttributionRow extends ImportedReviewAttribution {
+  reviewFingerprint: string;
+}
+
+interface VerifiedPurchaseRow extends VerifiedReviewProvenance {
+  reviewFingerprint: string;
+}
+
+export interface ParsedMigrationCli {
+  config: MigrationConfig;
+  domain: Omit<MigrationDomainOptions, "reviewAttributions" | "verifiedPurchases">;
+  projectRoot: string;
+  expectedDatabaseName?: string;
+  judgeMeFile?: string;
+  reviewAttributionsFile?: string;
+  verifiedPurchasesFile?: string;
+}
+
+export interface MigrationCliDependencies {
+  args?: readonly string[];
+  env?: Environment;
+  cwd?: string;
+  stdout?: (line: string) => void;
+  now?: () => Date;
+  createSource?: (config: MigrationConfig, parsed: ParsedMigrationCli) => MigrationSource;
+  applyFactories?: MigrationApplyFactories;
+}
+
+function required(value: string | undefined, name: string): string {
+  const normalized = value?.trim();
+  if (!normalized) throw new Error(`${name} is required`);
+  return normalized;
+}
+
+function ownValues(args: readonly string[], name: string): string[] {
+  return args.filter((argument) => argument.startsWith(`${name}=`)).map((argument) => argument.slice(name.length + 1));
+}
+
+function ownValue(args: readonly string[], name: string, fallback?: string): string | undefined {
+  const values = ownValues(args, name);
+  if (values.length > 1) throw new Error(`${name} may only be provided once`);
+  return values[0] ?? fallback;
+}
+
+function checkedRelativeFile(value: string | undefined, name: string): string | undefined {
+  if (value === undefined) return undefined;
+  const path = required(value, name);
+  if (isAbsolute(path) || path.includes("\0") || path.startsWith("-") || /(?:^|[/\\])\.\.(?:[/\\]|$)/u.test(path)) {
+    throw new Error(`${name} must be a relative file within the migration input root`);
+  }
+  return path;
+}
+
+function safeName(value: string | undefined, name: string, maximum = 255): string {
+  const result = required(value, name);
+  if (result.length > maximum || /[\0\r\n]/u.test(result)) throw new Error(`${name} is invalid`);
+  return result;
+}
+
+function configArgs(args: readonly string[]): string[] {
+  return args.filter((argument) => {
+    const equals = argument.indexOf("=");
+    return equals < 0 || !EXTRA_VALUE_FLAGS.has(argument.slice(0, equals));
+  });
+}
+
+export function parseMigrationCli(
+  env: Environment = process.env,
+  args: readonly string[] = process.argv.slice(2),
+  cwd = process.cwd(),
+): ParsedMigrationCli {
+  for (const argument of args) {
+    const equals = argument.indexOf("=");
+    if (equals > 0 && EXTRA_VALUE_FLAGS.has(argument.slice(0, equals))) continue;
+    if ([...EXTRA_VALUE_FLAGS].some((flag) => argument === flag)) throw new Error(`${argument} requires a value`);
+  }
+  const config = parseMigrationConfig(env, configArgs(args), cwd);
+  const fulfillmentType = ownValue(args, "--fulfillment-type", env.MIGRATION_FULFILLMENT_TYPE);
+  if (fulfillmentType !== "physical" && fulfillmentType !== "digital" && fulfillmentType !== "service") {
+    throw new Error("MIGRATION_FULFILLMENT_TYPE must be physical, digital, or service");
+  }
+  const unresolvedCustomer = ownValue(args, "--unresolved-customer", env.MIGRATION_UNRESOLVED_CUSTOMER);
+  if (unresolvedCustomer !== "reject" && unresolvedCustomer !== "guest") {
+    throw new Error("MIGRATION_UNRESOLVED_CUSTOMER must explicitly be reject or guest");
+  }
+  const argumentHosts = ownValues(args, "--media-host");
+  const environmentHosts = env.MIGRATION_MEDIA_HOSTS?.split(",") ?? [];
+  const allowedMediaHosts = (argumentHosts.length ? argumentHosts : environmentHosts).map((host) => host.trim()).filter(Boolean);
+  if (!allowedMediaHosts.length) throw new Error("At least one explicit --media-host or MIGRATION_MEDIA_HOSTS value is required");
+  if (new Set(allowedMediaHosts.map((host) => host.toLowerCase())).size !== allowedMediaHosts.length) {
+    throw new Error("Migration media hosts must be unique");
+  }
+
+  const projectRoot = resolve(cwd, ownValue(args, "--project-root", env.MIGRATION_PROJECT_ROOT) ?? ".");
+  const judgeMeFile = checkedRelativeFile(ownValue(args, "--judge-me-file", env.JUDGE_ME_FILE), "JUDGE_ME_FILE");
+  const reviewAttributionsFile = checkedRelativeFile(
+    ownValue(args, "--review-attributions", env.MIGRATION_REVIEW_ATTRIBUTIONS),
+    "MIGRATION_REVIEW_ATTRIBUTIONS",
+  );
+  const verifiedPurchasesFile = checkedRelativeFile(
+    ownValue(args, "--verified-purchases", env.MIGRATION_VERIFIED_PURCHASES),
+    "MIGRATION_VERIFIED_PURCHASES",
+  );
+  if ((judgeMeFile || reviewAttributionsFile || verifiedPurchasesFile) && !config.execution.includeSensitive) {
+    throw new Error("Judge.me inputs require --include-sensitive and --confirm-sensitive-data");
+  }
+  if ((reviewAttributionsFile || verifiedPurchasesFile) && !judgeMeFile) {
+    throw new Error("Review attribution inputs require a Judge.me file");
+  }
+  if (judgeMeFile && !config.inputRoot) {
+    throw new Error("Judge.me file input requires MIGRATION_INPUT_ROOT even when Shopify API extraction is used");
+  }
+
+  return {
+    config,
+    domain: {
+      currency: safeName(ownValue(args, "--currency", env.MIGRATION_CURRENCY), "MIGRATION_CURRENCY", 3).toUpperCase(),
+      inventoryLocationId: safeName(
+        ownValue(args, "--inventory-location-id", env.MIGRATION_INVENTORY_LOCATION_ID),
+        "MIGRATION_INVENTORY_LOCATION_ID",
+        200,
+      ),
+      fulfillmentType,
+      actorId: safeName(ownValue(args, "--actor-id", env.MIGRATION_ACTOR_ID), "MIGRATION_ACTOR_ID"),
+      fallbackAuthor: safeName(ownValue(args, "--fallback-author", env.MIGRATION_FALLBACK_AUTHOR), "MIGRATION_FALLBACK_AUTHOR", 160),
+      allowedMediaHosts,
+      unresolvedCustomer,
+    },
+    projectRoot,
+    ...(ownValue(args, "--expected-database-name", env.MIGRATION_DATABASE_NAME)
+      ? { expectedDatabaseName: safeName(ownValue(args, "--expected-database-name", env.MIGRATION_DATABASE_NAME), "MIGRATION_DATABASE_NAME", 128) }
+      : {}),
+    ...(judgeMeFile ? { judgeMeFile } : {}),
+    ...(reviewAttributionsFile ? { reviewAttributionsFile } : {}),
+    ...(verifiedPurchasesFile ? { verifiedPurchasesFile } : {}),
+  };
+}
+
+function emptySensitive(): Pick<MigrationSourceBundle, "customers" | "orders" | "judgeMeRows"> {
+  return { customers: [], orders: [], judgeMeRows: [] };
+}
+
+function fileSource(config: MigrationConfig, parsed: ParsedMigrationCli): MigrationSource {
+  const root = config.inputRoot!;
+  return {
+    async extract(includeSensitive) {
+      const custom = extractFileRecords<ShopifyCollection>(root, "custom_collections").records.map((record) => ({
+        ...record,
+        collection_type: "custom" as const,
+      }));
+      const smart = extractFileRecords<ShopifyCollection>(root, "smart_collections").records.map((record) => ({
+        ...record,
+        collection_type: "smart" as const,
+      }));
+      const sensitive = includeSensitive ? {
+        customers: extractFileRecords<ShopifyCustomer>(root, "customers").records,
+        orders: extractFileRecords<ShopifyOrder>(root, "orders").records,
+        judgeMeRows: parsed.judgeMeFile
+          ? readCsvFile<Record<string, string>>(root, parsed.judgeMeFile) as JudgeMeFileRow[]
+          : [],
+      } : emptySensitive();
+      return {
+        collections: [...custom, ...smart],
+        collects: extractFileRecords<ShopifyCollect>(root, "collects").records,
+        products: extractFileRecords<ShopifyProduct>(root, "products").records,
+        pages: extractFileRecords<ShopifyPage>(root, "pages").records,
+        blogs: extractFileRecords<ShopifyBlog>(root, "blogs").records,
+        articles: extractFileRecords<ShopifyArticle>(root, "articles").records,
+        redirects: extractFileRecords<ShopifyRedirect>(root, "redirects").records,
+        ...sensitive,
+      };
+    },
+  };
+}
+
+function apiSource(config: MigrationConfig, parsed: ParsedMigrationCli): MigrationSource {
+  const shopify = config.shopify!;
+  return {
+    async extract(includeSensitive) {
+      const client = new ShopifyClient({ ...shopify, includeSensitive });
+      const [custom, smart, collects, products, pages, blogs, redirects, customers, orders] = await Promise.all([
+        extractFromShopifyApi<ShopifyCollection>(client, "custom_collections.json", "custom_collections"),
+        extractFromShopifyApi<ShopifyCollection>(client, "smart_collections.json", "smart_collections"),
+        extractFromShopifyApi<ShopifyCollect>(client, "collects.json", "collects"),
+        extractFromShopifyApi<ShopifyProduct>(client, "products.json", "products"),
+        extractFromShopifyApi<ShopifyPage>(client, "pages.json", "pages"),
+        extractFromShopifyApi<ShopifyBlog>(client, "blogs.json", "blogs"),
+        extractFromShopifyApi<ShopifyRedirect>(client, "redirects.json", "redirects"),
+        includeSensitive
+          ? extractFromShopifyApi<ShopifyCustomer>(client, "customers.json", "customers")
+          : Promise.resolve({ records: [] as ShopifyCustomer[] }),
+        includeSensitive
+          ? extractFromShopifyApi<ShopifyOrder>(client, "orders.json", "orders", { query: { status: "any" } })
+          : Promise.resolve({ records: [] as ShopifyOrder[] }),
+      ]);
+      const articles = (await Promise.all(blogs.records.map((blog) => {
+        const id = String(blog.id);
+        if (!/^[1-9][0-9]*$/u.test(id)) throw new Error("Shopify blog ID is invalid for article extraction");
+        return extractFromShopifyApi<ShopifyArticle>(client, `blogs/${id}/articles.json`, "articles");
+      }))).flatMap((result) => result.records);
+      return {
+        collections: [
+          ...custom.records.map((record) => ({ ...record, collection_type: "custom" as const })),
+          ...smart.records.map((record) => ({ ...record, collection_type: "smart" as const })),
+        ],
+        collects: collects.records,
+        products: products.records,
+        pages: pages.records,
+        blogs: blogs.records,
+        articles,
+        redirects: redirects.records,
+        customers: customers.records,
+        orders: orders.records,
+        judgeMeRows: includeSensitive && parsed.judgeMeFile
+          ? readCsvFile<Record<string, string>>(config.inputRoot!, parsed.judgeMeFile) as JudgeMeFileRow[]
+          : [],
+      };
+    },
+  };
+}
+
+function keyedRows<T extends { reviewFingerprint: string }>(rows: readonly T[], name: string): Map<string, Omit<T, "reviewFingerprint">> {
+  const result = new Map<string, Omit<T, "reviewFingerprint">>();
+  for (const row of rows) {
+    if (!/^[a-f0-9]{64}$/u.test(row.reviewFingerprint) || result.has(row.reviewFingerprint)) {
+      throw new Error(`${name} contains an invalid or duplicate review fingerprint`);
+    }
+    const { reviewFingerprint, ...value } = row;
+    result.set(reviewFingerprint, value);
+  }
+  return result;
+}
+
+function canonicalProjectConfig(projectRoot: string): { projectRoot: string; text: string } {
+  const canonicalRoot = realpathSync(projectRoot);
+  if (canonicalRoot !== projectRoot || !lstatSync(canonicalRoot).isDirectory()) {
+    throw new Error("Migration project root must be an explicit canonical directory");
+  }
+  const configPath = join(canonicalRoot, "wrangler.jsonc");
+  if (realpathSync(configPath) !== configPath || !lstatSync(configPath).isFile() || lstatSync(configPath).size > 1024 * 1024) {
+    throw new Error("Migration Wrangler configuration must be a bounded canonical file");
+  }
+  return { projectRoot: canonicalRoot, text: readFileSync(configPath, "utf8") };
+}
+
+function defaultFactories(env: Environment): MigrationApplyFactories {
+  return {
+    createMediaStore(bucketName) {
+      return createR2S3MediaStore({
+        bucketName,
+        accountId: required(env.CLOUDFLARE_ACCOUNT_ID, "CLOUDFLARE_ACCOUNT_ID"),
+        accessKeyId: required(env.R2_ACCESS_KEY_ID, "R2_ACCESS_KEY_ID"),
+        secretAccessKey: required(env.R2_SECRET_ACCESS_KEY, "R2_SECRET_ACCESS_KEY"),
+      });
+    },
+    async createClerkClient(): Promise<ClerkMigrationClient> {
+      required(env.CLERK_SECRET_KEY, "CLERK_SECRET_KEY");
+      const client = await clerkClient();
+      return {
+        users: {
+          async getUserList(params) {
+            const response = await client.users.getUserList({
+              ...(params.externalId ? { externalId: [...params.externalId] } : {}),
+              ...(params.emailAddress ? { emailAddress: [...params.emailAddress] } : {}),
+              limit: params.limit,
+            });
+            return { data: response.data.map((user) => ({ id: user.id, externalId: user.externalId })) };
+          },
+          async createUser(params) {
+            const user = await client.users.createUser({ ...params, emailAddress: [...params.emailAddress] });
+            return { id: user.id, externalId: user.externalId };
+          },
+        },
+      };
+    },
+    createCommandRunner: () => createNodeCommandRunner(),
+  };
+}
+
+export async function runMigrationCli(dependencies: MigrationCliDependencies = {}): Promise<MigrationRunReport> {
+  const env = dependencies.env ?? process.env;
+  const cwd = dependencies.cwd ?? process.cwd();
+  const parsed = parseMigrationCli(env, dependencies.args ?? process.argv.slice(2), cwd);
+  const project = canonicalProjectConfig(parsed.projectRoot);
+  const inputRoot = parsed.config.inputRoot;
+  const reviewAttributions = parsed.reviewAttributionsFile
+    ? keyedRows(readJsonFile<ReviewAttributionRow>(inputRoot!, parsed.reviewAttributionsFile), "Review attributions")
+    : new Map<string, ImportedReviewAttribution>();
+  const verifiedPurchases = parsed.verifiedPurchasesFile
+    ? keyedRows(readJsonFile<VerifiedPurchaseRow>(inputRoot!, parsed.verifiedPurchasesFile), "Verified purchases")
+    : undefined;
+  const source = dependencies.createSource?.(parsed.config, parsed)
+    ?? (parsed.config.sourceMode === "file" ? fileSource(parsed.config, parsed) : apiSource(parsed.config, parsed));
+  const report = await orchestrateMigration({
+    config: parsed.config,
+    domain: {
+      ...parsed.domain,
+      reviewAttributions,
+      ...(verifiedPurchases ? { verifiedPurchases } : {}),
+    },
+    source,
+    projectRoot: project.projectRoot,
+    wranglerConfigText: project.text,
+    ...(parsed.expectedDatabaseName ? { expectedDatabaseName: parsed.expectedDatabaseName } : {}),
+    ...(parsed.config.execution.apply ? { applyFactories: dependencies.applyFactories ?? defaultFactories(env) } : {}),
+    runners: {
+      importMedia: importMediaPlans,
+      provisionClerk: provisionClerkCustomers,
+      runD1: runD1Import,
+    },
+    ...(dependencies.now ? { now: dependencies.now } : {}),
+  });
+  if (parsed.config.execution.apply && parsed.config.outputRoot) {
+    writeManifest(parsed.config.outputRoot, "manifest.json", {
+      version: 1,
+      authoritative: false,
+      generatedAt: report.generatedAt,
+      dryRun: report.dryRun,
+      target: report.target,
+      entities: report.entities,
+    });
+  }
+  (dependencies.stdout ?? console.log)(JSON.stringify(report));
+  return report;
+}
+
+const invokedPath = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : "";
+if (import.meta.url === invokedPath) {
+  runMigrationCli().catch((error: unknown) => {
+    const name = error instanceof Error && /^[A-Za-z][A-Za-z0-9]*$/u.test(error.name) ? error.name : "Error";
+    console.error(JSON.stringify({ success: false, errorClass: name }));
+    process.exitCode = 1;
+  });
+}

--- a/scripts/shopify-migration/cli.ts
+++ b/scripts/shopify-migration/cli.ts
@@ -1,15 +1,14 @@
 import { lstatSync, readFileSync, realpathSync } from "node:fs";
-import { isAbsolute, join, resolve } from "node:path";
+import { isAbsolute, join, relative, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 
 import {
   ClerkRetryableRequestError,
   provisionClerkCustomers,
-  type ClerkMigrationClient,
   type ClerkMigrationUser,
   type ClerkRequestContext,
 } from "./adapters/clerk/index.js";
-import { createNodeCommandRunner, runD1Import } from "./adapters/d1/index.js";
+import { createNodeCommandRunner, preflightD1Target, runD1Import } from "./adapters/d1/index.js";
 import { createR2S3MediaStore, importMediaPlans } from "./adapters/media/index.js";
 import { extractFileRecords } from "./extractors/file-based/index.js";
 import { extractFromShopifyApi } from "./extractors/shopify-api/index.js";
@@ -36,6 +35,7 @@ import {
   type MigrationRunReport,
   type MigrationSource,
   type MigrationSourceBundle,
+  type TargetBoundClerkMigrationClient,
 } from "./orchestrator.js";
 import type { ImportedReviewAttribution, VerifiedReviewProvenance } from "./transformers/sensitive/index.js";
 
@@ -52,7 +52,12 @@ const EXTRA_VALUE_FLAGS = new Set([
   "--judge-me-file",
   "--review-attributions",
   "--verified-purchases",
+  "--expected-shopify-order-count",
 ]);
+const EXTRA_BOOLEAN_FLAGS = new Set(["--confirm-shopify-read-all-orders"]);
+const MAX_MIGRATION_BLOGS = 1_000;
+const MAX_MIGRATION_ARTICLES = 50_000;
+const MAX_ARTICLES_PER_BLOG = 10_000;
 
 interface ReviewAttributionRow extends ImportedReviewAttribution {
   reviewFingerprint: string;
@@ -70,6 +75,8 @@ export interface ParsedMigrationCli {
   judgeMeFile?: string;
   reviewAttributionsFile?: string;
   verifiedPurchasesFile?: string;
+  expectedShopifyOrderCount?: number;
+  remoteTargetBinding?: { cloudflareAccountId?: string; clerkInstanceId?: string };
 }
 
 export interface MigrationCliDependencies {
@@ -115,6 +122,7 @@ function safeName(value: string | undefined, name: string, maximum = 255): strin
 
 function configArgs(args: readonly string[]): string[] {
   return args.filter((argument) => {
+    if (EXTRA_BOOLEAN_FLAGS.has(argument)) return false;
     const equals = argument.indexOf("=");
     return equals < 0 || !EXTRA_VALUE_FLAGS.has(argument.slice(0, equals));
   });
@@ -129,6 +137,7 @@ export function parseMigrationCli(
     const equals = argument.indexOf("=");
     if (equals > 0 && EXTRA_VALUE_FLAGS.has(argument.slice(0, equals))) continue;
     if ([...EXTRA_VALUE_FLAGS].some((flag) => argument === flag)) throw new Error(`${argument} requires a value`);
+    if (EXTRA_BOOLEAN_FLAGS.has(argument)) continue;
   }
   const config = parseMigrationConfig(env, configArgs(args), cwd);
   const fulfillmentType = ownValue(args, "--fulfillment-type", env.MIGRATION_FULFILLMENT_TYPE);
@@ -166,6 +175,50 @@ export function parseMigrationCli(
   if (judgeMeFile && !config.inputRoot) {
     throw new Error("Judge.me file input requires MIGRATION_INPUT_ROOT even when Shopify API extraction is used");
   }
+  const confirmReadAllCount = args.filter((argument) => argument === "--confirm-shopify-read-all-orders").length;
+  if (confirmReadAllCount > 1) throw new Error("--confirm-shopify-read-all-orders may only be provided once");
+  const confirmedReadAllOrders = confirmReadAllCount === 1 || env.MIGRATION_CONFIRM_SHOPIFY_READ_ALL_ORDERS === "1";
+  const expectedOrderCountValue = ownValue(
+    args,
+    "--expected-shopify-order-count",
+    env.MIGRATION_EXPECTED_SHOPIFY_ORDER_COUNT,
+  );
+  let expectedShopifyOrderCount: number | undefined;
+  if (expectedOrderCountValue !== undefined) {
+    if (!/^(?:0|[1-9][0-9]{0,7})$/u.test(expectedOrderCountValue)) {
+      throw new Error("Expected Shopify order count must be an integer from 0 to 99,999,999");
+    }
+    expectedShopifyOrderCount = Number(expectedOrderCountValue);
+  }
+  if (config.sourceMode === "api" && config.execution.includeSensitive) {
+    if (!confirmedReadAllOrders) {
+      throw new Error("Historical order API extraction requires --confirm-shopify-read-all-orders");
+    }
+    if (expectedShopifyOrderCount === undefined) {
+      throw new Error("Historical order API extraction requires an expected Shopify order count");
+    }
+  } else if (confirmedReadAllOrders || expectedShopifyOrderCount !== undefined) {
+    throw new Error("Shopify read_all_orders confirmation and count are only valid for sensitive API extraction");
+  }
+
+  const remoteTargetBinding = config.execution.apply && config.execution.target !== "local"
+    ? {
+      cloudflareAccountId: safeName(
+        env.MIGRATION_CLOUDFLARE_ACCOUNT_ID,
+        "MIGRATION_CLOUDFLARE_ACCOUNT_ID",
+        32,
+      ).toLowerCase(),
+      ...(env.MIGRATION_CLERK_INSTANCE_ID
+        ? { clerkInstanceId: safeName(env.MIGRATION_CLERK_INSTANCE_ID, "MIGRATION_CLERK_INSTANCE_ID", 204) }
+        : {}),
+    }
+    : undefined;
+  if (remoteTargetBinding && !/^[a-f0-9]{32}$/u.test(remoteTargetBinding.cloudflareAccountId)) {
+    throw new Error("MIGRATION_CLOUDFLARE_ACCOUNT_ID must be a 32-character account ID");
+  }
+  if (remoteTargetBinding?.clerkInstanceId && !/^ins_[A-Za-z0-9_-]{4,200}$/u.test(remoteTargetBinding.clerkInstanceId)) {
+    throw new Error("MIGRATION_CLERK_INSTANCE_ID is invalid");
+  }
 
   return {
     config,
@@ -189,6 +242,8 @@ export function parseMigrationCli(
     ...(judgeMeFile ? { judgeMeFile } : {}),
     ...(reviewAttributionsFile ? { reviewAttributionsFile } : {}),
     ...(verifiedPurchasesFile ? { verifiedPurchasesFile } : {}),
+    ...(expectedShopifyOrderCount !== undefined ? { expectedShopifyOrderCount } : {}),
+    ...(remoteTargetBinding ? { remoteTargetBinding } : {}),
   };
 }
 
@@ -249,11 +304,26 @@ export function createShopifyApiMigrationSource(config: MigrationConfig, parsed:
           ? extractFromShopifyApi<ShopifyOrder>(client, "orders.json", "orders", { query: { status: "any" } })
           : Promise.resolve({ records: [] as ShopifyOrder[] }),
       ]);
-      const articles = (await Promise.all(blogs.records.map((blog) => {
+      if (blogs.records.length > MAX_MIGRATION_BLOGS) {
+        throw new Error("Shopify blog count exceeds the migration safety limit");
+      }
+      const articles: ShopifyArticle[] = [];
+      for (const blog of blogs.records) {
         const id = String(blog.id);
         if (!/^[1-9][0-9]*$/u.test(id)) throw new Error("Shopify blog ID is invalid for article extraction");
-        return extractFromShopifyApi<ShopifyArticle>(client, `blogs/${id}/articles.json`, "articles");
-      }))).flatMap((result) => result.records);
+        const remaining = MAX_MIGRATION_ARTICLES - articles.length;
+        if (remaining < 1) throw new Error("Shopify article count exceeds the migration safety limit");
+        const result = await extractFromShopifyApi<ShopifyArticle>(
+          client,
+          `blogs/${id}/articles.json`,
+          "articles",
+          { maxRecords: Math.min(MAX_ARTICLES_PER_BLOG, remaining) },
+        );
+        articles.push(...result.records);
+      }
+      if (includeSensitive && orders.records.length !== parsed.expectedShopifyOrderCount) {
+        throw new Error("Shopify historical order count does not match the confirmed source count");
+      }
       return {
         collections: [
           ...custom.records.map((record) => ({ ...record, collection_type: "custom" as const })),
@@ -299,8 +369,35 @@ function canonicalProjectConfig(projectRoot: string): { projectRoot: string; tex
   return { projectRoot: canonicalRoot, text: readFileSync(configPath, "utf8") };
 }
 
+function isWithin(root: string, candidate: string): boolean {
+  const path = relative(root, candidate);
+  return path === "" || (!path.startsWith("..") && !isAbsolute(path));
+}
+
+/** Reject migration artifacts that could be committed with the application source. */
+export function assertPrivateMigrationRoots(config: MigrationConfig, projectRoot: string): void {
+  const canonicalRoots = [
+    ...(config.inputRoot ? [["input", config.inputRoot] as const] : []),
+    ...(config.outputRoot ? [["output", config.outputRoot] as const] : []),
+  ].map(([name, path]) => {
+    const canonical = realpathSync(path);
+    if (canonical !== path || !lstatSync(canonical).isDirectory()) {
+      throw new Error(`Migration ${name} root must be an existing canonical directory`);
+    }
+    if (isWithin(projectRoot, canonical)) {
+      throw new Error(`Migration ${name} root must be outside the project repository`);
+    }
+    return [name, canonical] as const;
+  });
+  if (canonicalRoots.length === 2 && canonicalRoots[0][1] === canonicalRoots[1][1]) {
+    throw new Error("Migration input and output roots must be separate directories");
+  }
+}
+
 const CLERK_USERS_URL = "https://api.clerk.com/v1/users";
+const CLERK_INSTANCE_URL = "https://api.clerk.com/v1/instance";
 const MAX_CLERK_RESPONSE_BYTES = 1024 * 1024;
+const CLERK_INSTANCE_TIMEOUT_MS = 30_000;
 
 function retryAfterMilliseconds(value: string | null): number | undefined {
   if (!value) return undefined;
@@ -408,7 +505,7 @@ function clerkUser(value: unknown): ClerkMigrationUser {
 export function createClerkRestMigrationClient(
   secretKey: string,
   fetchImplementation: typeof fetch = fetch,
-): ClerkMigrationClient {
+): TargetBoundClerkMigrationClient {
   if (!secretKey || secretKey.length > 2_048 || /[\0\r\n]/u.test(secretKey)) {
     throw new Error("CLERK_SECRET_KEY is invalid");
   }
@@ -417,6 +514,27 @@ export function createClerkRestMigrationClient(
     return context.signal;
   };
   return {
+    async verifyTarget(instanceId, environmentType) {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), CLERK_INSTANCE_TIMEOUT_MS);
+      let value: unknown;
+      try {
+        value = await clerkRequest(secretKey, fetchImplementation, new URL(CLERK_INSTANCE_URL), {
+          method: "GET",
+          signal: controller.signal,
+        });
+      } finally {
+        clearTimeout(timeout);
+      }
+      if (!value || typeof value !== "object" || Array.isArray(value)) {
+        throw new Error("Clerk instance response is invalid");
+      }
+      const instance = value as { id?: unknown; environment_type?: unknown; environmentType?: unknown };
+      const actualEnvironment = instance.environment_type ?? instance.environmentType;
+      if (instance.id !== instanceId || actualEnvironment !== environmentType) {
+        throw new Error("Clerk credential instance does not match the confirmed migration target");
+      }
+    },
     users: {
       async getUserList(params, context) {
         const url = new URL(CLERK_USERS_URL);
@@ -450,15 +568,22 @@ export function createClerkRestMigrationClient(
 
 function defaultFactories(env: Environment): MigrationApplyFactories {
   return {
-    createMediaStore(bucketName) {
+    createMediaStore(bucketName, cloudflareAccountId) {
+      const credentialAccountId = required(env.CLOUDFLARE_ACCOUNT_ID, "CLOUDFLARE_ACCOUNT_ID").toLowerCase();
+      if (credentialAccountId !== cloudflareAccountId) {
+        throw new Error("R2 credential account does not match the confirmed migration target");
+      }
       return createR2S3MediaStore({
         bucketName,
-        accountId: required(env.CLOUDFLARE_ACCOUNT_ID, "CLOUDFLARE_ACCOUNT_ID"),
+        accountId: cloudflareAccountId,
         accessKeyId: required(env.R2_ACCESS_KEY_ID, "R2_ACCESS_KEY_ID"),
         secretAccessKey: required(env.R2_SECRET_ACCESS_KEY, "R2_SECRET_ACCESS_KEY"),
       });
     },
-    async createClerkClient(): Promise<ClerkMigrationClient> {
+    async createClerkClient(clerkInstanceId): Promise<TargetBoundClerkMigrationClient> {
+      if (required(env.MIGRATION_CLERK_INSTANCE_ID, "MIGRATION_CLERK_INSTANCE_ID") !== clerkInstanceId) {
+        throw new Error("Clerk credentials do not match the confirmed migration target");
+      }
       return createClerkRestMigrationClient(required(env.CLERK_SECRET_KEY, "CLERK_SECRET_KEY"));
     },
     createCommandRunner: () => createNodeCommandRunner(),
@@ -470,6 +595,7 @@ export async function runMigrationCli(dependencies: MigrationCliDependencies = {
   const cwd = dependencies.cwd ?? process.cwd();
   const parsed = parseMigrationCli(env, dependencies.args ?? process.argv.slice(2), cwd);
   const project = canonicalProjectConfig(parsed.projectRoot);
+  assertPrivateMigrationRoots(parsed.config, project.projectRoot);
   const inputRoot = parsed.config.inputRoot;
   const reviewAttributions = parsed.reviewAttributionsFile
     ? keyedRows(readJsonFile<ReviewAttributionRow>(inputRoot!, parsed.reviewAttributionsFile), "Review attributions")
@@ -492,8 +618,10 @@ export async function runMigrationCli(dependencies: MigrationCliDependencies = {
     projectRoot: project.projectRoot,
     wranglerConfigText: project.text,
     ...(parsed.expectedDatabaseName ? { expectedDatabaseName: parsed.expectedDatabaseName } : {}),
+    ...(parsed.remoteTargetBinding ? { remoteTargetBinding: parsed.remoteTargetBinding } : {}),
     ...(parsed.config.execution.apply ? { applyFactories: dependencies.applyFactories ?? defaultFactories(env) } : {}),
     runners: {
+      preflightD1: preflightD1Target,
       importMedia: importMediaPlans,
       provisionClerk: provisionClerkCustomers,
       runD1: runD1Import,

--- a/scripts/shopify-migration/cli.ts
+++ b/scripts/shopify-migration/cli.ts
@@ -2,8 +2,6 @@ import { lstatSync, readFileSync, realpathSync } from "node:fs";
 import { isAbsolute, join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 
-import { clerkClient } from "@clerk/nextjs/server";
-
 import { provisionClerkCustomers, type ClerkMigrationClient } from "./adapters/clerk/index.js";
 import { createNodeCommandRunner, runD1Import } from "./adapters/d1/index.js";
 import { createR2S3MediaStore, importMediaPlans } from "./adapters/media/index.js";
@@ -307,6 +305,7 @@ function defaultFactories(env: Environment): MigrationApplyFactories {
     },
     async createClerkClient(): Promise<ClerkMigrationClient> {
       required(env.CLERK_SECRET_KEY, "CLERK_SECRET_KEY");
+      const { clerkClient } = await import("@clerk/nextjs/server");
       const client = await clerkClient();
       return {
         users: {

--- a/scripts/shopify-migration/extractors/file-based/index.ts
+++ b/scripts/shopify-migration/extractors/file-based/index.ts
@@ -1,0 +1,24 @@
+import { existsSync } from "node:fs";
+import type { ExtractResult } from "../../lib/types.js";
+import { readCsvFile, readJsonFile, resolveInputFile, type FileReadLimits } from "../../lib/file-reader.js";
+
+export function extractFileRecords<T>(
+  inputRoot: string,
+  basename: string,
+  limits: FileReadLimits = {},
+): ExtractResult<T> {
+  if (!/^[a-z][a-z0-9_-]{0,63}$/.test(basename)) throw new Error("Input entity basename is invalid");
+  const json = `${basename}.json`;
+  const csv = `${basename}.csv`;
+  let records: T[];
+  try {
+    const path = resolveInputFile(inputRoot, json);
+    if (!existsSync(path)) throw new Error("unreachable");
+    records = readJsonFile<T>(inputRoot, json, limits);
+  } catch (error) {
+    const code = error && typeof error === "object" && "code" in error ? String(error.code) : "";
+    if (code !== "ENOENT") throw error;
+    records = readCsvFile(inputRoot, csv, limits) as T[];
+  }
+  return { records, source: "file", extractedAt: new Date().toISOString() };
+}

--- a/scripts/shopify-migration/extractors/shopify-api/index.ts
+++ b/scripts/shopify-migration/extractors/shopify-api/index.ts
@@ -1,0 +1,12 @@
+import type { ExtractResult } from "../../lib/types.js";
+import type { PaginationOptions, ShopifyClient } from "../../lib/shopify-api.js";
+
+export async function extractFromShopifyApi<T>(
+  client: ShopifyClient,
+  resource: string,
+  key: string,
+  options?: PaginationOptions,
+): Promise<ExtractResult<T>> {
+  const records = await client.fetchPaginated<T>(resource, key, options);
+  return { records, source: "api", extractedAt: new Date().toISOString() };
+}

--- a/scripts/shopify-migration/lib/config.ts
+++ b/scripts/shopify-migration/lib/config.ts
@@ -10,7 +10,9 @@ export interface ExecutionPlan {
   includeSensitive: boolean;
   overwrite: boolean;
   confirmedSensitiveData: boolean;
+  confirmedPreview: boolean;
   confirmedProduction: boolean;
+  confirmedOverwrite: boolean;
 }
 
 export interface MigrationConfig {
@@ -22,8 +24,7 @@ export interface MigrationConfig {
   };
   inputRoot?: string;
   outputRoot?: string;
-  d1DatabaseName?: string;
-  r2BucketName?: string;
+  wranglerEnvironment?: string;
   execution: ExecutionPlan;
 }
 
@@ -88,11 +89,13 @@ export function parseMigrationConfig(
     "--include-sensitive",
     "--confirm-sensitive-data",
     "--overwrite",
+    "--confirm-overwrite",
+    "--confirm-preview",
     "--confirm-production",
   ]);
   for (const argument of args) {
     if (supported.has(argument)) continue;
-    if (["--source=", "--target=", "--input-root=", "--output-root="].some((prefix) => argument.startsWith(prefix))) continue;
+    if (["--source=", "--target=", "--input-root=", "--output-root=", "--env="].some((prefix) => argument.startsWith(prefix))) continue;
     throw new Error(`Unknown migration option: ${argument}`);
   }
 
@@ -109,35 +112,62 @@ export function parseMigrationConfig(
 
   const includeSensitive = hasFlag(args, "--include-sensitive");
   const confirmedSensitiveData = hasFlag(args, "--confirm-sensitive-data");
+  const confirmedPreview = hasFlag(args, "--confirm-preview");
   const confirmedProduction = hasFlag(args, "--confirm-production");
+  const overwrite = hasFlag(args, "--overwrite");
+  const confirmedOverwrite = hasFlag(args, "--confirm-overwrite");
   if (includeSensitive && !confirmedSensitiveData) {
     throw new Error("--include-sensitive requires --confirm-sensitive-data");
   }
+  if (!includeSensitive && confirmedSensitiveData) {
+    throw new Error("--confirm-sensitive-data requires --include-sensitive");
+  }
+  if (apply && target === "preview" && !confirmedPreview) {
+    throw new Error("Preview apply requires --confirm-preview");
+  }
   if (apply && target === "production" && !confirmedProduction) {
     throw new Error("Production apply requires --confirm-production");
+  }
+  if (apply && target === "production" && env.MERCORA_ALLOW_PRODUCTION_IMPORTS !== "1") {
+    throw new Error("Production apply requires MERCORA_ALLOW_PRODUCTION_IMPORTS=1");
+  }
+  if (confirmedPreview && target !== "preview") {
+    throw new Error("--confirm-preview may only be used with --target=preview");
+  }
+  if (confirmedProduction && target !== "production") {
+    throw new Error("--confirm-production may only be used with --target=production");
+  }
+  if (overwrite && apply && !confirmedOverwrite) {
+    throw new Error("Applying overwrite mode requires --confirm-overwrite");
+  }
+  if (!overwrite && confirmedOverwrite) {
+    throw new Error("--confirm-overwrite requires --overwrite");
   }
 
   const inputRootValue = flagValue(args, "--input-root") ?? env.MIGRATION_INPUT_ROOT;
   const outputRootValue = flagValue(args, "--output-root") ?? env.MIGRATION_OUTPUT_ROOT;
   const inputRoot = inputRootValue ? resolve(cwd, inputRootValue) : undefined;
   const outputRoot = outputRootValue ? resolve(cwd, outputRootValue) : undefined;
-  const d1DatabaseName = env.MIGRATION_D1_DATABASE?.trim() || undefined;
-  const r2BucketName = env.MIGRATION_R2_BUCKET?.trim() || undefined;
+  const wranglerEnvironment = flagValue(args, "--env")?.trim() || undefined;
+  if (wranglerEnvironment && !/^[a-z][a-z0-9_-]{0,62}$/i.test(wranglerEnvironment)) {
+    throw new Error("Wrangler environment name is invalid");
+  }
 
   const config: MigrationConfig = {
     sourceMode,
     ...(inputRoot ? { inputRoot } : {}),
     ...(outputRoot ? { outputRoot } : {}),
-    ...(d1DatabaseName ? { d1DatabaseName } : {}),
-    ...(r2BucketName ? { r2BucketName } : {}),
+    ...(wranglerEnvironment ? { wranglerEnvironment } : {}),
     execution: {
       dryRun: !apply,
       apply,
       target,
       includeSensitive,
-      overwrite: hasFlag(args, "--overwrite"),
+      overwrite,
       confirmedSensitiveData,
+      confirmedPreview,
       confirmedProduction,
+      confirmedOverwrite,
     },
   };
 

--- a/scripts/shopify-migration/lib/config.ts
+++ b/scripts/shopify-migration/lib/config.ts
@@ -13,6 +13,10 @@ export interface ExecutionPlan {
   confirmedPreview: boolean;
   confirmedProduction: boolean;
   confirmedOverwrite: boolean;
+  /** Explicit opt-in to create Clerk identities during an apply run. */
+  createClerkUsers?: boolean;
+  /** Acknowledges that Clerk auto-verifies email addresses passed to createUser. */
+  confirmedClerkAutoVerification?: boolean;
 }
 
 export interface MigrationConfig {
@@ -92,6 +96,8 @@ export function parseMigrationConfig(
     "--confirm-overwrite",
     "--confirm-preview",
     "--confirm-production",
+    "--create-clerk-users",
+    "--confirm-clerk-auto-verification",
   ]);
   for (const argument of args) {
     if (supported.has(argument)) continue;
@@ -117,6 +123,16 @@ export function parseMigrationConfig(
   const confirmedProduction = hasFlag(args, "--confirm-production");
   const overwrite = hasFlag(args, "--overwrite");
   const confirmedOverwrite = hasFlag(args, "--confirm-overwrite");
+  const createClerkUsersCount = args.filter((argument) => argument === "--create-clerk-users").length;
+  const confirmClerkAutoVerificationCount = args.filter(
+    (argument) => argument === "--confirm-clerk-auto-verification",
+  ).length;
+  if (createClerkUsersCount > 1) throw new Error("--create-clerk-users may only be provided once");
+  if (confirmClerkAutoVerificationCount > 1) {
+    throw new Error("--confirm-clerk-auto-verification may only be provided once");
+  }
+  const createClerkUsers = createClerkUsersCount === 1;
+  const confirmedClerkAutoVerification = confirmClerkAutoVerificationCount === 1;
   if (apply && target !== "local" && !targetArgument) {
     throw new Error("Remote apply requires an explicit --target=preview or --target=production option");
   }
@@ -147,6 +163,18 @@ export function parseMigrationConfig(
   if (!overwrite && confirmedOverwrite) {
     throw new Error("--confirm-overwrite requires --overwrite");
   }
+  if (createClerkUsers && !apply) {
+    throw new Error("--create-clerk-users may only be used with --apply");
+  }
+  if (createClerkUsers && !includeSensitive) {
+    throw new Error("--create-clerk-users requires --include-sensitive");
+  }
+  if (createClerkUsers && !confirmedClerkAutoVerification) {
+    throw new Error("--create-clerk-users requires --confirm-clerk-auto-verification");
+  }
+  if (!createClerkUsers && confirmedClerkAutoVerification) {
+    throw new Error("--confirm-clerk-auto-verification requires --create-clerk-users");
+  }
 
   const inputRootValue = flagValue(args, "--input-root") ?? env.MIGRATION_INPUT_ROOT;
   const outputRootValue = flagValue(args, "--output-root") ?? env.MIGRATION_OUTPUT_ROOT;
@@ -176,6 +204,8 @@ export function parseMigrationConfig(
       confirmedPreview,
       confirmedProduction,
       confirmedOverwrite,
+      createClerkUsers,
+      confirmedClerkAutoVerification,
     },
   };
 

--- a/scripts/shopify-migration/lib/config.ts
+++ b/scripts/shopify-migration/lib/config.ts
@@ -105,7 +105,8 @@ export function parseMigrationConfig(
   const sourceMode = (flagValue(args, "--source") ?? env.MIGRATION_SOURCE_MODE ?? "file") as SourceMode;
   if (sourceMode !== "api" && sourceMode !== "file") throw new Error("Migration source must be api or file");
 
-  const target = (flagValue(args, "--target") ?? env.MIGRATION_TARGET ?? "local") as MigrationTarget;
+  const targetArgument = flagValue(args, "--target");
+  const target = (targetArgument ?? env.MIGRATION_TARGET ?? "local") as MigrationTarget;
   if (!(["local", "preview", "production"] as const).includes(target)) {
     throw new Error("Migration target must be local, preview, or production");
   }
@@ -116,6 +117,9 @@ export function parseMigrationConfig(
   const confirmedProduction = hasFlag(args, "--confirm-production");
   const overwrite = hasFlag(args, "--overwrite");
   const confirmedOverwrite = hasFlag(args, "--confirm-overwrite");
+  if (apply && target !== "local" && !targetArgument) {
+    throw new Error("Remote apply requires an explicit --target=preview or --target=production option");
+  }
   if (includeSensitive && !confirmedSensitiveData) {
     throw new Error("--include-sensitive requires --confirm-sensitive-data");
   }
@@ -148,7 +152,11 @@ export function parseMigrationConfig(
   const outputRootValue = flagValue(args, "--output-root") ?? env.MIGRATION_OUTPUT_ROOT;
   const inputRoot = inputRootValue ? resolve(cwd, inputRootValue) : undefined;
   const outputRoot = outputRootValue ? resolve(cwd, outputRootValue) : undefined;
+  const environmentArgumentPresent = args.some((argument) => argument.startsWith("--env="));
   const wranglerEnvironment = flagValue(args, "--env")?.trim() || undefined;
+  if (environmentArgumentPresent && !wranglerEnvironment) {
+    throw new Error("--env requires a non-empty Wrangler environment name");
+  }
   if (wranglerEnvironment && !/^[a-z][a-z0-9_-]{0,62}$/i.test(wranglerEnvironment)) {
     throw new Error("Wrangler environment name is invalid");
   }

--- a/scripts/shopify-migration/lib/config.ts
+++ b/scripts/shopify-migration/lib/config.ts
@@ -1,0 +1,155 @@
+import { resolve } from "node:path";
+
+export type SourceMode = "api" | "file";
+export type MigrationTarget = "local" | "preview" | "production";
+
+export interface ExecutionPlan {
+  dryRun: boolean;
+  apply: boolean;
+  target: MigrationTarget;
+  includeSensitive: boolean;
+  overwrite: boolean;
+  confirmedSensitiveData: boolean;
+  confirmedProduction: boolean;
+}
+
+export interface MigrationConfig {
+  sourceMode: SourceMode;
+  shopify?: {
+    origin: string;
+    accessToken: string;
+    apiVersion: string;
+  };
+  inputRoot?: string;
+  outputRoot?: string;
+  d1DatabaseName?: string;
+  r2BucketName?: string;
+  execution: ExecutionPlan;
+}
+
+export type Environment = Record<string, string | undefined>;
+
+function requiredValue(value: string | undefined, name: string): string {
+  const normalized = value?.trim();
+  if (!normalized) throw new Error(`${name} is required`);
+  return normalized;
+}
+
+export function validateShopifyOrigin(value: string): string {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error("SHOPIFY_STORE_URL must be a valid HTTPS myshopify.com origin");
+  }
+  if (
+    url.protocol !== "https:" ||
+    !/^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.myshopify\.com$/i.test(url.hostname) ||
+    url.username !== "" ||
+    url.password !== "" ||
+    url.port !== "" ||
+    (url.pathname !== "" && url.pathname !== "/") ||
+    url.search !== "" ||
+    url.hash !== ""
+  ) {
+    throw new Error(
+      "SHOPIFY_STORE_URL must be an exact HTTPS *.myshopify.com origin without credentials, port, path, query, or fragment",
+    );
+  }
+  return url.origin;
+}
+
+export function validateShopifyApiVersion(value: string): string {
+  const version = value.trim();
+  if (!/^20\d{2}-(?:01|04|07|10)$/.test(version)) {
+    throw new Error("SHOPIFY_API_VERSION must be an explicit quarterly version such as 2026-07");
+  }
+  return version;
+}
+
+function flagValue(args: readonly string[], name: string): string | undefined {
+  const matches = args.filter((arg) => arg.startsWith(`${name}=`));
+  if (matches.length > 1) throw new Error(`${name} may only be provided once`);
+  return matches[0]?.slice(name.length + 1);
+}
+
+function hasFlag(args: readonly string[], name: string): boolean {
+  return args.includes(name);
+}
+
+export function parseMigrationConfig(
+  env: Environment = process.env,
+  args: readonly string[] = process.argv.slice(2),
+  cwd = process.cwd(),
+): MigrationConfig {
+  const supported = new Set([
+    "--apply",
+    "--dry-run",
+    "--include-sensitive",
+    "--confirm-sensitive-data",
+    "--overwrite",
+    "--confirm-production",
+  ]);
+  for (const argument of args) {
+    if (supported.has(argument)) continue;
+    if (["--source=", "--target=", "--input-root=", "--output-root="].some((prefix) => argument.startsWith(prefix))) continue;
+    throw new Error(`Unknown migration option: ${argument}`);
+  }
+
+  const apply = hasFlag(args, "--apply");
+  if (apply && hasFlag(args, "--dry-run")) throw new Error("--apply and --dry-run are mutually exclusive");
+
+  const sourceMode = (flagValue(args, "--source") ?? env.MIGRATION_SOURCE_MODE ?? "file") as SourceMode;
+  if (sourceMode !== "api" && sourceMode !== "file") throw new Error("Migration source must be api or file");
+
+  const target = (flagValue(args, "--target") ?? env.MIGRATION_TARGET ?? "local") as MigrationTarget;
+  if (!(["local", "preview", "production"] as const).includes(target)) {
+    throw new Error("Migration target must be local, preview, or production");
+  }
+
+  const includeSensitive = hasFlag(args, "--include-sensitive");
+  const confirmedSensitiveData = hasFlag(args, "--confirm-sensitive-data");
+  const confirmedProduction = hasFlag(args, "--confirm-production");
+  if (includeSensitive && !confirmedSensitiveData) {
+    throw new Error("--include-sensitive requires --confirm-sensitive-data");
+  }
+  if (apply && target === "production" && !confirmedProduction) {
+    throw new Error("Production apply requires --confirm-production");
+  }
+
+  const inputRootValue = flagValue(args, "--input-root") ?? env.MIGRATION_INPUT_ROOT;
+  const outputRootValue = flagValue(args, "--output-root") ?? env.MIGRATION_OUTPUT_ROOT;
+  const inputRoot = inputRootValue ? resolve(cwd, inputRootValue) : undefined;
+  const outputRoot = outputRootValue ? resolve(cwd, outputRootValue) : undefined;
+  const d1DatabaseName = env.MIGRATION_D1_DATABASE?.trim() || undefined;
+  const r2BucketName = env.MIGRATION_R2_BUCKET?.trim() || undefined;
+
+  const config: MigrationConfig = {
+    sourceMode,
+    ...(inputRoot ? { inputRoot } : {}),
+    ...(outputRoot ? { outputRoot } : {}),
+    ...(d1DatabaseName ? { d1DatabaseName } : {}),
+    ...(r2BucketName ? { r2BucketName } : {}),
+    execution: {
+      dryRun: !apply,
+      apply,
+      target,
+      includeSensitive,
+      overwrite: hasFlag(args, "--overwrite"),
+      confirmedSensitiveData,
+      confirmedProduction,
+    },
+  };
+
+  if (sourceMode === "file") {
+    config.inputRoot = resolve(cwd, requiredValue(inputRootValue, "MIGRATION_INPUT_ROOT"));
+  } else {
+    config.shopify = {
+      origin: validateShopifyOrigin(requiredValue(env.SHOPIFY_STORE_URL, "SHOPIFY_STORE_URL")),
+      accessToken: requiredValue(env.SHOPIFY_ACCESS_TOKEN, "SHOPIFY_ACCESS_TOKEN"),
+      apiVersion: validateShopifyApiVersion(requiredValue(env.SHOPIFY_API_VERSION, "SHOPIFY_API_VERSION")),
+    };
+  }
+
+  return config;
+}

--- a/scripts/shopify-migration/lib/file-reader.ts
+++ b/scripts/shopify-migration/lib/file-reader.ts
@@ -1,0 +1,109 @@
+import { lstatSync, readFileSync, realpathSync } from "node:fs";
+import { isAbsolute, relative, resolve } from "node:path";
+import { parse } from "csv-parse/sync";
+
+export const DEFAULT_MAX_INPUT_BYTES = 50 * 1024 * 1024;
+export const DEFAULT_MAX_INPUT_RECORDS = 100_000;
+export const DEFAULT_MAX_CSV_COLUMNS = 256;
+export const DEFAULT_MAX_CSV_RECORD_BYTES = 1024 * 1024;
+
+export interface FileReadLimits {
+  maxBytes?: number;
+  maxRecords?: number;
+  maxColumns?: number;
+  maxRecordBytes?: number;
+}
+
+function positiveLimit(value: number | undefined, fallback: number, name: string): number {
+  const limit = value ?? fallback;
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > Number.MAX_SAFE_INTEGER) {
+    throw new Error(`${name} must be a positive safe integer`);
+  }
+  return limit;
+}
+
+function isWithin(root: string, candidate: string): boolean {
+  const child = relative(root, candidate);
+  return child === "" || (!child.startsWith("..") && !isAbsolute(child));
+}
+
+/** Resolve an existing regular file, rejecting absolute paths, traversal, and symlink escapes. */
+export function resolveInputFile(inputRoot: string, requestedPath: string): string {
+  if (!requestedPath || isAbsolute(requestedPath) || requestedPath.includes("\0")) {
+    throw new Error("Input path must be a non-empty relative path");
+  }
+  const root = realpathSync(inputRoot);
+  const lexical = resolve(root, requestedPath);
+  if (!isWithin(root, lexical)) throw new Error("Input path escapes the configured input root");
+  const actual = realpathSync(lexical);
+  if (!isWithin(root, actual)) throw new Error("Input symlink escapes the configured input root");
+  if (!lstatSync(actual).isFile()) throw new Error("Input path must identify a regular file");
+  return actual;
+}
+
+function readBoundedText(inputRoot: string, requestedPath: string, limits: FileReadLimits): string {
+  const path = resolveInputFile(inputRoot, requestedPath);
+  const maxBytes = positiveLimit(limits.maxBytes, DEFAULT_MAX_INPUT_BYTES, "maxBytes");
+  const size = lstatSync(path).size;
+  if (size > maxBytes) throw new Error(`Input file exceeds the ${maxBytes}-byte limit`);
+  const content = readFileSync(path, "utf8");
+  if (Buffer.byteLength(content, "utf8") > maxBytes) throw new Error(`Input file exceeds the ${maxBytes}-byte limit`);
+  return content;
+}
+
+function assertRecordCount(records: readonly unknown[], limits: FileReadLimits): void {
+  const maxRecords = positiveLimit(limits.maxRecords, DEFAULT_MAX_INPUT_RECORDS, "maxRecords");
+  if (records.length > maxRecords) throw new Error(`Input contains more than ${maxRecords} records`);
+}
+
+export function readCsvFile<T extends Record<string, string> = Record<string, string>>(
+  inputRoot: string,
+  requestedPath: string,
+  limits: FileReadLimits = {},
+): T[] {
+  const content = readBoundedText(inputRoot, requestedPath, limits);
+  const maxColumns = positiveLimit(limits.maxColumns, DEFAULT_MAX_CSV_COLUMNS, "maxColumns");
+  const records = parse(content, {
+    bom: true,
+    columns(headers: string[]) {
+      if (headers.length > maxColumns) throw new Error(`CSV contains more than ${maxColumns} columns`);
+      const normalized = headers.map((header) => header.trim());
+      if (normalized.some((header) => !header)) throw new Error("CSV contains an empty column name");
+      if (new Set(normalized).size !== normalized.length) throw new Error("CSV contains duplicate column names");
+      if (normalized.some((header) => ["__proto__", "prototype", "constructor"].includes(header.toLowerCase()))) {
+        throw new Error("CSV contains an unsafe column name");
+      }
+      return normalized;
+    },
+    max_record_size: positiveLimit(limits.maxRecordBytes, DEFAULT_MAX_CSV_RECORD_BYTES, "maxRecordBytes"),
+    skip_empty_lines: true,
+    trim: true,
+  }) as T[];
+  assertRecordCount(records, limits);
+  return records;
+}
+
+export function readJsonFile<T>(
+  inputRoot: string,
+  requestedPath: string,
+  limits: FileReadLimits = {},
+): T[] {
+  const content = readBoundedText(inputRoot, requestedPath, limits);
+  let value: unknown;
+  try {
+    value = JSON.parse(content);
+  } catch {
+    throw new Error("Input file is not valid JSON");
+  }
+  let records: unknown[];
+  if (Array.isArray(value)) {
+    records = value;
+  } else if (value && typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>);
+    records = entries.length === 1 && Array.isArray(entries[0][1]) ? entries[0][1] : [value];
+  } else {
+    throw new Error("JSON input must be an object, array, or single array wrapper");
+  }
+  assertRecordCount(records, limits);
+  return records as T[];
+}

--- a/scripts/shopify-migration/lib/id-map.ts
+++ b/scripts/shopify-migration/lib/id-map.ts
@@ -1,0 +1,142 @@
+import { existsSync, lstatSync, mkdirSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
+import { dirname, isAbsolute, relative, resolve, sep } from "node:path";
+import { providerFingerprint } from "./ids.js";
+
+const ARTIFACT_VERSION = 1;
+const MAX_ARTIFACT_BYTES = 10 * 1024 * 1024;
+const safeLabel = /^[a-z][a-z0-9_-]{0,31}$/;
+
+export interface IdMapArtifact {
+  version: 1;
+  authoritative: false;
+  provider: string;
+  mappings: Record<string, Record<string, string>>;
+}
+
+export interface MigrationManifest {
+  version: 1;
+  authoritative: false;
+  generatedAt: string;
+  dryRun: boolean;
+  target: "local" | "preview" | "production";
+  entities: Record<string, { source: number; transformed: number; written: number; skipped: number; errors: number }>;
+}
+
+function normalizeLabel(value: string, field: string): string {
+  const normalized = value.trim().toLowerCase();
+  if (!safeLabel.test(normalized)) throw new Error(`${field} is invalid`);
+  return normalized;
+}
+
+function outputPath(root: string, requestedPath: string): string {
+  if (!requestedPath || isAbsolute(requestedPath) || requestedPath.includes("\0")) {
+    throw new Error("Artifact path must be a relative path");
+  }
+  mkdirSync(resolve(root), { recursive: true, mode: 0o700 });
+  const absoluteRoot = realpathSync(root);
+  const candidate = resolve(absoluteRoot, requestedPath);
+  const child = relative(absoluteRoot, candidate);
+  if (child.startsWith("..") || isAbsolute(child)) throw new Error("Artifact path escapes the configured output root");
+  let cursor = absoluteRoot;
+  for (const part of child.split(sep)) {
+    cursor = resolve(cursor, part);
+    if (existsSync(cursor) && lstatSync(cursor).isSymbolicLink()) {
+      throw new Error("Artifact path may not traverse a symbolic link");
+    }
+  }
+  return candidate;
+}
+
+function validateTargetId(value: string): string {
+  const normalized = value.trim();
+  if (!/^[A-Za-z0-9][A-Za-z0-9:_-]{0,255}$/.test(normalized)) {
+    throw new Error("Target ID is invalid or may contain sensitive data");
+  }
+  return normalized;
+}
+
+export class IdMap {
+  private readonly mappings = new Map<string, Map<string, string>>();
+  readonly provider: string;
+
+  constructor(provider: string) {
+    this.provider = normalizeLabel(provider, "provider");
+  }
+
+  register(entity: string, providerSourceId: string | number, targetId: string): void {
+    const entityName = normalizeLabel(entity, "entity");
+    const fingerprint = providerFingerprint(this.provider, entityName, providerSourceId);
+    const normalizedTarget = validateTargetId(targetId);
+    const entries = this.mappings.get(entityName) ?? new Map<string, string>();
+    const existing = entries.get(fingerprint);
+    if (existing && existing !== normalizedTarget) throw new Error("Provider identity is already mapped to a different target");
+    entries.set(fingerprint, normalizedTarget);
+    this.mappings.set(entityName, entries);
+  }
+
+  resolve(entity: string, providerSourceId: string | number): string | undefined {
+    const entityName = normalizeLabel(entity, "entity");
+    return this.mappings.get(entityName)?.get(providerFingerprint(this.provider, entityName, providerSourceId));
+  }
+
+  count(entity: string): number {
+    return this.mappings.get(normalizeLabel(entity, "entity"))?.size ?? 0;
+  }
+
+  toArtifact(): IdMapArtifact {
+    const mappings: Record<string, Record<string, string>> = {};
+    for (const [entity, values] of [...this.mappings].sort(([left], [right]) => left.localeCompare(right))) {
+      mappings[entity] = Object.fromEntries([...values].sort(([left], [right]) => left.localeCompare(right)));
+    }
+    return { version: ARTIFACT_VERSION, authoritative: false, provider: this.provider, mappings };
+  }
+
+  save(root: string, requestedPath: string): void {
+    const path = outputPath(root, requestedPath);
+    mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+    writeFileSync(path, `${JSON.stringify(this.toArtifact(), null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
+  }
+
+  static load(root: string, requestedPath: string): IdMap {
+    const path = outputPath(root, requestedPath);
+    const content = readFileSync(path, "utf8");
+    if (Buffer.byteLength(content) > MAX_ARTIFACT_BYTES) throw new Error("ID map artifact is too large");
+    const raw: unknown = JSON.parse(content);
+    if (!raw || typeof raw !== "object") throw new Error("ID map artifact is invalid");
+    const artifact = raw as Partial<IdMapArtifact>;
+    if (artifact.version !== 1 || artifact.authoritative !== false || !artifact.provider || !artifact.mappings) {
+      throw new Error("ID map artifact has an unsupported or authoritative format");
+    }
+    const map = new IdMap(artifact.provider);
+    for (const [entity, entries] of Object.entries(artifact.mappings)) {
+      normalizeLabel(entity, "entity");
+      if (!entries || typeof entries !== "object" || Array.isArray(entries)) throw new Error("ID map entries are invalid");
+      const values = new Map<string, string>();
+      for (const [fingerprint, targetId] of Object.entries(entries)) {
+        if (!/^[a-f0-9]{64}$/.test(fingerprint) || typeof targetId !== "string") throw new Error("ID map entry is invalid");
+        values.set(fingerprint, validateTargetId(targetId));
+      }
+      map.mappings.set(entity, values);
+    }
+    return map;
+  }
+}
+
+export function writeManifest(root: string, requestedPath: string, manifest: MigrationManifest): void {
+  if (manifest.version !== 1 || manifest.authoritative !== false) throw new Error("Manifest must be explicitly non-authoritative");
+  if (!Number.isFinite(Date.parse(manifest.generatedAt))) throw new Error("Manifest generatedAt must be an ISO timestamp");
+  if (typeof manifest.dryRun !== "boolean" || !(["local", "preview", "production"] as const).includes(manifest.target)) {
+    throw new Error("Manifest execution metadata is invalid");
+  }
+  const entities: MigrationManifest["entities"] = {};
+  for (const [entity, counts] of Object.entries(manifest.entities)) {
+    const entityName = normalizeLabel(entity, "entity");
+    for (const [name, count] of Object.entries(counts)) {
+      if (!Number.isSafeInteger(count) || count < 0) throw new Error(`Manifest ${entityName}.${name} count is invalid`);
+    }
+    entities[entityName] = { ...counts };
+  }
+  const path = outputPath(root, requestedPath);
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+  writeFileSync(path, `${JSON.stringify({ ...manifest, entities }, null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
+}

--- a/scripts/shopify-migration/lib/id-map.ts
+++ b/scripts/shopify-migration/lib/id-map.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { closeSync, constants, fstatSync, lstatSync, openSync, readSync } from "node:fs";
 import { providerFingerprint } from "./ids.js";
 import { atomicWritePrivateFile, resolvePrivateArtifactPath } from "./private-atomic-file.js";
 
@@ -79,8 +79,27 @@ export class IdMap {
 
   static load(root: string, requestedPath: string): IdMap {
     const path = resolvePrivateArtifactPath(root, requestedPath);
-    const content = readFileSync(path, "utf8");
-    if (Buffer.byteLength(content) > MAX_ARTIFACT_BYTES) throw new Error("ID map artifact is too large");
+    const pathMetadata = lstatSync(path);
+    if (pathMetadata.isSymbolicLink() || !pathMetadata.isFile()) throw new Error("ID map artifact must be a regular non-symlink file");
+    if (pathMetadata.size > MAX_ARTIFACT_BYTES) throw new Error("ID map artifact is too large");
+    const fd = openSync(path, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
+    let content: string;
+    try {
+      const descriptorMetadata = fstatSync(fd);
+      if (!descriptorMetadata.isFile()) throw new Error("ID map artifact must be a regular non-symlink file");
+      if (descriptorMetadata.size > MAX_ARTIFACT_BYTES) throw new Error("ID map artifact is too large");
+      const bytes = Buffer.allocUnsafe(MAX_ARTIFACT_BYTES + 1);
+      let offset = 0;
+      while (offset < bytes.byteLength) {
+        const read = readSync(fd, bytes, offset, bytes.byteLength - offset, null);
+        if (read === 0) break;
+        offset += read;
+      }
+      if (offset > MAX_ARTIFACT_BYTES) throw new Error("ID map artifact is too large");
+      content = bytes.toString("utf8", 0, offset);
+    } finally {
+      closeSync(fd);
+    }
     const raw: unknown = JSON.parse(content);
     if (!raw || typeof raw !== "object") throw new Error("ID map artifact is invalid");
     const artifact = raw as Partial<IdMapArtifact>;

--- a/scripts/shopify-migration/lib/id-map.ts
+++ b/scripts/shopify-migration/lib/id-map.ts
@@ -1,6 +1,6 @@
-import { existsSync, lstatSync, mkdirSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
-import { dirname, isAbsolute, relative, resolve, sep } from "node:path";
+import { readFileSync } from "node:fs";
 import { providerFingerprint } from "./ids.js";
+import { atomicWritePrivateFile, resolvePrivateArtifactPath } from "./private-atomic-file.js";
 
 const ARTIFACT_VERSION = 1;
 const MAX_ARTIFACT_BYTES = 10 * 1024 * 1024;
@@ -26,25 +26,6 @@ function normalizeLabel(value: string, field: string): string {
   const normalized = value.trim().toLowerCase();
   if (!safeLabel.test(normalized)) throw new Error(`${field} is invalid`);
   return normalized;
-}
-
-function outputPath(root: string, requestedPath: string): string {
-  if (!requestedPath || isAbsolute(requestedPath) || requestedPath.includes("\0")) {
-    throw new Error("Artifact path must be a relative path");
-  }
-  mkdirSync(resolve(root), { recursive: true, mode: 0o700 });
-  const absoluteRoot = realpathSync(root);
-  const candidate = resolve(absoluteRoot, requestedPath);
-  const child = relative(absoluteRoot, candidate);
-  if (child.startsWith("..") || isAbsolute(child)) throw new Error("Artifact path escapes the configured output root");
-  let cursor = absoluteRoot;
-  for (const part of child.split(sep)) {
-    cursor = resolve(cursor, part);
-    if (existsSync(cursor) && lstatSync(cursor).isSymbolicLink()) {
-      throw new Error("Artifact path may not traverse a symbolic link");
-    }
-  }
-  return candidate;
 }
 
 function validateTargetId(value: string): string {
@@ -92,13 +73,12 @@ export class IdMap {
   }
 
   save(root: string, requestedPath: string): void {
-    const path = outputPath(root, requestedPath);
-    mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
-    writeFileSync(path, `${JSON.stringify(this.toArtifact(), null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
+    const path = resolvePrivateArtifactPath(root, requestedPath);
+    atomicWritePrivateFile(path, `${JSON.stringify(this.toArtifact(), null, 2)}\n`, { maxBytes: MAX_ARTIFACT_BYTES });
   }
 
   static load(root: string, requestedPath: string): IdMap {
-    const path = outputPath(root, requestedPath);
+    const path = resolvePrivateArtifactPath(root, requestedPath);
     const content = readFileSync(path, "utf8");
     if (Buffer.byteLength(content) > MAX_ARTIFACT_BYTES) throw new Error("ID map artifact is too large");
     const raw: unknown = JSON.parse(content);
@@ -136,7 +116,6 @@ export function writeManifest(root: string, requestedPath: string, manifest: Mig
     }
     entities[entityName] = { ...counts };
   }
-  const path = outputPath(root, requestedPath);
-  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
-  writeFileSync(path, `${JSON.stringify({ ...manifest, entities }, null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
+  const path = resolvePrivateArtifactPath(root, requestedPath);
+  atomicWritePrivateFile(path, `${JSON.stringify({ ...manifest, entities }, null, 2)}\n`, { maxBytes: MAX_ARTIFACT_BYTES });
 }

--- a/scripts/shopify-migration/lib/ids.ts
+++ b/scripts/shopify-migration/lib/ids.ts
@@ -1,0 +1,28 @@
+import { createHash } from "node:crypto";
+
+function label(value: string, field: string): string {
+  const normalized = value.trim().toLowerCase();
+  if (!/^[a-z][a-z0-9_-]{0,31}$/.test(normalized)) {
+    throw new Error(`${field} must be a short lowercase identifier`);
+  }
+  return normalized;
+}
+
+function source(value: string | number): string {
+  const normalized = String(value).trim();
+  if (!normalized || normalized.length > 512) throw new Error("Provider source ID must be 1-512 characters");
+  return normalized;
+}
+
+/** One-way identity used in artifacts; the raw provider identifier is never persisted. */
+export function providerFingerprint(provider: string, entity: string, sourceId: string | number): string {
+  const material = `${label(provider, "provider")}\0${label(entity, "entity")}\0${source(sourceId)}`;
+  return createHash("sha256").update(material, "utf8").digest("hex");
+}
+
+/** Stable, merchant-neutral Mercora ID derived from a provider identity. */
+export function deterministicProviderId(provider: string, entity: string, sourceId: string | number): string {
+  const providerName = label(provider, "provider");
+  const entityName = label(entity, "entity");
+  return `${providerName}_${entityName}_${providerFingerprint(providerName, entityName, sourceId).slice(0, 24)}`;
+}

--- a/scripts/shopify-migration/lib/logger.ts
+++ b/scripts/shopify-migration/lib/logger.ts
@@ -1,0 +1,65 @@
+export type LogLevel = "info" | "warn" | "error";
+
+export interface StructuredLogRecord {
+  timestamp: string;
+  level: LogLevel;
+  event: string;
+  context?: unknown;
+}
+
+export type LogSink = (record: StructuredLogRecord) => void;
+
+const sensitiveKey = /(?:access.?token|authorization|cookie|secret|password|email|phone|address|first.?name|last.?name|customer.?name)/i;
+const emailLike = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi;
+
+function redactString(value: string, secrets: readonly string[]): string {
+  let redacted = value.replace(emailLike, "[REDACTED]");
+  for (const secret of secrets) {
+    if (secret) redacted = redacted.split(secret).join("[REDACTED]");
+  }
+  return redacted;
+}
+
+export function redactForLog(value: unknown, secrets: readonly string[] = [], key = ""): unknown {
+  if (sensitiveKey.test(key)) return "[REDACTED]";
+  if (typeof value === "string") return redactString(value, secrets);
+  if (Array.isArray(value)) return value.map((item) => redactForLog(item, secrets));
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([childKey, child]) => [
+        redactString(childKey, secrets),
+        redactForLog(child, secrets, childKey),
+      ]),
+    );
+  }
+  return value;
+}
+
+function consoleSink(record: StructuredLogRecord): void {
+  const line = JSON.stringify(record);
+  if (record.level === "error") console.error(line);
+  else if (record.level === "warn") console.warn(line);
+  else console.log(line);
+}
+
+export class MigrationLogger {
+  constructor(
+    private readonly sink: LogSink = consoleSink,
+    private readonly secrets: readonly string[] = [],
+    private readonly clock: () => Date = () => new Date(),
+  ) {}
+
+  private emit(level: LogLevel, event: string, context?: unknown): void {
+    if (!/^[a-z0-9][a-z0-9._-]{0,79}$/.test(event)) throw new Error("Log event must be a stable machine-readable name");
+    this.sink({
+      timestamp: this.clock().toISOString(),
+      level,
+      event,
+      ...(context === undefined ? {} : { context: redactForLog(context, this.secrets) }),
+    });
+  }
+
+  info(event: string, context?: unknown): void { this.emit("info", event, context); }
+  warn(event: string, context?: unknown): void { this.emit("warn", event, context); }
+  error(event: string, context?: unknown): void { this.emit("error", event, context); }
+}

--- a/scripts/shopify-migration/lib/logger.ts
+++ b/scripts/shopify-migration/lib/logger.ts
@@ -9,30 +9,71 @@ export interface StructuredLogRecord {
 
 export type LogSink = (record: StructuredLogRecord) => void;
 
-const sensitiveKey = /(?:access.?token|authorization|cookie|secret|password|email|phone|address|first.?name|last.?name|customer.?name)/i;
-const emailLike = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi;
+const REDACTED = "[REDACTED]";
+const numericField = /^(?:count|sourceCount|recordCount|transformed|written|inserted|migrated|skipped|errors|warnings|retries|attempt|page|pages|maxPages|maxRecords|durationMs|bytes)$/;
+const booleanField = /^(?:dryRun|apply|overwrite|success|completed)$/;
+const labelField = /^(?:entity|entityType|provider|stage|mode|sourceMode|target|operation|resource|status|errorClass)$/;
+const containerField = /^(?:metrics|summary|execution|retry|pagination|result)$/;
+const errorField = /^(?:error|exception)$/;
+const safeLabel = /^[a-zA-Z][a-zA-Z0-9._-]{0,79}$/;
 
-function redactString(value: string, secrets: readonly string[]): string {
-  let redacted = value.replace(emailLike, "[REDACTED]");
-  for (const secret of secrets) {
-    if (secret) redacted = redacted.split(secret).join("[REDACTED]");
-  }
-  return redacted;
+function containsSecret(value: string, secrets: readonly string[]): boolean {
+  return secrets.some((secret) => secret !== "" && value.includes(secret));
 }
 
-export function redactForLog(value: unknown, secrets: readonly string[] = [], key = ""): unknown {
-  if (sensitiveKey.test(key)) return "[REDACTED]";
-  if (typeof value === "string") return redactString(value, secrets);
-  if (Array.isArray(value)) return value.map((item) => redactForLog(item, secrets));
-  if (value && typeof value === "object") {
-    return Object.fromEntries(
-      Object.entries(value as Record<string, unknown>).map(([childKey, child]) => [
-        redactString(childKey, secrets),
-        redactForLog(child, secrets, childKey),
-      ]),
-    );
+function redactValue(
+  value: unknown,
+  secrets: readonly string[],
+  key: string,
+  seen: WeakSet<object>,
+  depth: number,
+): unknown {
+  if (depth > 5) return REDACTED;
+  if (value instanceof Error) {
+    return { errorClass: safeLabel.test(value.name) ? value.name : "Error" };
   }
-  return value;
+  if (numericField.test(key)) {
+    return typeof value === "number" && Number.isFinite(value) ? value : REDACTED;
+  }
+  if (booleanField.test(key)) return typeof value === "boolean" ? value : REDACTED;
+  if (labelField.test(key)) {
+    return typeof value === "string" && safeLabel.test(value) && !containsSecret(value, secrets)
+      ? value
+      : REDACTED;
+  }
+  if (Array.isArray(value)) return REDACTED;
+  if (value && typeof value === "object") {
+    if (key && !containerField.test(key)) return REDACTED;
+    if (seen.has(value)) return REDACTED;
+    seen.add(value);
+    const output: Record<string, unknown> = {};
+    let unknown = false;
+    for (const [childKey, child] of Object.entries(value as Record<string, unknown>).slice(0, 50)) {
+      if (
+        numericField.test(childKey) ||
+        booleanField.test(childKey) ||
+        labelField.test(childKey) ||
+        containerField.test(childKey) ||
+        (errorField.test(childKey) && child instanceof Error)
+      ) {
+        output[childKey] = redactValue(child, secrets, childKey, seen, depth + 1);
+      } else {
+        unknown = true;
+      }
+    }
+    if (unknown) output.redacted = REDACTED;
+    seen.delete(value);
+    return output;
+  }
+  return value === null ? null : REDACTED;
+}
+
+/**
+ * Admit only operational metadata. Unknown keys and all record payloads are
+ * redacted, so customer/order/provider values cannot cross the log boundary.
+ */
+export function redactForLog(value: unknown, secrets: readonly string[] = [], key = ""): unknown {
+  return redactValue(value, secrets, key, new WeakSet<object>(), 0);
 }
 
 function consoleSink(record: StructuredLogRecord): void {

--- a/scripts/shopify-migration/lib/private-atomic-file.ts
+++ b/scripts/shopify-migration/lib/private-atomic-file.ts
@@ -21,7 +21,26 @@ export interface AtomicFileOperations {
   fsync(fd: number): void;
   close(fd: number): void;
   rename(from: string, to: string): void;
+  fsyncDirectory(path: string): void;
   unlink(path: string): void;
+}
+
+function isUnsupportedDirectorySync(error: unknown): boolean {
+  if (!error || typeof error !== "object" || !("code" in error) || typeof error.code !== "string") return false;
+  return ["EINVAL", "ENOTSUP", "ENOSYS"].includes(error.code) ||
+    process.platform === "win32" && ["EACCES", "EISDIR", "EPERM"].includes(error.code);
+}
+
+function fsyncDirectory(path: string): void {
+  let directoryFd: number | undefined;
+  try {
+    directoryFd = openSync(path, "r");
+    fsyncSync(directoryFd);
+  } catch (error) {
+    if (!isUnsupportedDirectorySync(error)) throw error;
+  } finally {
+    if (directoryFd !== undefined) closeSync(directoryFd);
+  }
 }
 
 const nodeOperations: AtomicFileOperations = {
@@ -30,6 +49,7 @@ const nodeOperations: AtomicFileOperations = {
   fsync: fsyncSync,
   close: closeSync,
   rename: renameSync,
+  fsyncDirectory,
   unlink: unlinkSync,
 };
 
@@ -97,6 +117,7 @@ export function atomicWritePrivateFile(
     fd = undefined;
     operations.rename(tempPath, path);
     renamed = true;
+    operations.fsyncDirectory(dirname(path));
   } finally {
     if (fd !== undefined) {
       try { operations.close(fd); } catch { /* preserve the original failure */ }

--- a/scripts/shopify-migration/lib/private-atomic-file.ts
+++ b/scripts/shopify-migration/lib/private-atomic-file.ts
@@ -1,0 +1,108 @@
+import {
+  closeSync,
+  existsSync,
+  fsyncSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  realpathSync,
+  renameSync,
+  unlinkSync,
+  writeSync,
+} from "node:fs";
+import { randomBytes } from "node:crypto";
+import { dirname, isAbsolute, relative, resolve, sep } from "node:path";
+
+const DEFAULT_MAX_PRIVATE_FILE_BYTES = 10 * 1024 * 1024;
+
+export interface AtomicFileOperations {
+  open(path: string, flags: string, mode: number): number;
+  write(fd: number, buffer: Uint8Array, offset: number, length: number): number;
+  fsync(fd: number): void;
+  close(fd: number): void;
+  rename(from: string, to: string): void;
+  unlink(path: string): void;
+}
+
+const nodeOperations: AtomicFileOperations = {
+  open: openSync,
+  write: writeSync,
+  fsync: fsyncSync,
+  close: closeSync,
+  rename: renameSync,
+  unlink: unlinkSync,
+};
+
+function assertNoSymlinkTraversal(root: string, candidate: string): void {
+  const child = relative(root, candidate);
+  if (child.startsWith("..") || isAbsolute(child)) throw new Error("Artifact path escapes the configured output root");
+  let cursor = root;
+  for (const part of child.split(sep)) {
+    cursor = resolve(cursor, part);
+    if (existsSync(cursor) && lstatSync(cursor).isSymbolicLink()) {
+      throw new Error("Artifact path may not traverse a symbolic link");
+    }
+  }
+}
+
+/** Resolve a private artifact below an explicit root without following symlink components. */
+export function resolvePrivateArtifactPath(root: string, requestedPath: string): string {
+  if (!requestedPath || isAbsolute(requestedPath) || requestedPath.includes("\0")) {
+    throw new Error("Artifact path must be a relative path");
+  }
+  mkdirSync(resolve(root), { recursive: true, mode: 0o700 });
+  const absoluteRoot = realpathSync(root);
+  const candidate = resolve(absoluteRoot, requestedPath);
+  assertNoSymlinkTraversal(absoluteRoot, candidate);
+  mkdirSync(dirname(candidate), { recursive: true, mode: 0o700 });
+  assertNoSymlinkTraversal(absoluteRoot, candidate);
+  return candidate;
+}
+
+/**
+ * Replace a bounded private file atomically. The old valid file remains intact
+ * unless a fully written, fsynced 0600 temporary file is ready to rename.
+ */
+export function atomicWritePrivateFile(
+  path: string,
+  content: string | Uint8Array,
+  options: {
+    maxBytes?: number;
+    operations?: Partial<AtomicFileOperations>;
+  } = {},
+): void {
+  if (!isAbsolute(path) || path.includes("\0")) throw new Error("Private artifact destination must be absolute");
+  const maxBytes = options.maxBytes ?? DEFAULT_MAX_PRIVATE_FILE_BYTES;
+  if (!Number.isSafeInteger(maxBytes) || maxBytes < 1 || maxBytes > 100 * 1024 * 1024) {
+    throw new Error("Private artifact byte limit is invalid");
+  }
+  const bytes = typeof content === "string" ? Buffer.from(content, "utf8") : new Uint8Array(content);
+  if (bytes.byteLength > maxBytes) throw new Error(`Private artifact exceeds the ${maxBytes}-byte limit`);
+  const operations = { ...nodeOperations, ...options.operations };
+  const tempPath = resolve(dirname(path), `.${randomBytes(16).toString("hex")}.tmp`);
+  let fd: number | undefined;
+  let renamed = false;
+  try {
+    fd = operations.open(tempPath, "wx", 0o600);
+    let offset = 0;
+    while (offset < bytes.byteLength) {
+      const written = operations.write(fd, bytes, offset, bytes.byteLength - offset);
+      if (!Number.isSafeInteger(written) || written < 1 || written > bytes.byteLength - offset) {
+        throw new Error("Private artifact write did not make safe progress");
+      }
+      offset += written;
+    }
+    operations.fsync(fd);
+    operations.close(fd);
+    fd = undefined;
+    operations.rename(tempPath, path);
+    renamed = true;
+  } finally {
+    if (fd !== undefined) {
+      try { operations.close(fd); } catch { /* preserve the original failure */ }
+    }
+    if (!renamed) {
+      try { operations.unlink(tempPath); } catch { /* an absent temp is already clean */ }
+    }
+  }
+}

--- a/scripts/shopify-migration/lib/shopify-api.ts
+++ b/scripts/shopify-migration/lib/shopify-api.ts
@@ -1,0 +1,234 @@
+import type {
+  ShopifyArticle,
+  ShopifyBlog,
+  ShopifyCollect,
+  ShopifyCollection,
+  ShopifyCustomer,
+  ShopifyOrder,
+  ShopifyPage,
+  ShopifyProduct,
+  ShopifyRedirect,
+} from "./types.js";
+import { validateShopifyApiVersion, validateShopifyOrigin } from "./config.js";
+
+const DEFAULT_MAX_PAGES = 200;
+const DEFAULT_MAX_RECORDS = 50_000;
+const DEFAULT_MAX_RETRIES = 4;
+const DEFAULT_MAX_RETRY_AFTER_MS = 30_000;
+
+export interface ShopifyClientOptions {
+  origin: string;
+  accessToken: string;
+  apiVersion: string;
+  fetch?: typeof fetch;
+  sleep?: (milliseconds: number) => Promise<void>;
+  maxPages?: number;
+  maxRecords?: number;
+  maxRetries?: number;
+  maxRetryAfterMs?: number;
+  includeSensitive?: boolean;
+}
+
+export interface PaginationOptions {
+  query?: Readonly<Record<string, string | number | boolean>>;
+  pageSize?: number;
+  maxPages?: number;
+  maxRecords?: number;
+}
+
+function boundedInteger(value: number, name: string, maximum: number): number {
+  if (!Number.isSafeInteger(value) || value < 1 || value > maximum) {
+    throw new Error(`${name} must be an integer between 1 and ${maximum}`);
+  }
+  return value;
+}
+
+function splitLinkHeader(header: string): string[] {
+  const parts: string[] = [];
+  let start = 0;
+  let inAngle = false;
+  let inQuote = false;
+  let escaped = false;
+  for (let index = 0; index < header.length; index += 1) {
+    const character = header[index];
+    if (escaped) { escaped = false; continue; }
+    if (inQuote && character === "\\") { escaped = true; continue; }
+    if (character === '"' && !inAngle) inQuote = !inQuote;
+    else if (character === "<" && !inQuote) inAngle = true;
+    else if (character === ">" && !inQuote) inAngle = false;
+    else if (character === "," && !inAngle && !inQuote) {
+      parts.push(header.slice(start, index).trim());
+      start = index + 1;
+    }
+  }
+  if (inAngle || inQuote || escaped) throw new Error("Malformed Shopify Link header");
+  parts.push(header.slice(start).trim());
+  return parts.filter(Boolean);
+}
+
+export function parseNextLink(header: string | null, currentUrl: URL): URL | undefined {
+  if (!header) return undefined;
+  const matches: URL[] = [];
+  for (const part of splitLinkHeader(header)) {
+    const target = /^<([^<>]+)>/.exec(part)?.[1];
+    if (!target) throw new Error("Malformed Shopify Link header target");
+    const parameters = part.slice(part.indexOf(">") + 1).split(";").map((item) => item.trim()).filter(Boolean);
+    let next = false;
+    for (const parameter of parameters) {
+      const match = /^rel\s*=\s*(?:"([^"]*)"|([^\s;]+))$/i.exec(parameter);
+      if (match && (match[1] ?? match[2]).toLowerCase().split(/\s+/).includes("next")) next = true;
+    }
+    if (next) matches.push(new URL(target, currentUrl));
+  }
+  if (matches.length > 1) throw new Error("Shopify Link header contains multiple rel=next targets");
+  return matches[0];
+}
+
+function retryAfterMilliseconds(value: string | null, now = Date.now()): number {
+  if (!value) return 1_000;
+  const seconds = Number(value);
+  if (Number.isFinite(seconds) && seconds >= 0) return Math.ceil(seconds * 1_000);
+  const date = Date.parse(value);
+  return Number.isFinite(date) ? Math.max(0, date - now) : 1_000;
+}
+
+export class ShopifyClient {
+  readonly origin: string;
+  readonly apiVersion: string;
+  private readonly accessToken: string;
+  private readonly fetcher: typeof fetch;
+  private readonly sleep: (milliseconds: number) => Promise<void>;
+  private readonly maxPages: number;
+  private readonly maxRecords: number;
+  private readonly maxRetries: number;
+  private readonly maxRetryAfterMs: number;
+  private readonly includeSensitive: boolean;
+  private readonly apiPathPrefix: string;
+
+  constructor(options: ShopifyClientOptions) {
+    this.origin = validateShopifyOrigin(options.origin);
+    this.apiVersion = validateShopifyApiVersion(options.apiVersion);
+    if (!options.accessToken.trim()) throw new Error("Shopify access token is required");
+    this.accessToken = options.accessToken;
+    this.fetcher = options.fetch ?? fetch;
+    this.sleep = options.sleep ?? ((milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)));
+    this.maxPages = boundedInteger(options.maxPages ?? DEFAULT_MAX_PAGES, "maxPages", 10_000);
+    this.maxRecords = boundedInteger(options.maxRecords ?? DEFAULT_MAX_RECORDS, "maxRecords", 1_000_000);
+    this.maxRetries = boundedInteger((options.maxRetries ?? DEFAULT_MAX_RETRIES) + 1, "maxRetries", 21) - 1;
+    this.maxRetryAfterMs = boundedInteger(options.maxRetryAfterMs ?? DEFAULT_MAX_RETRY_AFTER_MS, "maxRetryAfterMs", 300_000);
+    this.includeSensitive = options.includeSensitive === true;
+    this.apiPathPrefix = `/admin/api/${this.apiVersion}/`;
+  }
+
+  private assertAllowedUrl(url: URL): void {
+    if (
+      url.origin !== this.origin ||
+      !url.pathname.startsWith(this.apiPathPrefix) ||
+      /%2e|%2f|%5c/i.test(url.pathname) ||
+      url.username !== "" ||
+      url.password !== ""
+    ) {
+      throw new Error("Shopify pagination target escaped the configured Admin API origin or version path");
+    }
+  }
+
+  private async request(url: URL): Promise<Response> {
+    this.assertAllowedUrl(url);
+    for (let attempt = 0; ; attempt += 1) {
+      const response = await this.fetcher(url, {
+        method: "GET",
+        redirect: "error",
+        headers: {
+          Accept: "application/json",
+          "X-Shopify-Access-Token": this.accessToken,
+        },
+      });
+      if (response.status !== 429) {
+        if (!response.ok) throw new Error(`Shopify API request failed with HTTP ${response.status}`);
+        return response;
+      }
+      if (attempt >= this.maxRetries) throw new Error("Shopify API rate limit retry budget exhausted");
+      const delay = Math.min(retryAfterMilliseconds(response.headers.get("retry-after")), this.maxRetryAfterMs);
+      await response.body?.cancel();
+      await this.sleep(delay);
+    }
+  }
+
+  async fetchPaginated<T>(resource: string, key: string, options: PaginationOptions = {}): Promise<T[]> {
+    if (!/^[a-z][a-z0-9_-]*(?:\/[a-z0-9_-]+)*\.json$/.test(resource)) {
+      throw new Error("Shopify resource must be a safe relative JSON endpoint");
+    }
+    if (!/^[a-z][a-z0-9_]*$/.test(key)) throw new Error("Shopify response key is invalid");
+    const pageSize = boundedInteger(options.pageSize ?? 250, "pageSize", 250);
+    const maxPages = boundedInteger(options.maxPages ?? this.maxPages, "maxPages", this.maxPages);
+    const maxRecords = boundedInteger(options.maxRecords ?? this.maxRecords, "maxRecords", this.maxRecords);
+    let next = new URL(`${this.apiPathPrefix}${resource}`, this.origin);
+    next.searchParams.set("limit", String(pageSize));
+    for (const [name, value] of Object.entries(options.query ?? {})) next.searchParams.set(name, String(value));
+
+    const visited = new Set<string>();
+    const records: T[] = [];
+    let pages = 0;
+    while (next) {
+      this.assertAllowedUrl(next);
+      if (visited.has(next.href)) throw new Error("Shopify pagination cycle detected");
+      if (pages >= maxPages) throw new Error(`Shopify pagination exceeded ${maxPages} pages`);
+      visited.add(next.href);
+      pages += 1;
+
+      const response = await this.request(next);
+      const payload: unknown = await response.json();
+      const page = payload && typeof payload === "object" ? (payload as Record<string, unknown>)[key] : undefined;
+      if (!Array.isArray(page)) throw new Error(`Shopify response did not contain an array at ${key}`);
+      if (records.length + page.length > maxRecords) throw new Error(`Shopify pagination exceeded ${maxRecords} records`);
+      records.push(...(page as T[]));
+
+      const candidate = parseNextLink(response.headers.get("link"), next);
+      if (!candidate) break;
+      this.assertAllowedUrl(candidate);
+      next = candidate;
+    }
+    return records;
+  }
+
+  fetchProducts(options?: PaginationOptions): Promise<ShopifyProduct[]> {
+    return this.fetchPaginated("products.json", "products", options);
+  }
+  fetchCollections(options?: PaginationOptions): Promise<ShopifyCollection[]> {
+    return Promise.all([
+      this.fetchPaginated<ShopifyCollection>("custom_collections.json", "custom_collections", options),
+      this.fetchPaginated<ShopifyCollection>("smart_collections.json", "smart_collections", options),
+    ]).then(([custom, smart]) => [
+      ...custom.map((collection) => ({ ...collection, collection_type: "custom" as const })),
+      ...smart.map((collection) => ({ ...collection, collection_type: "smart" as const })),
+    ]);
+  }
+  fetchCollects(options?: PaginationOptions): Promise<ShopifyCollect[]> {
+    return this.fetchPaginated("collects.json", "collects", options);
+  }
+  fetchCustomers(options?: PaginationOptions): Promise<ShopifyCustomer[]> {
+    if (!this.includeSensitive) throw new Error("Customer extraction requires confirmed sensitive-data access");
+    return this.fetchPaginated("customers.json", "customers", options);
+  }
+  fetchOrders(options: PaginationOptions = {}): Promise<ShopifyOrder[]> {
+    if (!this.includeSensitive) throw new Error("Order extraction requires confirmed sensitive-data access");
+    return this.fetchPaginated("orders.json", "orders", {
+      ...options,
+      query: { ...options.query, status: "any" },
+    });
+  }
+  fetchPages(options?: PaginationOptions): Promise<ShopifyPage[]> {
+    return this.fetchPaginated("pages.json", "pages", options);
+  }
+  fetchBlogs(options?: PaginationOptions): Promise<ShopifyBlog[]> {
+    return this.fetchPaginated("blogs.json", "blogs", options);
+  }
+  fetchArticles(blogId: string | number, options?: PaginationOptions): Promise<ShopifyArticle[]> {
+    const id = String(blogId);
+    if (!/^\d+$/.test(id)) throw new Error("Shopify blog ID must be numeric");
+    return this.fetchPaginated(`blogs/${id}/articles.json`, "articles", options);
+  }
+  fetchRedirects(options?: PaginationOptions): Promise<ShopifyRedirect[]> {
+    return this.fetchPaginated("redirects.json", "redirects", options);
+  }
+}

--- a/scripts/shopify-migration/lib/shopify-api.ts
+++ b/scripts/shopify-migration/lib/shopify-api.ts
@@ -15,6 +15,8 @@ const DEFAULT_MAX_PAGES = 200;
 const DEFAULT_MAX_RECORDS = 50_000;
 const DEFAULT_MAX_RETRIES = 4;
 const DEFAULT_MAX_RETRY_AFTER_MS = 30_000;
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+const DEFAULT_MAX_RESPONSE_BYTES = 25 * 1024 * 1024;
 
 const PUBLIC_RESOURCES = new Set([
   "blogs.json",
@@ -48,6 +50,8 @@ export interface ShopifyClientOptions {
   maxRecords?: number;
   maxRetries?: number;
   maxRetryAfterMs?: number;
+  timeoutMs?: number;
+  maxResponseBytes?: number;
   includeSensitive?: boolean;
 }
 
@@ -100,7 +104,13 @@ export function parseNextLink(header: string | null, currentUrl: URL): URL | und
       const match = /^rel\s*=\s*(?:"([^"]*)"|([^\s;]+))$/i.exec(parameter);
       if (match && (match[1] ?? match[2]).toLowerCase().split(/\s+/).includes("next")) next = true;
     }
-    if (next) matches.push(new URL(target, currentUrl));
+    if (next) {
+      try {
+        matches.push(new URL(target, currentUrl));
+      } catch {
+        throw new Error("Malformed Shopify Link header target");
+      }
+    }
   }
   if (matches.length > 1) throw new Error("Shopify Link header contains multiple rel=next targets");
   return matches[0];
@@ -114,6 +124,68 @@ function retryAfterMilliseconds(value: string | null, now = Date.now()): number 
   return Number.isFinite(date) ? Math.max(0, date - now) : 1_000;
 }
 
+class ShopifyTransportError extends Error {}
+
+function cancelBody(response: Response): void {
+  void response.body?.cancel().catch(() => undefined);
+}
+
+async function readBoundedJson(
+  response: Response,
+  maximumBytes: number,
+  expired: Promise<never>,
+): Promise<unknown> {
+  const declaredLength = response.headers.get("content-length");
+  if (declaredLength !== null) {
+    if (!/^(?:0|[1-9][0-9]*)$/u.test(declaredLength)) {
+      cancelBody(response);
+      throw new ShopifyTransportError("Shopify API response Content-Length is invalid");
+    }
+    const bytes = Number(declaredLength);
+    if (!Number.isSafeInteger(bytes) || bytes > maximumBytes) {
+      cancelBody(response);
+      throw new ShopifyTransportError(`Shopify API response exceeds ${maximumBytes} bytes`);
+    }
+  }
+  if (!response.body) throw new ShopifyTransportError("Shopify API response body is missing");
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let length = 0;
+  try {
+    while (true) {
+      const { done, value } = await Promise.race([reader.read(), expired]);
+      if (done) break;
+      length += value.byteLength;
+      if (length > maximumBytes) {
+        await reader.cancel().catch(() => undefined);
+        throw new ShopifyTransportError(`Shopify API response exceeds ${maximumBytes} bytes`);
+      }
+      chunks.push(value);
+    }
+  } catch (error) {
+    await reader.cancel().catch(() => undefined);
+    throw error;
+  } finally {
+    reader.releaseLock();
+  }
+
+  if (declaredLength !== null && Number(declaredLength) !== length) {
+    throw new ShopifyTransportError("Shopify API response Content-Length does not match its body");
+  }
+  const bytes = new Uint8Array(length);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  try {
+    return JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(bytes)) as unknown;
+  } catch {
+    throw new ShopifyTransportError("Shopify API response is not valid JSON");
+  }
+}
+
 export class ShopifyClient {
   readonly origin: string;
   readonly apiVersion: string;
@@ -124,6 +196,8 @@ export class ShopifyClient {
   private readonly maxRecords: number;
   private readonly maxRetries: number;
   private readonly maxRetryAfterMs: number;
+  private readonly timeoutMs: number;
+  private readonly maxResponseBytes: number;
   private readonly includeSensitive: boolean;
   private readonly apiPathPrefix: string;
 
@@ -138,6 +212,12 @@ export class ShopifyClient {
     this.maxRecords = boundedInteger(options.maxRecords ?? DEFAULT_MAX_RECORDS, "maxRecords", 1_000_000);
     this.maxRetries = boundedInteger((options.maxRetries ?? DEFAULT_MAX_RETRIES) + 1, "maxRetries", 21) - 1;
     this.maxRetryAfterMs = boundedInteger(options.maxRetryAfterMs ?? DEFAULT_MAX_RETRY_AFTER_MS, "maxRetryAfterMs", 300_000);
+    this.timeoutMs = boundedInteger(options.timeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS, "timeoutMs", 300_000);
+    this.maxResponseBytes = boundedInteger(
+      options.maxResponseBytes ?? DEFAULT_MAX_RESPONSE_BYTES,
+      "maxResponseBytes",
+      100 * 1024 * 1024,
+    );
     this.includeSensitive = options.includeSensitive === true;
     this.apiPathPrefix = `/admin/api/${this.apiVersion}/`;
   }
@@ -154,25 +234,54 @@ export class ShopifyClient {
     }
   }
 
-  private async request(url: URL): Promise<Response> {
+  private async request(url: URL): Promise<{ payload: unknown; link: string | null }> {
     this.assertAllowedUrl(url);
     for (let attempt = 0; ; attempt += 1) {
-      const response = await this.fetcher(url, {
-        method: "GET",
-        redirect: "error",
-        headers: {
-          Accept: "application/json",
-          "X-Shopify-Access-Token": this.accessToken,
-        },
+      const controller = new AbortController();
+      let timeout: ReturnType<typeof setTimeout> | undefined;
+      const expired = new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => {
+          controller.abort();
+          reject(new ShopifyTransportError("Shopify API request timed out"));
+        }, this.timeoutMs);
       });
-      if (response.status !== 429) {
-        if (!response.ok) throw new Error(`Shopify API request failed with HTTP ${response.status}`);
-        return response;
+      try {
+        const pending = this.fetcher(url, {
+          method: "GET",
+          redirect: "error",
+          signal: controller.signal,
+          headers: {
+            Accept: "application/json",
+            "X-Shopify-Access-Token": this.accessToken,
+          },
+        });
+        void pending.then((lateResponse) => {
+          if (controller.signal.aborted) cancelBody(lateResponse);
+        }).catch(() => undefined);
+        const response = await Promise.race([pending, expired]);
+        if (response.status === 429) {
+          cancelBody(response);
+          if (attempt >= this.maxRetries) {
+            throw new ShopifyTransportError("Shopify API rate limit retry budget exhausted");
+          }
+          const delay = Math.min(retryAfterMilliseconds(response.headers.get("retry-after")), this.maxRetryAfterMs);
+          if (timeout) clearTimeout(timeout);
+          timeout = undefined;
+          await this.sleep(delay);
+          continue;
+        }
+        if (!response.ok) {
+          cancelBody(response);
+          throw new ShopifyTransportError(`Shopify API request failed with HTTP ${response.status}`);
+        }
+        const payload = await readBoundedJson(response, this.maxResponseBytes, expired);
+        return { payload, link: response.headers.get("link") };
+      } catch (error) {
+        if (error instanceof ShopifyTransportError) throw error;
+        throw new ShopifyTransportError("Shopify API request failed");
+      } finally {
+        if (timeout) clearTimeout(timeout);
       }
-      if (attempt >= this.maxRetries) throw new Error("Shopify API rate limit retry budget exhausted");
-      const delay = Math.min(retryAfterMilliseconds(response.headers.get("retry-after")), this.maxRetryAfterMs);
-      await response.body?.cancel();
-      await this.sleep(delay);
     }
   }
 
@@ -200,13 +309,13 @@ export class ShopifyClient {
       pages += 1;
 
       const response = await this.request(next);
-      const payload: unknown = await response.json();
+      const payload = response.payload;
       const page = payload && typeof payload === "object" ? (payload as Record<string, unknown>)[key] : undefined;
       if (!Array.isArray(page)) throw new Error(`Shopify response did not contain an array at ${key}`);
       if (records.length + page.length > maxRecords) throw new Error(`Shopify pagination exceeded ${maxRecords} records`);
       records.push(...(page as T[]));
 
-      const candidate = parseNextLink(response.headers.get("link"), next);
+      const candidate = parseNextLink(response.link, next);
       if (!candidate) break;
       this.assertAllowedUrl(candidate);
       next = candidate;

--- a/scripts/shopify-migration/lib/shopify-api.ts
+++ b/scripts/shopify-migration/lib/shopify-api.ts
@@ -16,6 +16,28 @@ const DEFAULT_MAX_RECORDS = 50_000;
 const DEFAULT_MAX_RETRIES = 4;
 const DEFAULT_MAX_RETRY_AFTER_MS = 30_000;
 
+const PUBLIC_RESOURCES = new Set([
+  "blogs.json",
+  "collects.json",
+  "custom_collections.json",
+  "pages.json",
+  "products.json",
+  "redirects.json",
+  "smart_collections.json",
+]);
+const SENSITIVE_RESOURCES = new Set(["customers.json", "orders.json"]);
+
+function assertSupportedResource(resource: string, includeSensitive: boolean): void {
+  const articleResource = /^blogs\/\d+\/articles\.json$/u.test(resource);
+  if (SENSITIVE_RESOURCES.has(resource)) {
+    if (!includeSensitive) throw new Error("Sensitive Shopify extraction requires confirmed sensitive-data access");
+    return;
+  }
+  if (!PUBLIC_RESOURCES.has(resource) && !articleResource) {
+    throw new Error("Shopify resource is not supported by this migration toolkit");
+  }
+}
+
 export interface ShopifyClientOptions {
   origin: string;
   accessToken: string;
@@ -158,6 +180,7 @@ export class ShopifyClient {
     if (!/^[a-z][a-z0-9_-]*(?:\/[a-z0-9_-]+)*\.json$/.test(resource)) {
       throw new Error("Shopify resource must be a safe relative JSON endpoint");
     }
+    assertSupportedResource(resource, this.includeSensitive);
     if (!/^[a-z][a-z0-9_]*$/.test(key)) throw new Error("Shopify response key is invalid");
     const pageSize = boundedInteger(options.pageSize ?? 250, "pageSize", 250);
     const maxPages = boundedInteger(options.maxPages ?? this.maxPages, "maxPages", this.maxPages);

--- a/scripts/shopify-migration/lib/types.ts
+++ b/scripts/shopify-migration/lib/types.ts
@@ -1,0 +1,267 @@
+/** Transport and pipeline types shared by the operator-only migration tools. */
+
+export type ShopifyId = number | string;
+
+export interface ExtractResult<T> {
+  records: T[];
+  source: "api" | "file";
+  extractedAt: string;
+}
+
+export interface TransformResult<TSource, TTarget> {
+  records: TTarget[];
+  idMap: Map<string, string>;
+  skipped: Array<{ record: TSource; reason: string }>;
+  warnings: string[];
+}
+
+export interface LoadResult {
+  entity: string;
+  inserted: number;
+  skipped: number;
+  errors: Array<{ id: string; error: string }>;
+}
+
+export interface ShopifyProductImage {
+  id?: ShopifyId;
+  src: string;
+  position?: number;
+  alt?: string | null;
+  width?: number;
+  height?: number;
+  variant_ids?: ShopifyId[];
+}
+
+export interface ShopifyProductOption {
+  id?: ShopifyId;
+  name: string;
+  position?: number;
+  values: string[];
+}
+
+export interface ShopifyProductVariant {
+  id?: ShopifyId;
+  product_id?: ShopifyId;
+  title?: string;
+  sku?: string;
+  price: string;
+  compare_at_price?: string | null;
+  grams?: number;
+  weight?: number;
+  weight_unit?: string;
+  inventory_quantity?: number;
+  inventory_policy?: "deny" | "continue" | string;
+  inventory_management?: string | null;
+  fulfillment_service?: string;
+  requires_shipping?: boolean;
+  taxable?: boolean;
+  barcode?: string | null;
+  option1?: string | null;
+  option2?: string | null;
+  option3?: string | null;
+  image_id?: ShopifyId | null;
+  position?: number;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface ShopifyProduct {
+  id: ShopifyId;
+  title: string;
+  body_html?: string;
+  handle: string;
+  vendor?: string;
+  product_type?: string;
+  tags?: string;
+  status?: "active" | "draft" | "archived" | string;
+  published_at?: string | null;
+  created_at?: string;
+  updated_at?: string;
+  variants: ShopifyProductVariant[];
+  images: ShopifyProductImage[];
+  options?: ShopifyProductOption[];
+  image?: ShopifyProductImage | null;
+  seo_title?: string;
+  seo_description?: string;
+}
+
+export interface ShopifyCollectionImage {
+  src: string;
+  alt?: string | null;
+  width?: number;
+  height?: number;
+}
+
+export interface ShopifyCollection {
+  id: ShopifyId;
+  title: string;
+  handle: string;
+  body_html?: string;
+  image?: ShopifyCollectionImage | null;
+  published_at?: string | null;
+  sort_order?: string;
+  collection_type?: "custom" | "smart";
+  products_count?: number;
+  updated_at?: string;
+}
+
+export interface ShopifyCollect {
+  id: ShopifyId;
+  collection_id: ShopifyId;
+  product_id: ShopifyId;
+  position?: number;
+  sort_value?: string;
+}
+
+export interface ShopifyCustomerAddress {
+  id?: ShopifyId;
+  customer_id?: ShopifyId;
+  first_name?: string;
+  last_name?: string;
+  company?: string;
+  address1?: string;
+  address2?: string;
+  city?: string;
+  province?: string;
+  province_code?: string;
+  country?: string;
+  country_code?: string;
+  zip?: string;
+  phone?: string;
+  default?: boolean;
+}
+
+export interface ShopifyCustomer {
+  id: ShopifyId;
+  email?: string;
+  first_name?: string;
+  last_name?: string;
+  phone?: string;
+  verified_email?: boolean;
+  total_spent?: string;
+  orders_count?: number;
+  accepts_marketing?: boolean;
+  tags?: string;
+  created_at?: string;
+  updated_at?: string;
+  default_address?: ShopifyCustomerAddress | null;
+  addresses?: ShopifyCustomerAddress[];
+}
+
+export interface ShopifyOrderLineItem {
+  id?: ShopifyId;
+  product_id?: ShopifyId | null;
+  variant_id?: ShopifyId | null;
+  title: string;
+  variant_title?: string | null;
+  sku?: string;
+  quantity: number;
+  price: string;
+  total_discount?: string;
+  requires_shipping?: boolean;
+}
+
+export interface ShopifyOrder {
+  id: ShopifyId;
+  name?: string;
+  order_number?: number;
+  email?: string;
+  customer?: { id: ShopifyId } | null;
+  financial_status?: string;
+  fulfillment_status?: string | null;
+  total_price: string;
+  subtotal_price?: string;
+  total_tax?: string;
+  total_discounts?: string;
+  total_shipping_price_set?: { shop_money?: { amount: string; currency_code: string } };
+  currency?: string;
+  line_items: ShopifyOrderLineItem[];
+  shipping_address?: ShopifyCustomerAddress | null;
+  billing_address?: ShopifyCustomerAddress | null;
+  created_at?: string;
+  updated_at?: string;
+  closed_at?: string | null;
+  cancelled_at?: string | null;
+  cancel_reason?: string | null;
+  tags?: string;
+  note?: string | null;
+}
+
+export interface ShopifyPage {
+  id: ShopifyId;
+  title: string;
+  handle: string;
+  body_html?: string;
+  author?: string;
+  published_at?: string | null;
+  created_at?: string;
+  updated_at?: string;
+  template_suffix?: string | null;
+}
+
+export interface ShopifyBlog {
+  id: ShopifyId;
+  title: string;
+  handle: string;
+  commentable?: "no" | "moderate" | "yes" | string;
+  feedburner?: string | null;
+  feedburner_location?: string | null;
+  created_at?: string;
+  updated_at?: string;
+  tags?: string;
+}
+
+export interface ShopifyArticle {
+  id: ShopifyId;
+  blog_id: ShopifyId;
+  title: string;
+  handle: string;
+  body_html?: string;
+  summary_html?: string | null;
+  author?: string;
+  user_id?: ShopifyId;
+  tags?: string;
+  image?: ShopifyProductImage | null;
+  published?: boolean;
+  published_at?: string | null;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface ShopifyRedirect {
+  id: ShopifyId;
+  path: string;
+  target: string;
+}
+
+/** Raw Judge.me CSV row. Unknown columns remain strings and are size bounded by the reader. */
+export type JudgeMeFileRow = Record<string, string | undefined> & {
+  title?: string;
+  body?: string;
+  rating?: string;
+  review_date?: string;
+  created_at?: string;
+  reviewer_name?: string;
+  reviewer_email?: string;
+  product_id?: string;
+  product_handle?: string;
+  reply?: string;
+  picture_urls?: string;
+  source?: string;
+  status?: string;
+};
+
+export interface JudgeMeReview {
+  title?: string;
+  body: string;
+  rating: number;
+  review_date?: string;
+  reviewer_name?: string;
+  reviewer_email?: string;
+  product_id?: string;
+  product_handle?: string;
+  reply?: string;
+  picture_urls?: string;
+  source?: string;
+  status?: string;
+}

--- a/scripts/shopify-migration/lib/wrangler-target.ts
+++ b/scripts/shopify-migration/lib/wrangler-target.ts
@@ -141,7 +141,7 @@ export function resolveMediaTarget(config: WranglerConfig, options: WranglerTarg
 
 export function resolveDatabaseTarget(config: WranglerConfig, options: WranglerTargetOptions): {
   databaseName: string;
-  databaseId: string;
+  databaseId?: string;
   target: WranglerTarget;
   environment?: string;
 } {
@@ -149,7 +149,14 @@ export function resolveDatabaseTarget(config: WranglerConfig, options: WranglerT
   const databaseName = requiredName(binding.database_name, "DB database_name");
   const databaseId = options.target === "preview"
     ? requiredName(binding.preview_database_id, "DB preview_database_id")
-    : requiredName(binding.database_id, "DB database_id");
+    : options.target === "production"
+      ? requiredName(binding.database_id, "DB database_id")
+      : undefined;
   assertExpected(databaseName, options.expectedName, "DB database");
-  return { databaseName, databaseId, target: options.target, ...(options.environment ? { environment: options.environment } : {}) };
+  return {
+    databaseName,
+    ...(databaseId ? { databaseId } : {}),
+    target: options.target,
+    ...(options.environment ? { environment: options.environment } : {}),
+  };
 }

--- a/scripts/shopify-migration/lib/wrangler-target.ts
+++ b/scripts/shopify-migration/lib/wrangler-target.ts
@@ -101,7 +101,7 @@ export function parseWranglerJsonc(text: string): WranglerConfig {
 function section(config: WranglerConfig, environment: string | undefined): WranglerSection {
   if (!environment) return config;
   const selected = config.env?.[environment];
-  if (!selected || typeof selected !== "object") {
+  if (!selected || typeof selected !== "object" || Array.isArray(selected)) {
     throw new Error(`Wrangler environment "${environment}" is not configured; refusing root fallback`);
   }
   return selected;

--- a/scripts/shopify-migration/lib/wrangler-target.ts
+++ b/scripts/shopify-migration/lib/wrangler-target.ts
@@ -1,0 +1,155 @@
+export type WranglerTarget = "local" | "preview" | "production";
+
+interface D1Binding {
+  binding?: unknown;
+  database_name?: unknown;
+  database_id?: unknown;
+  preview_database_id?: unknown;
+}
+
+interface R2Binding {
+  binding?: unknown;
+  bucket_name?: unknown;
+  preview_bucket_name?: unknown;
+}
+
+interface WranglerSection {
+  d1_databases?: unknown;
+  r2_buckets?: unknown;
+}
+
+interface WranglerConfig extends WranglerSection {
+  env?: Record<string, WranglerSection>;
+}
+
+export interface WranglerTargetOptions {
+  target: WranglerTarget;
+  environment?: string;
+  expectedName?: string;
+}
+
+const MAX_CONFIG_BYTES = 1024 * 1024;
+const resourceName = /^[a-z0-9][a-z0-9_-]{1,126}[a-z0-9]$/i;
+
+/** Remove JSONC comments and trailing commas without altering string contents. */
+export function stripJsonc(text: string): string {
+  let uncommented = "";
+  let inString = false;
+  let escaped = false;
+  let lineComment = false;
+  let blockComment = false;
+  for (let index = 0; index < text.length; index += 1) {
+    const current = text[index];
+    const next = text[index + 1];
+    if (lineComment) {
+      if (current === "\n") { lineComment = false; uncommented += current; }
+      continue;
+    }
+    if (blockComment) {
+      if (current === "*" && next === "/") { blockComment = false; index += 1; }
+      continue;
+    }
+    if (inString) {
+      uncommented += current;
+      if (escaped) escaped = false;
+      else if (current === "\\") escaped = true;
+      else if (current === '"') inString = false;
+      continue;
+    }
+    if (current === '"') { inString = true; uncommented += current; }
+    else if (current === "/" && next === "/") { lineComment = true; index += 1; }
+    else if (current === "/" && next === "*") { blockComment = true; index += 1; }
+    else uncommented += current;
+  }
+  if (inString || blockComment) throw new Error("Wrangler JSONC is truncated");
+
+  let output = "";
+  inString = false;
+  escaped = false;
+  for (let index = 0; index < uncommented.length; index += 1) {
+    const current = uncommented[index];
+    if (inString) {
+      output += current;
+      if (escaped) escaped = false;
+      else if (current === "\\") escaped = true;
+      else if (current === '"') inString = false;
+      continue;
+    }
+    if (current === '"') { inString = true; output += current; continue; }
+    if (current === ",") {
+      let next = index + 1;
+      while (/\s/.test(uncommented[next] ?? "")) next += 1;
+      if (uncommented[next] === "}" || uncommented[next] === "]") continue;
+    }
+    output += current;
+  }
+  return output;
+}
+
+export function parseWranglerJsonc(text: string): WranglerConfig {
+  if (Buffer.byteLength(text, "utf8") > MAX_CONFIG_BYTES) throw new Error("Wrangler config is too large");
+  let parsed: unknown;
+  try { parsed = JSON.parse(stripJsonc(text)); }
+  catch (error) {
+    if (error instanceof Error && error.message === "Wrangler JSONC is truncated") throw error;
+    throw new Error("Wrangler config is not valid JSONC");
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) throw new Error("Wrangler config must be an object");
+  return parsed as WranglerConfig;
+}
+
+function section(config: WranglerConfig, environment: string | undefined): WranglerSection {
+  if (!environment) return config;
+  const selected = config.env?.[environment];
+  if (!selected || typeof selected !== "object") {
+    throw new Error(`Wrangler environment "${environment}" is not configured; refusing root fallback`);
+  }
+  return selected;
+}
+
+function exactBinding<T extends { binding?: unknown }>(value: unknown, binding: string, kind: string): T {
+  if (!Array.isArray(value)) throw new Error(`No ${kind} bindings are configured in the selected Wrangler section`);
+  const matches = value.filter((candidate): candidate is T =>
+    Boolean(candidate) && typeof candidate === "object" && (candidate as T).binding === binding);
+  if (matches.length !== 1) throw new Error(`Expected exactly one ${kind} binding named ${binding}`);
+  return matches[0];
+}
+
+function requiredName(value: unknown, field: string): string {
+  if (typeof value !== "string" || !resourceName.test(value)) throw new Error(`${field} is missing or invalid`);
+  return value;
+}
+
+function assertExpected(actual: string, expected: string | undefined, kind: string): void {
+  if (expected !== undefined && actual !== expected) {
+    throw new Error(`Configured ${kind} "${actual}" does not match expected name; refusing override`);
+  }
+}
+
+export function resolveMediaTarget(config: WranglerConfig, options: WranglerTargetOptions): {
+  bucketName: string;
+  target: WranglerTarget;
+  environment?: string;
+} {
+  const binding = exactBinding<R2Binding>(section(config, options.environment).r2_buckets, "MEDIA", "R2");
+  const bucketName = options.target === "preview"
+    ? requiredName(binding.preview_bucket_name, "MEDIA preview_bucket_name")
+    : requiredName(binding.bucket_name, "MEDIA bucket_name");
+  assertExpected(bucketName, options.expectedName, "MEDIA bucket");
+  return { bucketName, target: options.target, ...(options.environment ? { environment: options.environment } : {}) };
+}
+
+export function resolveDatabaseTarget(config: WranglerConfig, options: WranglerTargetOptions): {
+  databaseName: string;
+  databaseId: string;
+  target: WranglerTarget;
+  environment?: string;
+} {
+  const binding = exactBinding<D1Binding>(section(config, options.environment).d1_databases, "DB", "D1");
+  const databaseName = requiredName(binding.database_name, "DB database_name");
+  const databaseId = options.target === "preview"
+    ? requiredName(binding.preview_database_id, "DB preview_database_id")
+    : requiredName(binding.database_id, "DB database_id");
+  assertExpected(databaseName, options.expectedName, "DB database");
+  return { databaseName, databaseId, target: options.target, ...(options.environment ? { environment: options.environment } : {}) };
+}

--- a/scripts/shopify-migration/orchestrator.ts
+++ b/scripts/shopify-migration/orchestrator.ts
@@ -326,6 +326,14 @@ export async function orchestrateMigration(options: OrchestrateMigrationOptions)
       unresolvedCustomer: options.domain.unresolvedCustomer,
     })
     : { records: [], idMap: new Map<string, string>(), skipped: [], warnings: [] };
+  const preflightReviews = options.config.execution.includeSensitive
+    ? transformJudgeMeReviews(normalizedReviews.records, {
+      generatedAt,
+      productIds,
+      reviewAttributions: options.domain.reviewAttributions,
+      ...(options.domain.verifiedPurchases ? { verifiedPurchases: options.domain.verifiedPurchases } : {}),
+    })
+    : { records: [], idMap: new Map<string, string>(), skipped: [], warnings: [] };
 
   const publicInput: MaterializedD1Input = {
     categories: categories.records,
@@ -338,9 +346,9 @@ export async function orchestrateMigration(options: OrchestrateMigrationOptions)
   };
   const preflightPlan = buildD1ImportPlan(publicInput, { overwrite: options.config.execution.overwrite });
 
-  const warningCount = categories.warnings.length + products.warnings.length + pages.warnings.length +
+  const baseWarningCount = categories.warnings.length + products.warnings.length + pages.warnings.length +
     blog.warnings.length + redirects.warnings.length + customerPlans.warnings.length +
-    normalizedReviews.warnings.length + preflightOrders.warnings.length;
+    normalizedReviews.warnings.length;
 
   if (options.config.execution.dryRun) {
     return {
@@ -356,13 +364,18 @@ export async function orchestrateMigration(options: OrchestrateMigrationOptions)
         blogs: summary(source.articles.length, blog.records.length, blog.skipped.length, 0),
         customers: summary(source.customers.length, customerPlans.records.length, customerPlans.skipped.length, 0),
         orders: summary(source.orders.length, preflightOrders.records.length, preflightOrders.skipped.length, 0),
-        reviews: summary(source.judgeMeRows.length, normalizedReviews.records.length, normalizedReviews.skipped.length, 0),
+        reviews: summary(
+          source.judgeMeRows.length,
+          preflightReviews.records.length,
+          normalizedReviews.skipped.length + preflightReviews.skipped.length,
+          0,
+        ),
         redirects: summary(source.redirects.length, redirects.records.length, redirects.skipped.length, 0),
       },
       media: { planned: plannedMedia(mediaPlans).length, persisted: 0 },
       clerk: { created: 0, existing: 0, reconciliation: 0 },
       d1: dryRunD1(preflightPlan),
-      warnings: warningCount,
+      warnings: baseWarningCount + preflightOrders.warnings.length + preflightReviews.warnings.length,
     };
   }
 
@@ -384,7 +397,7 @@ export async function orchestrateMigration(options: OrchestrateMigrationOptions)
 
   let clerk: ClerkProvisioningResult = { idMap: new Map(), created: 0, existing: 0, reconciliation: [] };
   let customers = preflightCustomers;
-  if (options.config.execution.includeSensitive) {
+  if (options.config.execution.includeSensitive && customerPlans.records.length > 0) {
     const clerkClient = await options.applyFactories.createClerkClient();
     clerk = await options.runners.provisionClerk(customerPlans.records, options.config.execution, clerkClient);
     customers = materializeCustomers(customerPlans.records, clerk.idMap);
@@ -450,6 +463,6 @@ export async function orchestrateMigration(options: OrchestrateMigrationOptions)
     media: { planned: mediaPlans.length, persisted: mediaEvidence.length },
     clerk: { created: clerk.created, existing: clerk.existing, reconciliation: clerk.reconciliation.length },
     d1,
-    warnings: warningCount + orders.warnings.length + reviews.warnings.length,
+    warnings: baseWarningCount + orders.warnings.length + reviews.warnings.length,
   };
 }

--- a/scripts/shopify-migration/orchestrator.ts
+++ b/scripts/shopify-migration/orchestrator.ts
@@ -1,0 +1,455 @@
+import type { MigrationConfig } from "./lib/config.js";
+import { providerFingerprint } from "./lib/ids.js";
+import type {
+  JudgeMeFileRow,
+  ShopifyArticle,
+  ShopifyBlog,
+  ShopifyCollect,
+  ShopifyCollection,
+  ShopifyCustomer,
+  ShopifyOrder,
+  ShopifyPage,
+  ShopifyProduct,
+  ShopifyRedirect,
+} from "./lib/types.js";
+import {
+  parseWranglerJsonc,
+  resolveDatabaseTarget,
+  resolveMediaTarget,
+} from "./lib/wrangler-target.js";
+import {
+  D1_DEPENDENCIES,
+  buildD1ImportPlan,
+  type CommandRunner,
+  type D1ApplyResult,
+  type D1DryRunResult,
+  type MaterializedD1Input,
+} from "./adapters/d1/index.js";
+import type { ClerkMigrationClient, ClerkProvisioningResult } from "./adapters/clerk/index.js";
+import type {
+  AppliedMediaImportResult,
+  MediaImportResult,
+  MediaObjectStore,
+  PlannedMediaImportResult,
+} from "./adapters/media/index.js";
+import type { MediaRewrite } from "./transformers/_shared.js";
+import { validateMediaPlan } from "./adapters/media/index.js";
+import { collectionMembershipByProduct, transformProducts } from "./transformers/products.js";
+import { transformCollections } from "./transformers/categories.js";
+import { transformPages } from "./transformers/pages.js";
+import { transformBlogContent } from "./transformers/blog.js";
+import {
+  collectionRedirects,
+  pageRedirects,
+  productRedirects,
+  transformRedirects,
+} from "./transformers/redirects.js";
+import {
+  materializeCustomers,
+  normalizeJudgeMeFileRows,
+  transformCustomers,
+  transformHistoricalOrders,
+  transformJudgeMeReviews,
+  type CustomerProvisioningPlan,
+  type ImportedReviewAttribution,
+  type VerifiedReviewProvenance,
+} from "./transformers/sensitive/index.js";
+
+export interface MigrationSourceBundle {
+  collections: readonly ShopifyCollection[];
+  collects: readonly ShopifyCollect[];
+  products: readonly ShopifyProduct[];
+  pages: readonly ShopifyPage[];
+  blogs: readonly ShopifyBlog[];
+  articles: readonly ShopifyArticle[];
+  redirects: readonly ShopifyRedirect[];
+  customers: readonly ShopifyCustomer[];
+  orders: readonly ShopifyOrder[];
+  judgeMeRows: readonly JudgeMeFileRow[];
+}
+
+export interface MigrationSource {
+  extract(includeSensitive: boolean): Promise<MigrationSourceBundle>;
+}
+
+export interface MigrationDomainOptions {
+  currency: string;
+  inventoryLocationId: string;
+  fulfillmentType: "physical" | "digital" | "service";
+  actorId: string;
+  fallbackAuthor: string;
+  allowedMediaHosts: readonly string[];
+  unresolvedCustomer: "reject" | "guest";
+  reviewAttributions: ReadonlyMap<string, ImportedReviewAttribution>;
+  verifiedPurchases?: ReadonlyMap<string, VerifiedReviewProvenance>;
+}
+
+export interface MigrationApplyFactories {
+  createMediaStore(bucketName: string): MediaObjectStore;
+  createClerkClient(): Promise<ClerkMigrationClient>;
+  createCommandRunner(): CommandRunner;
+}
+
+export interface MigrationAdapterRunners {
+  importMedia(
+    plans: readonly MediaRewrite[],
+    options: {
+      execution: MigrationConfig["execution"];
+      wranglerConfigText: string;
+      wranglerEnvironment?: string;
+      allowedHosts: readonly string[];
+      store: MediaObjectStore;
+    },
+  ): Promise<MediaImportResult[]>;
+  provisionClerk(
+    plans: readonly CustomerProvisioningPlan[],
+    execution: MigrationConfig["execution"],
+    client: ClerkMigrationClient,
+  ): Promise<ClerkProvisioningResult>;
+  runD1(options: {
+    input: MaterializedD1Input;
+    execution: MigrationConfig["execution"];
+    projectRoot: string;
+    wranglerEnvironment?: string;
+    expectedDatabaseName?: string;
+    mediaEvidence?: readonly AppliedMediaImportResult[];
+    commandRunner: CommandRunner;
+  }): Promise<D1DryRunResult | D1ApplyResult>;
+}
+
+export interface OrchestrateMigrationOptions {
+  config: MigrationConfig;
+  domain: MigrationDomainOptions;
+  source: MigrationSource;
+  projectRoot: string;
+  wranglerConfigText: string;
+  expectedDatabaseName?: string;
+  applyFactories?: MigrationApplyFactories;
+  runners?: MigrationAdapterRunners;
+  now?: () => Date;
+}
+
+export interface MigrationEntitySummary {
+  source: number;
+  transformed: number;
+  written: number;
+  skipped: number;
+  errors: number;
+}
+
+export interface MigrationRunReport {
+  version: 1;
+  authoritative: false;
+  generatedAt: string;
+  dryRun: boolean;
+  target: MigrationConfig["execution"]["target"];
+  entities: Record<string, MigrationEntitySummary>;
+  media: { planned: number; persisted: number };
+  clerk: { created: number; existing: number; reconciliation: number };
+  d1: D1DryRunResult | D1ApplyResult;
+  warnings: number;
+}
+
+function fingerprintPlaceholder(fingerprint: string): string {
+  if (!/^[a-f0-9]{64}$/u.test(fingerprint)) throw new Error("Customer source fingerprint is invalid");
+  return `user_migration_preflight_${fingerprint.slice(0, 48)}`;
+}
+
+function uniqueMedia(plans: readonly MediaRewrite[], allowedHosts: readonly string[]): MediaRewrite[] {
+  const byKey = new Map<string, MediaRewrite>();
+  for (const plan of plans) {
+    validateMediaPlan(plan, allowedHosts);
+    const prior = byKey.get(plan.objectKey);
+    if (prior && JSON.stringify(prior) !== JSON.stringify(plan)) {
+      throw new Error("Migration media plan contains a conflicting object key");
+    }
+    byKey.set(plan.objectKey, plan);
+  }
+  return [...byKey.values()].sort((left, right) => left.objectKey.localeCompare(right.objectKey));
+}
+
+function plannedMedia(plans: readonly MediaRewrite[]): PlannedMediaImportResult[] {
+  return plans.map((plan) => ({
+    objectKey: plan.objectKey,
+    publicPath: plan.publicPath,
+    contentType: plan.contentType,
+    status: "planned",
+    byteLength: null,
+    sha256: null,
+  }));
+}
+
+function variantIdsByFingerprint(
+  products: ReturnType<typeof transformProducts>["records"],
+): Map<string, string> {
+  const mappings = new Map<string, string>();
+  for (const product of products) {
+    for (const inventory of product.inventory) {
+      const external = JSON.parse(inventory.external_references) as { shopify_fingerprint?: unknown };
+      if (typeof external.shopify_fingerprint !== "string" || !/^[a-f0-9]{64}$/u.test(external.shopify_fingerprint)) {
+        throw new Error("Transformed inventory is missing its source fingerprint");
+      }
+      mappings.set(external.shopify_fingerprint, inventory.sku_id);
+    }
+  }
+  return mappings;
+}
+
+function productMappings(
+  products: ReturnType<typeof transformProducts>,
+  source: readonly ShopifyProduct[],
+): Map<string, string> {
+  const mappings = new Map(products.idMap);
+  const accepted = new Map(products.records.map((record) => [record.sourceFingerprint, record.product.id]));
+  for (const product of source) {
+    const fingerprint = providerFingerprint("shopify", "product", product.id);
+    const id = accepted.get(fingerprint);
+    if (id) mappings.set(providerFingerprint("shopify", "product_handle", product.handle), id);
+  }
+  return mappings;
+}
+
+function dryRunD1(plan: ReturnType<typeof buildD1ImportPlan>): D1DryRunResult {
+  const dependencies = D1_DEPENDENCIES.map((dependency) => ({ dependency, count: plan.counts[dependency] }));
+  return {
+    dryRun: true,
+    dependencies,
+    totalRows: dependencies.reduce((total, item) => total + item.count, 0),
+    chunkCount: plan.chunks.length,
+    requiredMediaCount: plan.requiredMediaPaths.length,
+  };
+}
+
+function summary(source: number, transformed: number, skipped: number, written: number): MigrationEntitySummary {
+  return { source, transformed, written, skipped, errors: 0 };
+}
+
+function assertMode(config: MigrationConfig): void {
+  if (config.execution.apply === config.execution.dryRun) {
+    throw new Error("Migration must be exactly one of dry-run or apply");
+  }
+  if (config.execution.includeSensitive !== config.execution.confirmedSensitiveData) {
+    throw new Error("Sensitive migration data requires matching explicit confirmation");
+  }
+}
+
+export async function orchestrateMigration(options: OrchestrateMigrationOptions): Promise<MigrationRunReport> {
+  assertMode(options.config);
+  const generatedAt = (options.now ?? (() => new Date()))().toISOString();
+  const wrangler = parseWranglerJsonc(options.wranglerConfigText);
+  const targetOptions = {
+    target: options.config.execution.target,
+    ...(options.config.wranglerEnvironment ? { environment: options.config.wranglerEnvironment } : {}),
+  } as const;
+  const mediaTarget = resolveMediaTarget(wrangler, targetOptions);
+  resolveDatabaseTarget(wrangler, {
+    ...targetOptions,
+    ...(options.expectedDatabaseName ? { expectedName: options.expectedDatabaseName } : {}),
+  });
+
+  const source = await options.source.extract(options.config.execution.includeSensitive);
+  if (!options.config.execution.includeSensitive && (source.customers.length || source.orders.length || source.judgeMeRows.length)) {
+    throw new Error("Source returned sensitive records without explicit sensitive-data inclusion");
+  }
+
+  const categories = transformCollections(source.collections, {
+    generatedAt,
+    allowedMediaHosts: options.domain.allowedMediaHosts,
+  });
+  const memberships = collectionMembershipByProduct(source.collects, categories.idMap);
+  const products = transformProducts(source.products, {
+    currency: options.domain.currency,
+    generatedAt,
+    inventoryLocationId: options.domain.inventoryLocationId,
+    fulfillmentType: options.domain.fulfillmentType,
+    allowedMediaHosts: options.domain.allowedMediaHosts,
+    categoryIdsByProduct: memberships,
+  });
+  const pages = transformPages(source.pages, {
+    generatedAt,
+    actorId: options.domain.actorId,
+    allowedMediaHosts: options.domain.allowedMediaHosts,
+  });
+  const blog = transformBlogContent(source.blogs, source.articles, {
+    generatedAt,
+    actorId: options.domain.actorId,
+    fallbackAuthor: options.domain.fallbackAuthor,
+    allowedMediaHosts: options.domain.allowedMediaHosts,
+  });
+
+  const acceptedProducts = new Map(products.records.map((record) => [record.sourceFingerprint, record.product.slug]));
+  const acceptedCategories = new Map(categories.records.map((record) => [record.sourceFingerprint, record.category.slug]));
+  const acceptedPages = new Map(pages.records.map((record) => [record.sourceFingerprint, record.page.slug]));
+  const redirects = transformRedirects(source.redirects, {
+    generated: [
+      ...productRedirects(source.products.flatMap((record) => {
+        const slug = acceptedProducts.get(providerFingerprint("shopify", "product", record.id));
+        return slug ? [{ legacyHandle: record.handle, publicSlug: slug }] : [];
+      })),
+      ...collectionRedirects(source.collections.flatMap((record) => {
+        const slug = acceptedCategories.get(providerFingerprint("shopify", "category", record.id));
+        return slug ? [{ legacyHandle: record.handle, publicSlug: slug }] : [];
+      })),
+      ...pageRedirects(source.pages.flatMap((record) => {
+        const slug = acceptedPages.get(providerFingerprint("shopify", "page", record.id));
+        return slug ? [{ legacyHandle: record.handle, publicSlug: slug }] : [];
+      })),
+      ...blog.records.map((record) => record.redirect),
+    ],
+  });
+
+  const mediaPlans = uniqueMedia([
+    ...categories.records.flatMap((record) => record.media),
+    ...products.records.flatMap((record) => record.media),
+    ...pages.records.flatMap((record) => record.media),
+    ...blog.records.flatMap((record) => record.media),
+  ], options.domain.allowedMediaHosts);
+
+  const customerPlans = options.config.execution.includeSensitive
+    ? transformCustomers(source.customers, { generatedAt })
+    : { records: [], skipped: [], warnings: [] };
+  const normalizedReviews = options.config.execution.includeSensitive
+    ? normalizeJudgeMeFileRows(source.judgeMeRows)
+    : { records: [], skipped: [], warnings: [] };
+  const preflightCustomerIds = new Map(
+    customerPlans.records.map((plan) => [plan.sourceFingerprint, fingerprintPlaceholder(plan.sourceFingerprint)]),
+  );
+  const preflightCustomers = materializeCustomers(customerPlans.records, preflightCustomerIds);
+  const productIds = productMappings(products, source.products);
+  const variantIds = variantIdsByFingerprint(products.records);
+  const preflightOrders = options.config.execution.includeSensitive
+    ? transformHistoricalOrders(source.orders, {
+      generatedAt,
+      customerIds: preflightCustomers.idMap,
+      productIds,
+      variantIds,
+      unresolvedCustomer: options.domain.unresolvedCustomer,
+    })
+    : { records: [], idMap: new Map<string, string>(), skipped: [], warnings: [] };
+
+  const publicInput: MaterializedD1Input = {
+    categories: categories.records,
+    products: products.records,
+    pages: pages.records,
+    blog,
+    customers: preflightCustomers.records,
+    orders: preflightOrders.records,
+    redirects: redirects.records,
+  };
+  const preflightPlan = buildD1ImportPlan(publicInput, { overwrite: options.config.execution.overwrite });
+
+  const warningCount = categories.warnings.length + products.warnings.length + pages.warnings.length +
+    blog.warnings.length + redirects.warnings.length + customerPlans.warnings.length +
+    normalizedReviews.warnings.length + preflightOrders.warnings.length;
+
+  if (options.config.execution.dryRun) {
+    return {
+      version: 1,
+      authoritative: false,
+      generatedAt,
+      dryRun: true,
+      target: options.config.execution.target,
+      entities: {
+        categories: summary(source.collections.length, categories.records.length, categories.skipped.length, 0),
+        products: summary(source.products.length, products.records.length, products.skipped.length, 0),
+        pages: summary(source.pages.length, pages.records.length, pages.skipped.length, 0),
+        blogs: summary(source.articles.length, blog.records.length, blog.skipped.length, 0),
+        customers: summary(source.customers.length, customerPlans.records.length, customerPlans.skipped.length, 0),
+        orders: summary(source.orders.length, preflightOrders.records.length, preflightOrders.skipped.length, 0),
+        reviews: summary(source.judgeMeRows.length, normalizedReviews.records.length, normalizedReviews.skipped.length, 0),
+        redirects: summary(source.redirects.length, redirects.records.length, redirects.skipped.length, 0),
+      },
+      media: { planned: plannedMedia(mediaPlans).length, persisted: 0 },
+      clerk: { created: 0, existing: 0, reconciliation: 0 },
+      d1: dryRunD1(preflightPlan),
+      warnings: warningCount,
+    };
+  }
+
+  if (!options.applyFactories || !options.runners) {
+    throw new Error("Apply mode requires explicit adapter factories and runners");
+  }
+  const mediaStore = options.applyFactories.createMediaStore(mediaTarget.bucketName);
+  const mediaResults = await options.runners.importMedia(mediaPlans, {
+    execution: options.config.execution,
+    wranglerConfigText: options.wranglerConfigText,
+    ...(options.config.wranglerEnvironment ? { wranglerEnvironment: options.config.wranglerEnvironment } : {}),
+    allowedHosts: options.domain.allowedMediaHosts,
+    store: mediaStore,
+  });
+  if (mediaResults.some((result) => result.status === "planned")) {
+    throw new Error("Apply media phase returned unpersisted plans");
+  }
+  const mediaEvidence = mediaResults as AppliedMediaImportResult[];
+
+  let clerk: ClerkProvisioningResult = { idMap: new Map(), created: 0, existing: 0, reconciliation: [] };
+  let customers = preflightCustomers;
+  if (options.config.execution.includeSensitive) {
+    const clerkClient = await options.applyFactories.createClerkClient();
+    clerk = await options.runners.provisionClerk(customerPlans.records, options.config.execution, clerkClient);
+    customers = materializeCustomers(customerPlans.records, clerk.idMap);
+  }
+  const orders = options.config.execution.includeSensitive
+    ? transformHistoricalOrders(source.orders, {
+      generatedAt,
+      customerIds: customers.idMap,
+      productIds,
+      variantIds,
+      unresolvedCustomer: options.domain.unresolvedCustomer,
+    })
+    : preflightOrders;
+  const reviews = options.config.execution.includeSensitive
+    ? transformJudgeMeReviews(normalizedReviews.records, {
+      generatedAt,
+      productIds,
+      customerIdsByEmailFingerprint: customers.emailIdMap,
+      reviewAttributions: options.domain.reviewAttributions,
+      ...(options.domain.verifiedPurchases ? { verifiedPurchases: options.domain.verifiedPurchases } : {}),
+    })
+    : { records: [], idMap: new Map<string, string>(), skipped: [], warnings: [] };
+
+  const finalInput: MaterializedD1Input = {
+    categories: categories.records,
+    products: products.records,
+    pages: pages.records,
+    blog,
+    customers: customers.records,
+    orders: orders.records,
+    reviews: reviews.records,
+    redirects: redirects.records,
+  };
+  buildD1ImportPlan(finalInput, { overwrite: options.config.execution.overwrite });
+  const commandRunner = options.applyFactories.createCommandRunner();
+  const d1 = await options.runners.runD1({
+    input: finalInput,
+    execution: options.config.execution,
+    projectRoot: options.projectRoot,
+    ...(options.config.wranglerEnvironment ? { wranglerEnvironment: options.config.wranglerEnvironment } : {}),
+    ...(options.expectedDatabaseName ? { expectedDatabaseName: options.expectedDatabaseName } : {}),
+    mediaEvidence,
+    commandRunner,
+  });
+  if (d1.dryRun) throw new Error("Apply D1 phase unexpectedly returned a dry-run result");
+
+  return {
+    version: 1,
+    authoritative: false,
+    generatedAt,
+    dryRun: false,
+    target: options.config.execution.target,
+    entities: {
+      categories: summary(source.collections.length, categories.records.length, categories.skipped.length, categories.records.length),
+      products: summary(source.products.length, products.records.length, products.skipped.length, products.records.length),
+      pages: summary(source.pages.length, pages.records.length, pages.skipped.length, pages.records.length),
+      blogs: summary(source.articles.length, blog.records.length, blog.skipped.length, blog.records.length),
+      customers: summary(source.customers.length, customers.records.length, customerPlans.skipped.length + customers.skipped.length, customers.records.length),
+      orders: summary(source.orders.length, orders.records.length, orders.skipped.length, orders.records.length),
+      reviews: summary(source.judgeMeRows.length, reviews.records.length, normalizedReviews.skipped.length + reviews.skipped.length, reviews.records.length),
+      redirects: summary(source.redirects.length, redirects.records.length, redirects.skipped.length, redirects.records.length),
+    },
+    media: { planned: mediaPlans.length, persisted: mediaEvidence.length },
+    clerk: { created: clerk.created, existing: clerk.existing, reconciliation: clerk.reconciliation.length },
+    d1,
+    warnings: warningCount + orders.warnings.length + reviews.warnings.length,
+  };
+}

--- a/scripts/shopify-migration/orchestrator.ts
+++ b/scripts/shopify-migration/orchestrator.ts
@@ -23,6 +23,7 @@ import {
   type CommandRunner,
   type D1ApplyResult,
   type D1DryRunResult,
+  type D1PreflightReceipt,
   type MaterializedD1Input,
 } from "./adapters/d1/index.js";
 import type { ClerkMigrationClient, ClerkProvisioningResult } from "./adapters/clerk/index.js";
@@ -85,12 +86,23 @@ export interface MigrationDomainOptions {
 }
 
 export interface MigrationApplyFactories {
-  createMediaStore(bucketName: string): MediaObjectStore;
-  createClerkClient(): Promise<ClerkMigrationClient>;
+  createMediaStore(bucketName: string, cloudflareAccountId: string): MediaObjectStore;
+  createClerkClient(clerkInstanceId: string): Promise<TargetBoundClerkMigrationClient>;
   createCommandRunner(): CommandRunner;
 }
 
+export interface TargetBoundClerkMigrationClient extends ClerkMigrationClient {
+  verifyTarget(instanceId: string, environmentType: "development" | "production"): Promise<void>;
+}
+
 export interface MigrationAdapterRunners {
+  preflightD1(options: {
+    execution: MigrationConfig["execution"];
+    projectRoot: string;
+    wranglerEnvironment?: string;
+    expectedDatabaseName?: string;
+    commandRunner: CommandRunner;
+  }): Promise<D1PreflightReceipt>;
   importMedia(
     plans: readonly MediaRewrite[],
     options: {
@@ -114,7 +126,13 @@ export interface MigrationAdapterRunners {
     expectedDatabaseName?: string;
     mediaEvidence?: readonly AppliedMediaImportResult[];
     commandRunner: CommandRunner;
+    preflightReceipt?: D1PreflightReceipt;
   }): Promise<D1DryRunResult | D1ApplyResult>;
+}
+
+export interface RemoteTargetBinding {
+  cloudflareAccountId?: string;
+  clerkInstanceId?: string;
 }
 
 export interface OrchestrateMigrationOptions {
@@ -124,6 +142,7 @@ export interface OrchestrateMigrationOptions {
   projectRoot: string;
   wranglerConfigText: string;
   expectedDatabaseName?: string;
+  remoteTargetBinding?: RemoteTargetBinding;
   applyFactories?: MigrationApplyFactories;
   runners?: MigrationAdapterRunners;
   now?: () => Date;
@@ -231,6 +250,52 @@ function assertMode(config: MigrationConfig): void {
   if (config.execution.includeSensitive !== config.execution.confirmedSensitiveData) {
     throw new Error("Sensitive migration data requires matching explicit confirmation");
   }
+}
+
+function selectedWranglerIdentity(
+  config: unknown,
+  environment: string | undefined,
+): { cloudflareAccountId: string; clerkInstanceId: string | null } {
+  if (!config || typeof config !== "object" || Array.isArray(config)) throw new Error("Wrangler target identity is invalid");
+  const root = config as Record<string, unknown>;
+  const selected = environment
+    ? (root.env as Record<string, unknown> | undefined)?.[environment]
+    : root;
+  if (!selected || typeof selected !== "object" || Array.isArray(selected)) {
+    throw new Error("Wrangler target identity section is missing");
+  }
+  const section = selected as Record<string, unknown>;
+  const accountId = section.account_id ?? root.account_id;
+  if (typeof accountId !== "string" || !/^[a-f0-9]{32}$/iu.test(accountId)) {
+    throw new Error("Selected Wrangler target requires an explicit Cloudflare account_id");
+  }
+  const vars = section.vars;
+  const clerkInstanceId = vars && typeof vars === "object" && !Array.isArray(vars)
+    ? (vars as Record<string, unknown>).CLERK_INSTANCE_ID
+    : undefined;
+  if (clerkInstanceId !== undefined && (
+    typeof clerkInstanceId !== "string" || !/^ins_[A-Za-z0-9_-]{4,200}$/u.test(clerkInstanceId)
+  )) throw new Error("Selected Wrangler CLERK_INSTANCE_ID is invalid");
+  return {
+    cloudflareAccountId: accountId.toLowerCase(),
+    clerkInstanceId: typeof clerkInstanceId === "string" ? clerkInstanceId : null,
+  };
+}
+
+function bindRemoteTarget(
+  config: unknown,
+  environment: string | undefined,
+  supplied: RemoteTargetBinding | undefined,
+  requireClerk: boolean,
+): { cloudflareAccountId: string; clerkInstanceId: string | null } {
+  const selected = selectedWranglerIdentity(config, environment);
+  if (!supplied?.cloudflareAccountId || supplied.cloudflareAccountId.toLowerCase() !== selected.cloudflareAccountId) {
+    throw new Error("Cloudflare credential account does not match the confirmed Wrangler target");
+  }
+  if (requireClerk && (
+    !selected.clerkInstanceId || !supplied.clerkInstanceId || supplied.clerkInstanceId !== selected.clerkInstanceId
+  )) throw new Error("Clerk instance does not match the confirmed Wrangler target");
+  return selected;
 }
 
 export async function orchestrateMigration(options: OrchestrateMigrationOptions): Promise<MigrationRunReport> {
@@ -382,14 +447,42 @@ export async function orchestrateMigration(options: OrchestrateMigrationOptions)
   if (!options.applyFactories || !options.runners) {
     throw new Error("Apply mode requires explicit adapter factories and runners");
   }
-  const mediaStore = options.applyFactories.createMediaStore(mediaTarget.bucketName);
-  const mediaResults = await options.runners.importMedia(mediaPlans, {
+  const needsMedia = mediaPlans.length > 0;
+  const needsClerk = options.config.execution.includeSensitive && customerPlans.records.length > 0;
+  if (options.config.execution.target === "local" && (needsMedia || needsClerk)) {
+    throw new Error("Local apply cannot use remote R2 or Clerk; remove external-write plans or use a confirmed remote target");
+  }
+  const remoteIdentity = options.config.execution.target === "local"
+    ? null
+    : bindRemoteTarget(
+      wrangler,
+      options.config.wranglerEnvironment,
+      options.remoteTargetBinding,
+      needsClerk,
+    );
+  const commandRunner = options.applyFactories.createCommandRunner();
+  const preflightReceipt = await options.runners.preflightD1({
+    execution: options.config.execution,
+    projectRoot: options.projectRoot,
+    ...(options.config.wranglerEnvironment ? { wranglerEnvironment: options.config.wranglerEnvironment } : {}),
+    ...(options.expectedDatabaseName ? { expectedDatabaseName: options.expectedDatabaseName } : {}),
+    commandRunner,
+  });
+  let clerkClient: TargetBoundClerkMigrationClient | undefined;
+  if (needsClerk) {
+    clerkClient = await options.applyFactories.createClerkClient(remoteIdentity!.clerkInstanceId!);
+    await clerkClient.verifyTarget(
+      remoteIdentity!.clerkInstanceId!,
+      options.config.execution.target === "production" ? "production" : "development",
+    );
+  }
+  const mediaResults = needsMedia ? await options.runners.importMedia(mediaPlans, {
     execution: options.config.execution,
     wranglerConfigText: options.wranglerConfigText,
     ...(options.config.wranglerEnvironment ? { wranglerEnvironment: options.config.wranglerEnvironment } : {}),
     allowedHosts: options.domain.allowedMediaHosts,
-    store: mediaStore,
-  });
+    store: options.applyFactories.createMediaStore(mediaTarget.bucketName, remoteIdentity!.cloudflareAccountId),
+  }) : [];
   if (mediaResults.some((result) => result.status === "planned")) {
     throw new Error("Apply media phase returned unpersisted plans");
   }
@@ -397,9 +490,8 @@ export async function orchestrateMigration(options: OrchestrateMigrationOptions)
 
   let clerk: ClerkProvisioningResult = { idMap: new Map(), created: 0, existing: 0, reconciliation: [] };
   let customers = preflightCustomers;
-  if (options.config.execution.includeSensitive && customerPlans.records.length > 0) {
-    const clerkClient = await options.applyFactories.createClerkClient();
-    clerk = await options.runners.provisionClerk(customerPlans.records, options.config.execution, clerkClient);
+  if (needsClerk) {
+    clerk = await options.runners.provisionClerk(customerPlans.records, options.config.execution, clerkClient!);
     customers = materializeCustomers(customerPlans.records, clerk.idMap);
   }
   const orders = options.config.execution.includeSensitive
@@ -432,7 +524,6 @@ export async function orchestrateMigration(options: OrchestrateMigrationOptions)
     redirects: redirects.records,
   };
   buildD1ImportPlan(finalInput, { overwrite: options.config.execution.overwrite });
-  const commandRunner = options.applyFactories.createCommandRunner();
   const d1 = await options.runners.runD1({
     input: finalInput,
     execution: options.config.execution,
@@ -441,6 +532,7 @@ export async function orchestrateMigration(options: OrchestrateMigrationOptions)
     ...(options.expectedDatabaseName ? { expectedDatabaseName: options.expectedDatabaseName } : {}),
     mediaEvidence,
     commandRunner,
+    preflightReceipt,
   });
   if (d1.dryRun) throw new Error("Apply D1 phase unexpectedly returned a dry-run result");
 

--- a/scripts/shopify-migration/transformers/_shared.ts
+++ b/scripts/shopify-migration/transformers/_shared.ts
@@ -1,0 +1,199 @@
+import { CURRENCY_PRECISION } from "../../../lib/money/currencies.js";
+import { Money, type StoredMoney } from "../../../lib/money/money.js";
+import { sanitizeRichHtmlServer } from "../../../lib/utils/sanitize-html-core.js";
+
+export const SHOPIFY_PROVIDER = "shopify";
+
+// Kept identical to the O02 public CMS route reservation contract.
+const RESERVED_PAGE_SLUGS = new Set([
+  "account", "admin", "api", "blog", "cart", "category", "checkout",
+  "order-status", "orders", "product", "robots.txt", "sign-in", "sign-up",
+  "sitemap.xml",
+]);
+
+export function isReservedPageSlug(slug: string): boolean {
+  return RESERVED_PAGE_SLUGS.has(slug.trim().toLowerCase());
+}
+
+export interface MediaRewrite {
+  sourceUrl: string;
+  objectKey: string;
+  publicPath: string;
+  contentType: "image/avif" | "image/gif" | "image/jpeg" | "image/png" | "image/webp";
+  role: "product" | "category" | "page-inline" | "blog-cover" | "blog-inline";
+  ownerId: string;
+  altText?: string;
+  width?: number;
+  height?: number;
+}
+
+export interface TransformFailure<T> {
+  record: T;
+  reason: string;
+}
+
+export interface PureTransformResult<TSource, TRecord> {
+  records: TRecord[];
+  idMap: Map<string, string>;
+  skipped: Array<TransformFailure<TSource>>;
+  warnings: string[];
+}
+
+export function requiredMigrationTime(value: string): string {
+  const timestamp = Date.parse(value);
+  if (!Number.isFinite(timestamp)) {
+    throw new TypeError("generatedAt must be a valid ISO 8601 timestamp");
+  }
+  return new Date(timestamp).toISOString();
+}
+
+export function isoTimestamp(value: string | null | undefined, fallback: string): string {
+  if (!value) return fallback;
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? new Date(timestamp).toISOString() : fallback;
+}
+
+export function unixTimestamp(value: string | null | undefined): number | null {
+  if (!value) return null;
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? Math.floor(timestamp / 1_000) : null;
+}
+
+export function hasValidTimestamp(value: string | null | undefined): value is string {
+  return typeof value === "string" && value.trim().length > 0 && Number.isFinite(Date.parse(value));
+}
+
+export function requireSupportedCurrency(currency: string): string {
+  const normalized = currency.trim().toUpperCase();
+  if (!(normalized in CURRENCY_PRECISION)) {
+    throw new RangeError(`Unsupported migration currency: ${currency}`);
+  }
+  return normalized;
+}
+
+export function majorToStoredMoney(value: string | number, currency: string): StoredMoney {
+  const normalized = requireSupportedCurrency(currency);
+  const money = Money.fromMajor(value, normalized);
+  if (money.isNegative()) throw new RangeError("Money amounts cannot be negative");
+  return money.toJSON();
+}
+
+export function normalizeSlug(value: string): string {
+  return value.trim().toLowerCase()
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+export function uniqueStrings(values: readonly string[]): string[] {
+  const seen = new Set<string>();
+  return values.flatMap((raw) => {
+    const value = raw.trim();
+    const key = value.toLocaleLowerCase("en-US");
+    if (!value || seen.has(key)) return [];
+    seen.add(key);
+    return [value];
+  });
+}
+
+export function clampInventory(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return 0;
+  return Math.min(Number.MAX_SAFE_INTEGER, Math.max(0, Math.trunc(value)));
+}
+
+function safeExtension(sourceUrl: string): string | null {
+  try {
+    const pathname = new URL(sourceUrl).pathname;
+    const extension = pathname.match(/\.([a-zA-Z0-9]{2,5})$/)?.[1]?.toLowerCase();
+    return extension && ["avif", "gif", "jpeg", "jpg", "png", "webp"].includes(extension)
+      ? extension
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function imageContentType(extension: string): MediaRewrite["contentType"] {
+  if (extension === "jpg" || extension === "jpeg") return "image/jpeg";
+  return `image/${extension}` as MediaRewrite["contentType"];
+}
+
+function safeSourceUrl(value: string): string | null {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "https:" || url.username || url.password) return null;
+    return url.href;
+  } catch {
+    return null;
+  }
+}
+
+export function mediaRewrite(
+  source: string,
+  ownerId: string,
+  role: MediaRewrite["role"],
+  position: number,
+  metadata: Pick<MediaRewrite, "altText" | "width" | "height"> = {},
+): MediaRewrite | null {
+  const sourceUrl = safeSourceUrl(source);
+  if (!sourceUrl) return null;
+  const extension = safeExtension(sourceUrl);
+  if (!extension) return null;
+  const prefix = role === "product" ? "products"
+    : role === "category" ? "categories"
+      : role.startsWith("blog") ? "blog"
+        : "pages";
+  const roleSegment = role === "blog-cover" ? "/cover"
+    : role === "blog-inline" || role === "page-inline" ? "/inline"
+      : "";
+  const objectKey = `${prefix}/${ownerId}${roleSegment}/${position}.${extension}`;
+  return {
+    sourceUrl,
+    objectKey,
+    publicPath: `/media/${objectKey}`,
+    contentType: imageContentType(extension),
+    role,
+    ownerId,
+    ...metadata,
+  };
+}
+
+/** Rewrite remote image sources to the future local object path before sanitizing. */
+export function rewriteAndSanitizeHtml(
+  html: string,
+  ownerId: string,
+  role: "page-inline" | "blog-inline",
+): { html: string; media: MediaRewrite[] } {
+  const media: MediaRewrite[] = [];
+  let position = 0;
+  const rewritten = html.replace(
+    /(<img\b[^>]*?\bsrc\s*=\s*)(["'])([^"']+)(\2)/giu,
+    (match, prefix: string, quote: string, source: string) => {
+      const plan = mediaRewrite(source, ownerId, role, ++position);
+      if (!plan) return match;
+      media.push(plan);
+      return `${prefix}${quote}${plan.publicPath}${quote}`;
+    },
+  );
+  return { html: sanitizeRichHtmlServer(rewritten), media };
+}
+
+export function plainText(html: string): string {
+  return sanitizeRichHtmlServer(html)
+    .replace(/<[^>]*>/g, " ")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#(?:39|x27);/gi, "'")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function excerptFromHtml(html: string, maxLength = 160): string | null {
+  const value = plainText(html);
+  if (!value) return null;
+  return value.length <= maxLength ? value : `${value.slice(0, maxLength - 3).trimEnd()}...`;
+}

--- a/scripts/shopify-migration/transformers/_shared.ts
+++ b/scripts/shopify-migration/transformers/_shared.ts
@@ -40,6 +40,11 @@ const MAX_MEDIA_HOSTS = 16;
 const MAX_INLINE_MEDIA = 100;
 export const MAX_SQL_TEXT_BYTES = 48 * 1024;
 const DNS_HOSTNAME = /^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/u;
+const MYSHOPIFY_HOST = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.myshopify\.com$/u;
+
+function isShopifyAssetHost(hostname: string): boolean {
+  return hostname === "cdn.shopify.com" || MYSHOPIFY_HOST.test(hostname);
+}
 
 /** Normalize a small exact-host allowlist. Empty explicitly disables media import. */
 export function mediaHostAllowlist(hosts: readonly string[]): MediaHostAllowlist {
@@ -60,9 +65,9 @@ export function mediaHostAllowlist(hosts: readonly string[]): MediaHostAllowlist
     }
     if (
       !DNS_HOSTNAME.test(hostname) || isIP(hostname) !== 0 || hostname === "localhost" ||
-      hostname.endsWith(".localhost")
+      hostname.endsWith(".localhost") || !isShopifyAssetHost(hostname)
     ) {
-      throw new TypeError(`Invalid allowed media hostname: ${raw}`);
+      throw new TypeError(`Invalid or non-Shopify allowed media hostname: ${raw}`);
     }
     normalized.add(hostname);
   }
@@ -189,7 +194,8 @@ function safeSourceUrl(
     const hostname = url.hostname.toLowerCase();
     if (
       url.protocol !== "https:" || url.username || url.password || url.port || isIP(hostname) !== 0 ||
-      hostname === "localhost" || hostname.endsWith(".localhost") || !allowedHosts.has(hostname)
+      hostname === "localhost" || hostname.endsWith(".localhost") || !allowedHosts.has(hostname) ||
+      !isShopifyAssetHost(hostname) || (MYSHOPIFY_HOST.test(hostname) && !url.pathname.startsWith("/cdn/"))
     ) return null;
     return { href: url.href, hostname };
   } catch {

--- a/scripts/shopify-migration/transformers/_shared.ts
+++ b/scripts/shopify-migration/transformers/_shared.ts
@@ -1,3 +1,5 @@
+import { isIP } from "node:net";
+
 import { CURRENCY_PRECISION } from "../../../lib/money/currencies.js";
 import { Money, type StoredMoney } from "../../../lib/money/money.js";
 import { sanitizeRichHtmlServer } from "../../../lib/utils/sanitize-html-core.js";
@@ -17,14 +19,51 @@ export function isReservedPageSlug(slug: string): boolean {
 
 export interface MediaRewrite {
   sourceUrl: string;
+  sourceHost: string;
   objectKey: string;
   publicPath: string;
-  contentType: "image/avif" | "image/gif" | "image/jpeg" | "image/png" | "image/webp";
+  contentType: "image/jpeg" | "image/png" | "image/webp";
   role: "product" | "category" | "page-inline" | "blog-cover" | "blog-inline";
   ownerId: string;
+  requiredBeforePersistence: true;
   altText?: string;
   width?: number;
   height?: number;
+}
+
+export type MediaHostAllowlist = ReadonlySet<string>;
+
+const MAX_MEDIA_HOSTS = 16;
+const MAX_INLINE_MEDIA = 100;
+export const MAX_SQL_TEXT_BYTES = 48 * 1024;
+const DNS_HOSTNAME = /^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/u;
+
+/** Normalize a small exact-host allowlist. Empty explicitly disables media import. */
+export function mediaHostAllowlist(hosts: readonly string[]): MediaHostAllowlist {
+  if (!Array.isArray(hosts) || hosts.length > MAX_MEDIA_HOSTS) {
+    throw new TypeError(`allowedMediaHosts must contain at most ${MAX_MEDIA_HOSTS} exact hostnames`);
+  }
+  const normalized = new Set<string>();
+  for (const raw of hosts) {
+    const value = raw.trim();
+    if (!value || value.includes("://") || /[/\\@:#?%\[\]]/u.test(value)) {
+      throw new TypeError(`Invalid allowed media hostname: ${raw}`);
+    }
+    let hostname: string;
+    try {
+      hostname = new URL(`https://${value}`).hostname.toLowerCase();
+    } catch {
+      throw new TypeError(`Invalid allowed media hostname: ${raw}`);
+    }
+    if (
+      !DNS_HOSTNAME.test(hostname) || isIP(hostname) !== 0 || hostname === "localhost" ||
+      hostname.endsWith(".localhost")
+    ) {
+      throw new TypeError(`Invalid allowed media hostname: ${raw}`);
+    }
+    normalized.add(hostname);
+  }
+  return normalized;
 }
 
 export interface TransformFailure<T> {
@@ -102,11 +141,27 @@ export function clampInventory(value: unknown): number {
   return Math.min(Number.MAX_SAFE_INTEGER, Math.max(0, Math.trunc(value)));
 }
 
+export function boundedPositiveInteger(value: unknown, maximum = 100_000): number | undefined {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0 && value <= maximum
+    ? value
+    : undefined;
+}
+
+/** Bytes consumed after Wrangler SQL literal escaping doubles apostrophes. */
+export function escapedSqlUtf8Bytes(value: string): number {
+  const apostrophes = value.match(/'/gu)?.length ?? 0;
+  return new TextEncoder().encode(value).byteLength + apostrophes;
+}
+
+export function fitsEscapedSqlText(value: string, maximum = MAX_SQL_TEXT_BYTES): boolean {
+  return escapedSqlUtf8Bytes(value) <= maximum;
+}
+
 function safeExtension(sourceUrl: string): string | null {
   try {
     const pathname = new URL(sourceUrl).pathname;
     const extension = pathname.match(/\.([a-zA-Z0-9]{2,5})$/)?.[1]?.toLowerCase();
-    return extension && ["avif", "gif", "jpeg", "jpg", "png", "webp"].includes(extension)
+    return extension && ["jpeg", "jpg", "png", "webp"].includes(extension)
       ? extension
       : null;
   } catch {
@@ -119,11 +174,21 @@ function imageContentType(extension: string): MediaRewrite["contentType"] {
   return `image/${extension}` as MediaRewrite["contentType"];
 }
 
-function safeSourceUrl(value: string): string | null {
+function safeSourceUrl(
+  value: string,
+  allowedHosts: MediaHostAllowlist,
+): { href: string; hostname: string } | null {
+  if (value.length > 2_048) return null;
+  const authority = /^https:\/\/([^/?#]+)/iu.exec(value)?.[1];
+  if (!authority || authority.includes(":") || authority.includes("@")) return null;
   try {
     const url = new URL(value);
-    if (url.protocol !== "https:" || url.username || url.password) return null;
-    return url.href;
+    const hostname = url.hostname.toLowerCase();
+    if (
+      url.protocol !== "https:" || url.username || url.password || url.port || isIP(hostname) !== 0 ||
+      hostname === "localhost" || hostname.endsWith(".localhost") || !allowedHosts.has(hostname)
+    ) return null;
+    return { href: url.href, hostname };
   } catch {
     return null;
   }
@@ -131,14 +196,15 @@ function safeSourceUrl(value: string): string | null {
 
 export function mediaRewrite(
   source: string,
+  allowedHosts: MediaHostAllowlist,
   ownerId: string,
   role: MediaRewrite["role"],
   position: number,
   metadata: Pick<MediaRewrite, "altText" | "width" | "height"> = {},
 ): MediaRewrite | null {
-  const sourceUrl = safeSourceUrl(source);
+  const sourceUrl = safeSourceUrl(source, allowedHosts);
   if (!sourceUrl) return null;
-  const extension = safeExtension(sourceUrl);
+  const extension = safeExtension(sourceUrl.href);
   if (!extension) return null;
   const prefix = role === "product" ? "products"
     : role === "category" ? "categories"
@@ -149,12 +215,14 @@ export function mediaRewrite(
       : "";
   const objectKey = `${prefix}/${ownerId}${roleSegment}/${position}.${extension}`;
   return {
-    sourceUrl,
+    sourceUrl: sourceUrl.href,
+    sourceHost: sourceUrl.hostname,
     objectKey,
     publicPath: `/media/${objectKey}`,
     contentType: imageContentType(extension),
     role,
     ownerId,
+    requiredBeforePersistence: true,
     ...metadata,
   };
 }
@@ -162,18 +230,27 @@ export function mediaRewrite(
 /** Rewrite remote image sources to the future local object path before sanitizing. */
 export function rewriteAndSanitizeHtml(
   html: string,
+  allowedHosts: MediaHostAllowlist,
   ownerId: string,
   role: "page-inline" | "blog-inline",
 ): { html: string; media: MediaRewrite[] } {
   const media: MediaRewrite[] = [];
   let position = 0;
   const rewritten = html.replace(
-    /(<img\b[^>]*?\bsrc\s*=\s*)(["'])([^"']+)(\2)/giu,
-    (match, prefix: string, quote: string, source: string) => {
-      const plan = mediaRewrite(source, ownerId, role, ++position);
-      if (!plan) return match;
+    /<img\b[^>]*>/giu,
+    (tag) => {
+      const sourceAttributes = [...tag.matchAll(/\bsrc\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))/giu)];
+      if (sourceAttributes.length === 0) return tag;
+      if (sourceAttributes.length !== 1) return "";
+      const sourceAttribute = sourceAttributes[0];
+      const source = sourceAttribute[1] ?? sourceAttribute[2] ?? sourceAttribute[3] ?? "";
+      position += 1;
+      const plan = position <= MAX_INLINE_MEDIA
+        ? mediaRewrite(source, allowedHosts, ownerId, role, position)
+        : null;
+      if (!plan) return "";
       media.push(plan);
-      return `${prefix}${quote}${plan.publicPath}${quote}`;
+      return tag.replace(sourceAttribute[0], `src="${plan.publicPath}"`);
     },
   );
   return { html: sanitizeRichHtmlServer(rewritten), media };

--- a/scripts/shopify-migration/transformers/_shared.ts
+++ b/scripts/shopify-migration/transformers/_shared.ts
@@ -5,6 +5,9 @@ import { Money, type StoredMoney } from "../../../lib/money/money.js";
 import { sanitizeRichHtmlServer } from "../../../lib/utils/sanitize-html-core.js";
 
 export const SHOPIFY_PROVIDER = "shopify";
+/** Stable persistence fallback when Shopify provides no usable source timestamp. */
+export const UNKNOWN_SOURCE_TIMESTAMP = "1970-01-01T00:00:00.000Z";
+export const UNKNOWN_SOURCE_UNIX_TIMESTAMP = 0;
 
 // Kept identical to the O02 public CMS route reservation contract.
 const RESERVED_PAGE_SLUGS = new Set([

--- a/scripts/shopify-migration/transformers/_shared.ts
+++ b/scripts/shopify-migration/transformers/_shared.ts
@@ -3,6 +3,7 @@ import { isIP } from "node:net";
 import { CURRENCY_PRECISION } from "../../../lib/money/currencies.js";
 import { Money, type StoredMoney } from "../../../lib/money/money.js";
 import { sanitizeRichHtmlServer } from "../../../lib/utils/sanitize-html-core.js";
+import { providerFingerprint } from "../lib/ids.js";
 
 export const SHOPIFY_PROVIDER = "shopify";
 /** Stable persistence fallback when Shopify provides no usable source timestamp. */
@@ -84,6 +85,29 @@ export interface PureTransformResult<TSource, TRecord> {
   idMap: Map<string, string>;
   skipped: Array<TransformFailure<TSource>>;
   warnings: string[];
+}
+
+/** Canonicalize top-level provider records and identify ambiguous repeated source IDs. */
+export function canonicalProviderRecords<T>(
+  records: readonly T[],
+  entity: string,
+  sourceId: (record: T) => string | number | null | undefined,
+): { records: T[]; duplicateFingerprints: ReadonlySet<string> } {
+  const keyed = records.map((record, index) => {
+    const raw = String(sourceId(record) ?? "").trim();
+    return {
+      record,
+      key: raw ? providerFingerprint(SHOPIFY_PROVIDER, entity, raw) : `~${String(index).padStart(12, "0")}`,
+      valid: Boolean(raw),
+    };
+  });
+  const counts = new Map<string, number>();
+  for (const item of keyed) if (item.valid) counts.set(item.key, (counts.get(item.key) ?? 0) + 1);
+  keyed.sort((left, right) => left.key < right.key ? -1 : left.key > right.key ? 1 : 0);
+  return {
+    records: keyed.map(({ record }) => record),
+    duplicateFingerprints: new Set([...counts].flatMap(([key, count]) => count > 1 ? [key] : [])),
+  };
 }
 
 export function requiredMigrationTime(value: string): string {

--- a/scripts/shopify-migration/transformers/blog.ts
+++ b/scripts/shopify-migration/transformers/blog.ts
@@ -5,6 +5,7 @@ import {
   SHOPIFY_PROVIDER,
   UNKNOWN_SOURCE_UNIX_TIMESTAMP,
   boundedPositiveInteger,
+  canonicalProviderRecords,
   excerptFromHtml,
   fitsEscapedSqlText,
   mediaHostAllowlist,
@@ -96,11 +97,13 @@ export function transformBlogContent(
   const categoryIdMap = new Map<string, string>();
   const skipped: Array<TransformFailure<ShopifyBlog | ShopifyArticle>> = [];
   const warnings: string[] = [];
-  const categorySlugs = new Set<string>();
-  const postSlugs = new Set<string>();
   const blogByFingerprint = new Map<string, { slug: string; handle: string }>();
+  const blogHandleByFingerprint = new Map<string, string>();
+  const blogSourceByFingerprint = new Map<string, ShopifyBlog>();
+  const articleSourceByFingerprint = new Map<string, ShopifyArticle>();
 
-  for (const blog of blogs) {
+  const canonicalBlogs = canonicalProviderRecords(blogs, "blog", (blog) => blog.id);
+  for (const blog of canonicalBlogs.records) {
     const sourceId = String(blog.id ?? "").trim();
     const name = blog.title?.trim();
     const slug = normalizeSlug(blog.handle ?? "");
@@ -112,14 +115,13 @@ export function transformBlogContent(
       skipped.push({ record: blog, reason: "Blog requires an id, title, and valid handle" });
       continue;
     }
-    if (categorySlugs.has(slug)) {
-      skipped.push({ record: blog, reason: `Duplicate blog category slug: ${slug}` });
+    const fingerprint = providerFingerprint(SHOPIFY_PROVIDER, "blog", sourceId);
+    if (canonicalBlogs.duplicateFingerprints.has(fingerprint)) {
+      skipped.push({ record: blog, reason: "Duplicate blog source identity" });
       continue;
     }
-    categorySlugs.add(slug);
-    const fingerprint = providerFingerprint(SHOPIFY_PROVIDER, "blog", sourceId);
-    categoryIdMap.set(fingerprint, slug);
-    blogByFingerprint.set(fingerprint, { slug, handle: exactHandle });
+    blogHandleByFingerprint.set(fingerprint, exactHandle);
+    blogSourceByFingerprint.set(fingerprint, blog);
     categories.push({
       sourceFingerprint: fingerprint,
       record: {
@@ -133,7 +135,26 @@ export function transformBlogContent(
     });
   }
 
-  for (const article of articles) {
+  const categorySlugCounts = new Map<string, number>();
+  for (const category of categories) {
+    categorySlugCounts.set(category.record.slug, (categorySlugCounts.get(category.record.slug) ?? 0) + 1);
+  }
+  const acceptedCategories = categories.flatMap((category) => {
+    if (categorySlugCounts.get(category.record.slug) === 1) return [category];
+    skipped.push({
+      record: blogSourceByFingerprint.get(category.sourceFingerprint)!,
+      reason: `Ambiguous duplicate blog category slug: ${category.record.slug}`,
+    });
+    return [];
+  });
+  for (const category of acceptedCategories) {
+    const handle = blogHandleByFingerprint.get(category.sourceFingerprint)!;
+    categoryIdMap.set(category.sourceFingerprint, category.record.slug);
+    blogByFingerprint.set(category.sourceFingerprint, { slug: category.record.slug, handle });
+  }
+
+  const canonicalArticles = canonicalProviderRecords(articles, "article", (article) => article.id);
+  for (const article of canonicalArticles.records) {
     const sourceId = String(article.id ?? "").trim();
     const sourceFingerprint = sourceId && sourceId.length <= 256
       ? providerFingerprint(SHOPIFY_PROVIDER, "article", sourceId)
@@ -147,6 +168,10 @@ export function transformBlogContent(
     const slug = normalizeSlug(article.handle ?? "");
     const exactHandle = article.handle?.trim();
     const author = article.author?.trim() || fallbackAuthor;
+    if (sourceFingerprint && canonicalArticles.duplicateFingerprints.has(sourceFingerprint)) {
+      skipped.push({ record: article, reason: "Duplicate article source identity" });
+      continue;
+    }
     if (
       !sourceFingerprint || sourceId.length > 256 || !category || !title || title.length > 200 || !slug || slug.length > 160 || !author ||
       author.length > 160 || (article.body_html?.length ?? 0) > 100_000 ||
@@ -159,10 +184,6 @@ export function transformBlogContent(
           ? "Article references a blog that was not imported"
           : "Article requires an id, title, author, and valid handle",
       });
-      continue;
-    }
-    if (postSlugs.has(slug)) {
-      skipped.push({ record: article, reason: `Duplicate blog post slug: ${slug}` });
       continue;
     }
     const ownerId = deterministicProviderId(SHOPIFY_PROVIDER, "article", sourceId);
@@ -199,8 +220,7 @@ export function transformBlogContent(
       continue;
     }
 
-    postSlugs.add(slug);
-
+    articleSourceByFingerprint.set(sourceFingerprint, article);
     records.push({
       sourceFingerprint,
       categoryReference: {
@@ -237,8 +257,17 @@ export function transformBlogContent(
       },
       conflict: { strategy: "insert-only", key: "slug", onConflict: "skip" },
     });
-    idMap.set(sourceFingerprint, slug);
   }
-
-  return { categories, records, idMap, categoryIdMap, skipped, warnings };
+  const postSlugCounts = new Map<string, number>();
+  for (const post of records) postSlugCounts.set(post.record.slug, (postSlugCounts.get(post.record.slug) ?? 0) + 1);
+  const acceptedRecords = records.flatMap((record) => {
+    if (postSlugCounts.get(record.record.slug) === 1) return [record];
+    skipped.push({
+      record: articleSourceByFingerprint.get(record.sourceFingerprint)!,
+      reason: `Ambiguous duplicate blog post slug: ${record.record.slug}`,
+    });
+    return [];
+  });
+  for (const record of acceptedRecords) idMap.set(record.sourceFingerprint, record.record.slug);
+  return { categories: acceptedCategories, records: acceptedRecords, idMap, categoryIdMap, skipped, warnings };
 }

--- a/scripts/shopify-migration/transformers/blog.ts
+++ b/scripts/shopify-migration/transformers/blog.ts
@@ -3,6 +3,7 @@ import type { ShopifyArticle, ShopifyBlog } from "../lib/types.js";
 import { deterministicProviderId, providerFingerprint } from "../lib/ids.js";
 import {
   SHOPIFY_PROVIDER,
+  UNKNOWN_SOURCE_UNIX_TIMESTAMP,
   boundedPositiveInteger,
   excerptFromHtml,
   fitsEscapedSqlText,
@@ -82,7 +83,7 @@ export function transformBlogContent(
   articles: readonly ShopifyArticle[],
   options: BlogTransformOptions,
 ): BlogTransformResult {
-  const generatedAt = unixTimestamp(requiredMigrationTime(options.generatedAt))!;
+  requiredMigrationTime(options.generatedAt);
   const actorId = options.actorId.trim();
   const fallbackAuthor = options.fallbackAuthor.trim();
   const allowedMediaHosts = mediaHostAllowlist(options.allowedMediaHosts);
@@ -125,8 +126,8 @@ export function transformBlogContent(
         name,
         slug,
         description: null,
-        created_at: unixTimestamp(blog.created_at) ?? generatedAt,
-        updated_at: unixTimestamp(blog.updated_at) ?? generatedAt,
+        created_at: unixTimestamp(blog.created_at) ?? UNKNOWN_SOURCE_UNIX_TIMESTAMP,
+        updated_at: unixTimestamp(blog.updated_at) ?? UNKNOWN_SOURCE_UNIX_TIMESTAMP,
       },
       conflict: { strategy: "insert-only", key: "slug", onConflict: "reuse" },
     });
@@ -222,8 +223,8 @@ export function transformBlogContent(
         meta_title: title,
         meta_description: summary,
         published_at: status === "published" ? publishedAt : null,
-        created_at: unixTimestamp(article.created_at) ?? generatedAt,
-        updated_at: unixTimestamp(article.updated_at) ?? generatedAt,
+        created_at: unixTimestamp(article.created_at) ?? UNKNOWN_SOURCE_UNIX_TIMESTAMP,
+        updated_at: unixTimestamp(article.updated_at) ?? UNKNOWN_SOURCE_UNIX_TIMESTAMP,
         created_by: actorId,
         updated_by: actorId,
       },

--- a/scripts/shopify-migration/transformers/blog.ts
+++ b/scripts/shopify-migration/transformers/blog.ts
@@ -3,7 +3,10 @@ import type { ShopifyArticle, ShopifyBlog } from "../lib/types.js";
 import { deterministicProviderId, providerFingerprint } from "../lib/ids.js";
 import {
   SHOPIFY_PROVIDER,
+  boundedPositiveInteger,
   excerptFromHtml,
+  fitsEscapedSqlText,
+  mediaHostAllowlist,
   mediaRewrite,
   normalizeSlug,
   requiredMigrationTime,
@@ -62,6 +65,7 @@ export interface BlogTransformOptions {
   generatedAt: string;
   actorId: string;
   fallbackAuthor: string;
+  allowedMediaHosts: readonly string[];
 }
 
 export interface BlogTransformResult {
@@ -81,8 +85,9 @@ export function transformBlogContent(
   const generatedAt = unixTimestamp(requiredMigrationTime(options.generatedAt))!;
   const actorId = options.actorId.trim();
   const fallbackAuthor = options.fallbackAuthor.trim();
-  if (!actorId) throw new TypeError("actorId is required for blog attribution");
-  if (!fallbackAuthor) throw new TypeError("fallbackAuthor is required");
+  const allowedMediaHosts = mediaHostAllowlist(options.allowedMediaHosts);
+  if (!actorId || actorId.length > 255) throw new TypeError("actorId must be 1-255 characters for blog attribution");
+  if (!fallbackAuthor || fallbackAuthor.length > 160) throw new TypeError("fallbackAuthor must be 1-160 characters");
 
   const categories: BlogCategoryPlan[] = [];
   const records: BlogPostPlan[] = [];
@@ -100,7 +105,7 @@ export function transformBlogContent(
     const slug = normalizeSlug(blog.handle ?? "");
     const exactHandle = blog.handle?.trim();
     if (
-      !sourceId || !name || name.length > 120 || !slug || slug.length > 160 ||
+      !sourceId || sourceId.length > 256 || !name || name.length > 120 || !slug || slug.length > 160 ||
       exactHandle !== slug || !/^[a-z0-9]+(?:-[a-z0-9]+)*$/u.test(exactHandle)
     ) {
       skipped.push({ record: blog, reason: "Blog requires an id, title, and valid handle" });
@@ -129,17 +134,22 @@ export function transformBlogContent(
 
   for (const article of articles) {
     const sourceId = String(article.id ?? "").trim();
-    const sourceFingerprint = sourceId
+    const sourceFingerprint = sourceId && sourceId.length <= 256
       ? providerFingerprint(SHOPIFY_PROVIDER, "article", sourceId)
       : "";
-    const blogFingerprint = providerFingerprint(SHOPIFY_PROVIDER, "blog", article.blog_id);
+    const blogSourceId = String(article.blog_id ?? "").trim();
+    const blogFingerprint = blogSourceId && blogSourceId.length <= 256
+      ? providerFingerprint(SHOPIFY_PROVIDER, "blog", blogSourceId)
+      : "";
     const category = blogByFingerprint.get(blogFingerprint);
     const title = article.title?.trim();
     const slug = normalizeSlug(article.handle ?? "");
     const exactHandle = article.handle?.trim();
     const author = article.author?.trim() || fallbackAuthor;
     if (
-      !sourceFingerprint || !category || !title || title.length > 200 || !slug || slug.length > 160 || !author ||
+      !sourceFingerprint || sourceId.length > 256 || !category || !title || title.length > 200 || !slug || slug.length > 160 || !author ||
+      author.length > 160 || (article.body_html?.length ?? 0) > 100_000 ||
+      (article.summary_html?.length ?? 0) > 10_000 || (article.tags?.length ?? 0) > 4_000 ||
       exactHandle !== slug || !/^[a-z0-9]+(?:-[a-z0-9]+)*$/u.test(exactHandle)
     ) {
       skipped.push({
@@ -154,15 +164,17 @@ export function transformBlogContent(
       skipped.push({ record: article, reason: `Duplicate blog post slug: ${slug}` });
       continue;
     }
-    postSlugs.add(slug);
-
     const ownerId = deterministicProviderId(SHOPIFY_PROVIDER, "article", sourceId);
-    const body = rewriteAndSanitizeHtml(article.body_html ?? "", ownerId, "blog-inline");
+    const body = rewriteAndSanitizeHtml(article.body_html ?? "", allowedMediaHosts, ownerId, "blog-inline");
+    if (body.html.length > 100_000 || !fitsEscapedSqlText(body.html)) {
+      skipped.push({ record: article, reason: "Article content exceeds the SQL-safe text limit" });
+      continue;
+    }
     const cover = article.image?.src
-      ? mediaRewrite(article.image.src, ownerId, "blog-cover", 1, {
-        altText: article.image.alt?.trim() || title,
-        width: article.image.width,
-        height: article.image.height,
+      ? mediaRewrite(article.image.src, allowedMediaHosts, ownerId, "blog-cover", 1, {
+        altText: (article.image.alt?.trim() || title).slice(0, 300),
+        width: boundedPositiveInteger(article.image.width),
+        height: boundedPositiveInteger(article.image.height),
       })
       : null;
     if (article.image?.src && !cover) {
@@ -172,9 +184,21 @@ export function transformBlogContent(
     if (article.published_at && publishedAt === null) {
       warnings.push(`Article ${sourceFingerprint} has an invalid publication time and was imported as draft`);
     }
-    const status = article.published !== false && publishedAt !== null ? "published" : "draft";
+    const requestedPublished = article.published !== false && publishedAt !== null;
+    const status = requestedPublished && body.html.trim() ? "published" : "draft";
+    if (requestedPublished && !body.html.trim()) {
+      warnings.push(`Article ${sourceFingerprint} has no safe content and was imported as draft`);
+    }
     const summary = article.summary_html ? excerptFromHtml(article.summary_html) : excerptFromHtml(body.html);
-    const tags = normalizeBlogTags((article.tags ?? "").split(",").filter((tag) => tag.trim()));
+    let tags: string[];
+    try {
+      tags = normalizeBlogTags((article.tags ?? "").split(",").filter((tag) => tag.trim()));
+    } catch {
+      skipped.push({ record: article, reason: "Article tags exceed the current blog limits" });
+      continue;
+    }
+
+    postSlugs.add(slug);
 
     records.push({
       sourceFingerprint,

--- a/scripts/shopify-migration/transformers/blog.ts
+++ b/scripts/shopify-migration/transformers/blog.ts
@@ -1,0 +1,219 @@
+import { calculateBlogReadingTime, normalizeBlogTags } from "../../../lib/blog/values.js";
+import type { ShopifyArticle, ShopifyBlog } from "../lib/types.js";
+import { deterministicProviderId, providerFingerprint } from "../lib/ids.js";
+import {
+  SHOPIFY_PROVIDER,
+  excerptFromHtml,
+  mediaRewrite,
+  normalizeSlug,
+  requiredMigrationTime,
+  rewriteAndSanitizeHtml,
+  unixTimestamp,
+  type MediaRewrite,
+  type TransformFailure,
+} from "./_shared.js";
+
+export interface BlogCategoryPlan {
+  sourceFingerprint: string;
+  record: {
+    name: string;
+    slug: string;
+    description: null;
+    created_at: number;
+    updated_at: number;
+  };
+  conflict: { strategy: "insert-only"; key: "slug"; onConflict: "reuse" };
+}
+
+export interface BlogPostPlan {
+  sourceFingerprint: string;
+  categoryReference: { provider: typeof SHOPIFY_PROVIDER; sourceFingerprint: string; slug: string };
+  record: {
+    title: string;
+    slug: string;
+    author: string;
+    excerpt: string | null;
+    tags: string;
+    cover_image_url: string | null;
+    cover_image_alt: string | null;
+    status: "draft" | "published";
+    editor_json: null;
+    html: string;
+    reading_time: number;
+    meta_title: string;
+    meta_description: string | null;
+    published_at: number | null;
+    created_at: number;
+    updated_at: number;
+    created_by: string;
+    updated_by: string;
+  };
+  media: MediaRewrite[];
+  redirect: {
+    sourcePath: string;
+    targetPath: string;
+    statusCode: 301;
+    entityType: "blog";
+  };
+  conflict: { strategy: "insert-only"; key: "slug"; onConflict: "skip" };
+}
+
+export interface BlogTransformOptions {
+  generatedAt: string;
+  actorId: string;
+  fallbackAuthor: string;
+}
+
+export interface BlogTransformResult {
+  categories: BlogCategoryPlan[];
+  records: BlogPostPlan[];
+  idMap: Map<string, string>;
+  categoryIdMap: Map<string, string>;
+  skipped: Array<TransformFailure<ShopifyBlog | ShopifyArticle>>;
+  warnings: string[];
+}
+
+export function transformBlogContent(
+  blogs: readonly ShopifyBlog[],
+  articles: readonly ShopifyArticle[],
+  options: BlogTransformOptions,
+): BlogTransformResult {
+  const generatedAt = unixTimestamp(requiredMigrationTime(options.generatedAt))!;
+  const actorId = options.actorId.trim();
+  const fallbackAuthor = options.fallbackAuthor.trim();
+  if (!actorId) throw new TypeError("actorId is required for blog attribution");
+  if (!fallbackAuthor) throw new TypeError("fallbackAuthor is required");
+
+  const categories: BlogCategoryPlan[] = [];
+  const records: BlogPostPlan[] = [];
+  const idMap = new Map<string, string>();
+  const categoryIdMap = new Map<string, string>();
+  const skipped: Array<TransformFailure<ShopifyBlog | ShopifyArticle>> = [];
+  const warnings: string[] = [];
+  const categorySlugs = new Set<string>();
+  const postSlugs = new Set<string>();
+  const blogByFingerprint = new Map<string, { slug: string; handle: string }>();
+
+  for (const blog of blogs) {
+    const sourceId = String(blog.id ?? "").trim();
+    const name = blog.title?.trim();
+    const slug = normalizeSlug(blog.handle ?? "");
+    const exactHandle = blog.handle?.trim();
+    if (
+      !sourceId || !name || name.length > 120 || !slug || slug.length > 160 ||
+      exactHandle !== slug || !/^[a-z0-9]+(?:-[a-z0-9]+)*$/u.test(exactHandle)
+    ) {
+      skipped.push({ record: blog, reason: "Blog requires an id, title, and valid handle" });
+      continue;
+    }
+    if (categorySlugs.has(slug)) {
+      skipped.push({ record: blog, reason: `Duplicate blog category slug: ${slug}` });
+      continue;
+    }
+    categorySlugs.add(slug);
+    const fingerprint = providerFingerprint(SHOPIFY_PROVIDER, "blog", sourceId);
+    categoryIdMap.set(fingerprint, slug);
+    blogByFingerprint.set(fingerprint, { slug, handle: exactHandle });
+    categories.push({
+      sourceFingerprint: fingerprint,
+      record: {
+        name,
+        slug,
+        description: null,
+        created_at: unixTimestamp(blog.created_at) ?? generatedAt,
+        updated_at: unixTimestamp(blog.updated_at) ?? generatedAt,
+      },
+      conflict: { strategy: "insert-only", key: "slug", onConflict: "reuse" },
+    });
+  }
+
+  for (const article of articles) {
+    const sourceId = String(article.id ?? "").trim();
+    const sourceFingerprint = sourceId
+      ? providerFingerprint(SHOPIFY_PROVIDER, "article", sourceId)
+      : "";
+    const blogFingerprint = providerFingerprint(SHOPIFY_PROVIDER, "blog", article.blog_id);
+    const category = blogByFingerprint.get(blogFingerprint);
+    const title = article.title?.trim();
+    const slug = normalizeSlug(article.handle ?? "");
+    const exactHandle = article.handle?.trim();
+    const author = article.author?.trim() || fallbackAuthor;
+    if (
+      !sourceFingerprint || !category || !title || title.length > 200 || !slug || slug.length > 160 || !author ||
+      exactHandle !== slug || !/^[a-z0-9]+(?:-[a-z0-9]+)*$/u.test(exactHandle)
+    ) {
+      skipped.push({
+        record: article,
+        reason: !category
+          ? "Article references a blog that was not imported"
+          : "Article requires an id, title, author, and valid handle",
+      });
+      continue;
+    }
+    if (postSlugs.has(slug)) {
+      skipped.push({ record: article, reason: `Duplicate blog post slug: ${slug}` });
+      continue;
+    }
+    postSlugs.add(slug);
+
+    const ownerId = deterministicProviderId(SHOPIFY_PROVIDER, "article", sourceId);
+    const body = rewriteAndSanitizeHtml(article.body_html ?? "", ownerId, "blog-inline");
+    const cover = article.image?.src
+      ? mediaRewrite(article.image.src, ownerId, "blog-cover", 1, {
+        altText: article.image.alt?.trim() || title,
+        width: article.image.width,
+        height: article.image.height,
+      })
+      : null;
+    if (article.image?.src && !cover) {
+      warnings.push(`Article ${sourceFingerprint} has an invalid or unsupported cover image; image omitted`);
+    }
+    const publishedAt = unixTimestamp(article.published_at);
+    if (article.published_at && publishedAt === null) {
+      warnings.push(`Article ${sourceFingerprint} has an invalid publication time and was imported as draft`);
+    }
+    const status = article.published !== false && publishedAt !== null ? "published" : "draft";
+    const summary = article.summary_html ? excerptFromHtml(article.summary_html) : excerptFromHtml(body.html);
+    const tags = normalizeBlogTags((article.tags ?? "").split(",").filter((tag) => tag.trim()));
+
+    records.push({
+      sourceFingerprint,
+      categoryReference: {
+        provider: SHOPIFY_PROVIDER,
+        sourceFingerprint: blogFingerprint,
+        slug: category.slug,
+      },
+      record: {
+        title,
+        slug,
+        author,
+        excerpt: summary,
+        tags: JSON.stringify(tags),
+        cover_image_url: cover?.publicPath ?? null,
+        cover_image_alt: cover?.altText ?? null,
+        status,
+        editor_json: null,
+        html: body.html,
+        reading_time: calculateBlogReadingTime(body.html),
+        meta_title: title,
+        meta_description: summary,
+        published_at: status === "published" ? publishedAt : null,
+        created_at: unixTimestamp(article.created_at) ?? generatedAt,
+        updated_at: unixTimestamp(article.updated_at) ?? generatedAt,
+        created_by: actorId,
+        updated_by: actorId,
+      },
+      media: [...(cover ? [cover] : []), ...body.media],
+      redirect: {
+        sourcePath: `/blogs/${category.handle}/${slug}`,
+        targetPath: `/blog/${slug}`,
+        statusCode: 301,
+        entityType: "blog",
+      },
+      conflict: { strategy: "insert-only", key: "slug", onConflict: "skip" },
+    });
+    idMap.set(sourceFingerprint, slug);
+  }
+
+  return { categories, records, idMap, categoryIdMap, skipped, warnings };
+}

--- a/scripts/shopify-migration/transformers/categories.ts
+++ b/scripts/shopify-migration/transformers/categories.ts
@@ -4,6 +4,7 @@ import {
   SHOPIFY_PROVIDER,
   UNKNOWN_SOURCE_TIMESTAMP,
   boundedPositiveInteger,
+  canonicalProviderRecords,
   clampInventory,
   excerptFromHtml,
   fitsEscapedSqlText,
@@ -60,10 +61,12 @@ export function transformCollections(
   const idMap = new Map<string, string>();
   const skipped: Array<{ record: ShopifyCollection; reason: string }> = [];
   const warnings: string[] = [];
-  const slugs = new Set<string>();
+  const sourceByFingerprint = new Map<string, ShopifyCollection>();
 
-  collections.forEach((collection, position) => {
+  const canonical = canonicalProviderRecords(collections, "category", (collection) => collection.id);
+  canonical.records.forEach((collection) => {
     const sourceId = String(collection.id ?? "").trim();
+    const sourceFingerprint = sourceId ? providerFingerprint(SHOPIFY_PROVIDER, "category", sourceId) : "";
     const slug = normalizeSlug(collection.handle ?? "");
     const title = collection.title?.trim();
     if (
@@ -73,8 +76,8 @@ export function transformCollections(
       skipped.push({ record: collection, reason: "Collection requires an id, title, and valid handle" });
       return;
     }
-    if (slugs.has(slug)) {
-      skipped.push({ record: collection, reason: `Duplicate category slug: ${slug}` });
+    if (canonical.duplicateFingerprints.has(sourceFingerprint)) {
+      skipped.push({ record: collection, reason: "Duplicate collection source identity" });
       return;
     }
     const id = deterministicProviderId(SHOPIFY_PROVIDER, "category", sourceId);
@@ -85,8 +88,7 @@ export function transformCollections(
       skipped.push({ record: collection, reason: "Category description exceeds the SQL-safe text limit" });
       return;
     }
-    slugs.add(slug);
-    idMap.set(providerFingerprint(SHOPIFY_PROVIDER, "category", sourceId), id);
+    sourceByFingerprint.set(sourceFingerprint, collection);
     const image = collection.image?.src
       ? mediaRewrite(collection.image.src, allowedMediaHosts, id, "category", 1, {
         altText: (collection.image.alt?.trim() || title).slice(0, 300),
@@ -116,7 +118,7 @@ export function transformCollections(
     } : null;
 
     records.push({
-      sourceFingerprint: providerFingerprint(SHOPIFY_PROVIDER, "category", sourceId),
+      sourceFingerprint,
       media: image ? [image] : [],
       category: {
         id,
@@ -125,10 +127,10 @@ export function transformCollections(
         slug,
         status: hasValidTimestamp(collection.published_at) ? "active" : "inactive",
         parent_id: null,
-        position: position + 1,
+        position: 0,
         path: `/${slug}`,
         external_references: JSON.stringify({
-          shopify_fingerprint: providerFingerprint(SHOPIFY_PROVIDER, "category", sourceId),
+          shopify_fingerprint: sourceFingerprint,
         }),
         created_at: isoTimestamp(collection.published_at, UNKNOWN_SOURCE_TIMESTAMP),
         updated_at: isoTimestamp(collection.updated_at, UNKNOWN_SOURCE_TIMESTAMP),
@@ -144,5 +146,16 @@ export function transformCollections(
     });
   });
 
-  return { records, idMap, skipped, warnings };
+  const slugCounts = new Map<string, number>();
+  for (const { category } of records) slugCounts.set(category.slug, (slugCounts.get(category.slug) ?? 0) + 1);
+  const accepted = records.flatMap((record) => {
+    if (slugCounts.get(record.category.slug) === 1) return [record];
+    skipped.push({ record: sourceByFingerprint.get(record.sourceFingerprint)!, reason: `Ambiguous duplicate category slug: ${record.category.slug}` });
+    return [];
+  }).map((record, position) => ({
+    ...record,
+    category: { ...record.category, position: position + 1 },
+  }));
+  for (const record of accepted) idMap.set(record.sourceFingerprint, record.category.id);
+  return { records: accepted, idMap, skipped, warnings };
 }

--- a/scripts/shopify-migration/transformers/categories.ts
+++ b/scripts/shopify-migration/transformers/categories.ts
@@ -1,0 +1,134 @@
+import type { ShopifyCollection } from "../lib/types.js";
+import { deterministicProviderId, providerFingerprint } from "../lib/ids.js";
+import {
+  SHOPIFY_PROVIDER,
+  excerptFromHtml,
+  hasValidTimestamp,
+  isoTimestamp,
+  mediaRewrite,
+  normalizeSlug,
+  requiredMigrationTime,
+  type MediaRewrite,
+  type PureTransformResult,
+} from "./_shared.js";
+
+export interface CategoryInsertRecord {
+  id: string;
+  name: string;
+  description: string | null;
+  slug: string;
+  status: "active" | "inactive";
+  parent_id: null;
+  position: number;
+  path: string;
+  external_references: string;
+  created_at: string;
+  updated_at: string;
+  children: string;
+  product_count: number;
+  attributes: string;
+  tags: string;
+  primary_image: string | null;
+  media: string | null;
+  seo: null;
+  extensions: string;
+}
+
+export interface CategoryTransformRecord {
+  sourceFingerprint: string;
+  category: CategoryInsertRecord;
+  media: MediaRewrite[];
+}
+
+export interface CategoryTransformOptions {
+  generatedAt: string;
+}
+
+export function transformCollections(
+  collections: readonly ShopifyCollection[],
+  options: CategoryTransformOptions,
+): PureTransformResult<ShopifyCollection, CategoryTransformRecord> {
+  const generatedAt = requiredMigrationTime(options.generatedAt);
+  const records: CategoryTransformRecord[] = [];
+  const idMap = new Map<string, string>();
+  const skipped: Array<{ record: ShopifyCollection; reason: string }> = [];
+  const warnings: string[] = [];
+  const slugs = new Set<string>();
+
+  collections.forEach((collection, position) => {
+    const sourceId = String(collection.id ?? "").trim();
+    const slug = normalizeSlug(collection.handle ?? "");
+    const title = collection.title?.trim();
+    if (!sourceId || !slug || !title) {
+      skipped.push({ record: collection, reason: "Collection requires an id, title, and valid handle" });
+      return;
+    }
+    if (slugs.has(slug)) {
+      skipped.push({ record: collection, reason: `Duplicate category slug: ${slug}` });
+      return;
+    }
+    slugs.add(slug);
+
+    const id = deterministicProviderId(SHOPIFY_PROVIDER, "category", sourceId);
+    idMap.set(providerFingerprint(SHOPIFY_PROVIDER, "category", sourceId), id);
+    const image = collection.image?.src
+      ? mediaRewrite(collection.image.src, id, "category", 1, {
+        altText: collection.image.alt?.trim() || title,
+        width: collection.image.width,
+        height: collection.image.height,
+      })
+      : null;
+    if (collection.image?.src && !image) {
+      warnings.push(
+        `Collection ${providerFingerprint(SHOPIFY_PROVIDER, "category", sourceId)} has an invalid or unsupported image URL; image omitted`,
+      );
+    }
+    const primaryImage = image ? {
+      id: deterministicProviderId(SHOPIFY_PROVIDER, "media", `${sourceId}:category:1`),
+      type: "image",
+      status: "active",
+      external_references: {
+        shopify_fingerprint: providerFingerprint(SHOPIFY_PROVIDER, "media", `${sourceId}:category:1`),
+      },
+      file: {
+        url: image.publicPath,
+        format: image.objectKey.split(".").at(-1) ?? "jpg",
+        ...(image.width ? { width: image.width } : {}),
+        ...(image.height ? { height: image.height } : {}),
+      },
+      accessibility: { alt_text: image.altText },
+    } : null;
+
+    records.push({
+      sourceFingerprint: providerFingerprint(SHOPIFY_PROVIDER, "category", sourceId),
+      media: image ? [image] : [],
+      category: {
+        id,
+        name: JSON.stringify({ en: title }),
+        description: collection.body_html
+          ? JSON.stringify({ en: excerptFromHtml(collection.body_html, 10_000) ?? "" })
+          : null,
+        slug,
+        status: hasValidTimestamp(collection.published_at) ? "active" : "inactive",
+        parent_id: null,
+        position: position + 1,
+        path: `/${slug}`,
+        external_references: JSON.stringify({
+          shopify_fingerprint: providerFingerprint(SHOPIFY_PROVIDER, "category", sourceId),
+        }),
+        created_at: isoTimestamp(collection.published_at, generatedAt),
+        updated_at: isoTimestamp(collection.updated_at, generatedAt),
+        children: "[]",
+        product_count: Math.max(0, Math.trunc(collection.products_count ?? 0)),
+        attributes: "{}",
+        tags: "[]",
+        primary_image: primaryImage ? JSON.stringify(primaryImage) : null,
+        media: primaryImage ? JSON.stringify([primaryImage]) : null,
+        seo: null,
+        extensions: JSON.stringify({ shopify: { collection_type: collection.collection_type ?? null } }),
+      },
+    });
+  });
+
+  return { records, idMap, skipped, warnings };
+}

--- a/scripts/shopify-migration/transformers/categories.ts
+++ b/scripts/shopify-migration/transformers/categories.ts
@@ -2,9 +2,13 @@ import type { ShopifyCollection } from "../lib/types.js";
 import { deterministicProviderId, providerFingerprint } from "../lib/ids.js";
 import {
   SHOPIFY_PROVIDER,
+  boundedPositiveInteger,
+  clampInventory,
   excerptFromHtml,
+  fitsEscapedSqlText,
   hasValidTimestamp,
   isoTimestamp,
+  mediaHostAllowlist,
   mediaRewrite,
   normalizeSlug,
   requiredMigrationTime,
@@ -42,6 +46,7 @@ export interface CategoryTransformRecord {
 
 export interface CategoryTransformOptions {
   generatedAt: string;
+  allowedMediaHosts: readonly string[];
 }
 
 export function transformCollections(
@@ -49,6 +54,7 @@ export function transformCollections(
   options: CategoryTransformOptions,
 ): PureTransformResult<ShopifyCollection, CategoryTransformRecord> {
   const generatedAt = requiredMigrationTime(options.generatedAt);
+  const allowedMediaHosts = mediaHostAllowlist(options.allowedMediaHosts);
   const records: CategoryTransformRecord[] = [];
   const idMap = new Map<string, string>();
   const skipped: Array<{ record: ShopifyCollection; reason: string }> = [];
@@ -59,7 +65,10 @@ export function transformCollections(
     const sourceId = String(collection.id ?? "").trim();
     const slug = normalizeSlug(collection.handle ?? "");
     const title = collection.title?.trim();
-    if (!sourceId || !slug || !title) {
+    if (
+      !sourceId || sourceId.length > 256 || !slug || slug.length > 160 || !title || title.length > 120 ||
+      (collection.body_html?.length ?? 0) > 100_000
+    ) {
       skipped.push({ record: collection, reason: "Collection requires an id, title, and valid handle" });
       return;
     }
@@ -70,12 +79,19 @@ export function transformCollections(
     slugs.add(slug);
 
     const id = deterministicProviderId(SHOPIFY_PROVIDER, "category", sourceId);
+    const description = collection.body_html
+      ? JSON.stringify({ en: excerptFromHtml(collection.body_html, 10_000) ?? "" })
+      : null;
+    if (description && !fitsEscapedSqlText(description, 24 * 1024)) {
+      skipped.push({ record: collection, reason: "Category description exceeds the SQL-safe text limit" });
+      return;
+    }
     idMap.set(providerFingerprint(SHOPIFY_PROVIDER, "category", sourceId), id);
     const image = collection.image?.src
-      ? mediaRewrite(collection.image.src, id, "category", 1, {
-        altText: collection.image.alt?.trim() || title,
-        width: collection.image.width,
-        height: collection.image.height,
+      ? mediaRewrite(collection.image.src, allowedMediaHosts, id, "category", 1, {
+        altText: (collection.image.alt?.trim() || title).slice(0, 300),
+        width: boundedPositiveInteger(collection.image.width),
+        height: boundedPositiveInteger(collection.image.height),
       })
       : null;
     if (collection.image?.src && !image) {
@@ -105,9 +121,7 @@ export function transformCollections(
       category: {
         id,
         name: JSON.stringify({ en: title }),
-        description: collection.body_html
-          ? JSON.stringify({ en: excerptFromHtml(collection.body_html, 10_000) ?? "" })
-          : null,
+        description,
         slug,
         status: hasValidTimestamp(collection.published_at) ? "active" : "inactive",
         parent_id: null,
@@ -119,7 +133,7 @@ export function transformCollections(
         created_at: isoTimestamp(collection.published_at, generatedAt),
         updated_at: isoTimestamp(collection.updated_at, generatedAt),
         children: "[]",
-        product_count: Math.max(0, Math.trunc(collection.products_count ?? 0)),
+        product_count: clampInventory(collection.products_count),
         attributes: "{}",
         tags: "[]",
         primary_image: primaryImage ? JSON.stringify(primaryImage) : null,

--- a/scripts/shopify-migration/transformers/categories.ts
+++ b/scripts/shopify-migration/transformers/categories.ts
@@ -2,6 +2,7 @@ import type { ShopifyCollection } from "../lib/types.js";
 import { deterministicProviderId, providerFingerprint } from "../lib/ids.js";
 import {
   SHOPIFY_PROVIDER,
+  UNKNOWN_SOURCE_TIMESTAMP,
   boundedPositiveInteger,
   clampInventory,
   excerptFromHtml,
@@ -53,7 +54,7 @@ export function transformCollections(
   collections: readonly ShopifyCollection[],
   options: CategoryTransformOptions,
 ): PureTransformResult<ShopifyCollection, CategoryTransformRecord> {
-  const generatedAt = requiredMigrationTime(options.generatedAt);
+  requiredMigrationTime(options.generatedAt);
   const allowedMediaHosts = mediaHostAllowlist(options.allowedMediaHosts);
   const records: CategoryTransformRecord[] = [];
   const idMap = new Map<string, string>();
@@ -130,8 +131,8 @@ export function transformCollections(
         external_references: JSON.stringify({
           shopify_fingerprint: providerFingerprint(SHOPIFY_PROVIDER, "category", sourceId),
         }),
-        created_at: isoTimestamp(collection.published_at, generatedAt),
-        updated_at: isoTimestamp(collection.updated_at, generatedAt),
+        created_at: isoTimestamp(collection.published_at, UNKNOWN_SOURCE_TIMESTAMP),
+        updated_at: isoTimestamp(collection.updated_at, UNKNOWN_SOURCE_TIMESTAMP),
         children: "[]",
         product_count: clampInventory(collection.products_count),
         attributes: "{}",

--- a/scripts/shopify-migration/transformers/categories.ts
+++ b/scripts/shopify-migration/transformers/categories.ts
@@ -77,8 +77,6 @@ export function transformCollections(
       skipped.push({ record: collection, reason: `Duplicate category slug: ${slug}` });
       return;
     }
-    slugs.add(slug);
-
     const id = deterministicProviderId(SHOPIFY_PROVIDER, "category", sourceId);
     const description = collection.body_html
       ? JSON.stringify({ en: excerptFromHtml(collection.body_html, 10_000) ?? "" })
@@ -87,6 +85,7 @@ export function transformCollections(
       skipped.push({ record: collection, reason: "Category description exceeds the SQL-safe text limit" });
       return;
     }
+    slugs.add(slug);
     idMap.set(providerFingerprint(SHOPIFY_PROVIDER, "category", sourceId), id);
     const image = collection.image?.src
       ? mediaRewrite(collection.image.src, allowedMediaHosts, id, "category", 1, {

--- a/scripts/shopify-migration/transformers/index.ts
+++ b/scripts/shopify-migration/transformers/index.ts
@@ -1,0 +1,5 @@
+export * from "./blog.js";
+export * from "./categories.js";
+export * from "./pages.js";
+export * from "./products.js";
+export * from "./redirects.js";

--- a/scripts/shopify-migration/transformers/pages.ts
+++ b/scripts/shopify-migration/transformers/pages.ts
@@ -2,6 +2,7 @@ import type { ShopifyPage } from "../lib/types.js";
 import { deterministicProviderId, providerFingerprint } from "../lib/ids.js";
 import {
   SHOPIFY_PROVIDER,
+  UNKNOWN_SOURCE_UNIX_TIMESTAMP,
   excerptFromHtml,
   fitsEscapedSqlText,
   isReservedPageSlug,
@@ -74,8 +75,7 @@ export function transformPages(
   pages: readonly ShopifyPage[],
   options: PageTransformOptions,
 ): PureTransformResult<ShopifyPage, PageTransformRecord> {
-  const generatedAtIso = requiredMigrationTime(options.generatedAt);
-  const generatedAt = unixTimestamp(generatedAtIso)!;
+  requiredMigrationTime(options.generatedAt);
   const actorId = options.actorId.trim();
   const allowedMediaHosts = mediaHostAllowlist(options.allowedMediaHosts);
   if (!actorId || actorId.length > 255) throw new TypeError("actorId must be 1-255 characters for page version attribution");
@@ -121,8 +121,8 @@ export function transformPages(
     if (source.published_at && publishedAt === null) {
       warnings.push(`Page ${sourceFingerprint} has an invalid publication time and was imported as draft`);
     }
-    const createdAt = unixTimestamp(source.created_at) ?? generatedAt;
-    const updatedAt = unixTimestamp(source.updated_at) ?? generatedAt;
+    const createdAt = unixTimestamp(source.created_at) ?? UNKNOWN_SOURCE_UNIX_TIMESTAMP;
+    const updatedAt = unixTimestamp(source.updated_at) ?? UNKNOWN_SOURCE_UNIX_TIMESTAMP;
     const excerpt = excerptFromHtml(html);
     const page: PageInsertRecord = {
       title,

--- a/scripts/shopify-migration/transformers/pages.ts
+++ b/scripts/shopify-migration/transformers/pages.ts
@@ -1,0 +1,165 @@
+import type { ShopifyPage } from "../lib/types.js";
+import { deterministicProviderId, providerFingerprint } from "../lib/ids.js";
+import {
+  SHOPIFY_PROVIDER,
+  excerptFromHtml,
+  isReservedPageSlug,
+  normalizeSlug,
+  requiredMigrationTime,
+  rewriteAndSanitizeHtml,
+  unixTimestamp,
+  type MediaRewrite,
+  type PureTransformResult,
+} from "./_shared.js";
+
+export interface PageInsertRecord {
+  title: string;
+  slug: string;
+  content: string;
+  excerpt: string | null;
+  meta_title: string;
+  meta_description: string | null;
+  meta_keywords: null;
+  status: "draft" | "published";
+  published_at: number | null;
+  template: string;
+  parent_id: null;
+  sort_order: number;
+  created_at: number;
+  updated_at: number;
+  created_by: string;
+  updated_by: string;
+  version: 1;
+  show_in_nav: 0;
+  nav_title: null;
+  custom_css: null;
+  custom_js: null;
+  is_protected: 0;
+  required_roles: null;
+}
+
+export interface InitialPageVersionPlan {
+  pageReference: { provider: typeof SHOPIFY_PROVIDER; sourceFingerprint: string; slug: string };
+  record: {
+    title: string;
+    content: string;
+    excerpt: string | null;
+    meta_title: string;
+    meta_description: string | null;
+    meta_keywords: null;
+    version: 1;
+    change_summary: "Initial Shopify import";
+    created_at: number;
+    created_by: string;
+  };
+}
+
+export interface PageTransformRecord {
+  sourceFingerprint: string;
+  page: PageInsertRecord;
+  initialVersion: InitialPageVersionPlan;
+  media: MediaRewrite[];
+  conflict: { strategy: "insert-only"; key: "slug"; onConflict: "skip" };
+}
+
+export interface PageTransformOptions {
+  generatedAt: string;
+  actorId: string;
+}
+
+export function transformPages(
+  pages: readonly ShopifyPage[],
+  options: PageTransformOptions,
+): PureTransformResult<ShopifyPage, PageTransformRecord> {
+  const generatedAtIso = requiredMigrationTime(options.generatedAt);
+  const generatedAt = unixTimestamp(generatedAtIso)!;
+  const actorId = options.actorId.trim();
+  if (!actorId) throw new TypeError("actorId is required for page version attribution");
+  const records: PageTransformRecord[] = [];
+  const idMap = new Map<string, string>();
+  const skipped: Array<{ record: ShopifyPage; reason: string }> = [];
+  const warnings: string[] = [];
+  const slugs = new Set<string>();
+
+  for (const source of pages) {
+    const sourceId = String(source.id ?? "").trim();
+    const title = source.title?.trim();
+    const slug = normalizeSlug(source.handle ?? "");
+    if (!sourceId || !title || !slug) {
+      skipped.push({ record: source, reason: "Page requires an id, title, and valid handle" });
+      continue;
+    }
+    if (isReservedPageSlug(slug)) {
+      skipped.push({ record: source, reason: `Page slug is reserved by the storefront: ${slug}` });
+      continue;
+    }
+    if (slugs.has(slug)) {
+      skipped.push({ record: source, reason: `Duplicate page slug: ${slug}` });
+      continue;
+    }
+    slugs.add(slug);
+
+    const pageReferenceId = deterministicProviderId(SHOPIFY_PROVIDER, "page", sourceId);
+    const sourceFingerprint = providerFingerprint(SHOPIFY_PROVIDER, "page", sourceId);
+    const { html, media } = rewriteAndSanitizeHtml(source.body_html ?? "", pageReferenceId, "page-inline");
+    const publishedAt = unixTimestamp(source.published_at);
+    if (source.published_at && publishedAt === null) {
+      warnings.push(`Page ${sourceFingerprint} has an invalid publication time and was imported as draft`);
+    }
+    const createdAt = unixTimestamp(source.created_at) ?? generatedAt;
+    const updatedAt = unixTimestamp(source.updated_at) ?? generatedAt;
+    const excerpt = excerptFromHtml(html);
+    const page: PageInsertRecord = {
+      title,
+      slug,
+      content: html,
+      excerpt,
+      meta_title: title,
+      meta_description: excerpt,
+      meta_keywords: null,
+      status: publishedAt === null ? "draft" : "published",
+      published_at: publishedAt,
+      template: source.template_suffix?.trim() || "default",
+      parent_id: null,
+      sort_order: 0,
+      created_at: createdAt,
+      updated_at: updatedAt,
+      created_by: actorId,
+      updated_by: actorId,
+      version: 1,
+      show_in_nav: 0,
+      nav_title: null,
+      custom_css: null,
+      custom_js: null,
+      is_protected: 0,
+      required_roles: null,
+    };
+    records.push({
+      sourceFingerprint,
+      page,
+      media,
+      conflict: { strategy: "insert-only", key: "slug", onConflict: "skip" },
+      initialVersion: {
+        pageReference: {
+          provider: SHOPIFY_PROVIDER,
+          sourceFingerprint,
+          slug,
+        },
+        record: {
+          title,
+          content: html,
+          excerpt,
+          meta_title: title,
+          meta_description: excerpt,
+          meta_keywords: null,
+          version: 1,
+          change_summary: "Initial Shopify import",
+          created_at: createdAt,
+          created_by: actorId,
+        },
+      },
+    });
+    idMap.set(sourceFingerprint, slug);
+  }
+  return { records, idMap, skipped, warnings };
+}

--- a/scripts/shopify-migration/transformers/pages.ts
+++ b/scripts/shopify-migration/transformers/pages.ts
@@ -3,6 +3,7 @@ import { deterministicProviderId, providerFingerprint } from "../lib/ids.js";
 import {
   SHOPIFY_PROVIDER,
   UNKNOWN_SOURCE_UNIX_TIMESTAMP,
+  canonicalProviderRecords,
   excerptFromHtml,
   fitsEscapedSqlText,
   isReservedPageSlug,
@@ -83,9 +84,10 @@ export function transformPages(
   const idMap = new Map<string, string>();
   const skipped: Array<{ record: ShopifyPage; reason: string }> = [];
   const warnings: string[] = [];
-  const slugs = new Set<string>();
+  const sourceByFingerprint = new Map<string, ShopifyPage>();
 
-  for (const source of pages) {
+  const canonical = canonicalProviderRecords(pages, "page", (page) => page.id);
+  for (const source of canonical.records) {
     const sourceId = String(source.id ?? "").trim();
     const title = source.title?.trim();
     const slug = normalizeSlug(source.handle ?? "");
@@ -96,16 +98,16 @@ export function transformPages(
       skipped.push({ record: source, reason: "Page requires an id, title, and valid handle" });
       continue;
     }
+    const sourceFingerprint = providerFingerprint(SHOPIFY_PROVIDER, "page", sourceId);
+    if (canonical.duplicateFingerprints.has(sourceFingerprint)) {
+      skipped.push({ record: source, reason: "Duplicate page source identity" });
+      continue;
+    }
     if (isReservedPageSlug(slug)) {
       skipped.push({ record: source, reason: `Page slug is reserved by the storefront: ${slug}` });
       continue;
     }
-    if (slugs.has(slug)) {
-      skipped.push({ record: source, reason: `Duplicate page slug: ${slug}` });
-      continue;
-    }
     const pageReferenceId = deterministicProviderId(SHOPIFY_PROVIDER, "page", sourceId);
-    const sourceFingerprint = providerFingerprint(SHOPIFY_PROVIDER, "page", sourceId);
     const { html, media } = rewriteAndSanitizeHtml(
       source.body_html ?? "",
       allowedMediaHosts,
@@ -116,7 +118,7 @@ export function transformPages(
       skipped.push({ record: source, reason: "Page content is empty or exceeds the SQL-safe text limit" });
       continue;
     }
-    slugs.add(slug);
+    sourceByFingerprint.set(sourceFingerprint, source);
     const publishedAt = unixTimestamp(source.published_at);
     if (source.published_at && publishedAt === null) {
       warnings.push(`Page ${sourceFingerprint} has an invalid publication time and was imported as draft`);
@@ -174,7 +176,14 @@ export function transformPages(
         },
       },
     });
-    idMap.set(sourceFingerprint, slug);
   }
-  return { records, idMap, skipped, warnings };
+  const slugCounts = new Map<string, number>();
+  for (const { page } of records) slugCounts.set(page.slug, (slugCounts.get(page.slug) ?? 0) + 1);
+  const accepted = records.flatMap((record) => {
+    if (slugCounts.get(record.page.slug) === 1) return [record];
+    skipped.push({ record: sourceByFingerprint.get(record.sourceFingerprint)!, reason: `Ambiguous duplicate page slug: ${record.page.slug}` });
+    return [];
+  });
+  for (const record of accepted) idMap.set(record.sourceFingerprint, record.page.slug);
+  return { records: accepted, idMap, skipped, warnings };
 }

--- a/scripts/shopify-migration/transformers/pages.ts
+++ b/scripts/shopify-migration/transformers/pages.ts
@@ -3,7 +3,9 @@ import { deterministicProviderId, providerFingerprint } from "../lib/ids.js";
 import {
   SHOPIFY_PROVIDER,
   excerptFromHtml,
+  fitsEscapedSqlText,
   isReservedPageSlug,
+  mediaHostAllowlist,
   normalizeSlug,
   requiredMigrationTime,
   rewriteAndSanitizeHtml,
@@ -65,6 +67,7 @@ export interface PageTransformRecord {
 export interface PageTransformOptions {
   generatedAt: string;
   actorId: string;
+  allowedMediaHosts: readonly string[];
 }
 
 export function transformPages(
@@ -74,7 +77,8 @@ export function transformPages(
   const generatedAtIso = requiredMigrationTime(options.generatedAt);
   const generatedAt = unixTimestamp(generatedAtIso)!;
   const actorId = options.actorId.trim();
-  if (!actorId) throw new TypeError("actorId is required for page version attribution");
+  const allowedMediaHosts = mediaHostAllowlist(options.allowedMediaHosts);
+  if (!actorId || actorId.length > 255) throw new TypeError("actorId must be 1-255 characters for page version attribution");
   const records: PageTransformRecord[] = [];
   const idMap = new Map<string, string>();
   const skipped: Array<{ record: ShopifyPage; reason: string }> = [];
@@ -85,7 +89,10 @@ export function transformPages(
     const sourceId = String(source.id ?? "").trim();
     const title = source.title?.trim();
     const slug = normalizeSlug(source.handle ?? "");
-    if (!sourceId || !title || !slug) {
+    if (
+      !sourceId || sourceId.length > 256 || !title || title.length > 500 || !slug || slug.length > 160 ||
+      (source.body_html?.length ?? 0) > 100_000 || (source.template_suffix?.length ?? 0) > 100
+    ) {
       skipped.push({ record: source, reason: "Page requires an id, title, and valid handle" });
       continue;
     }
@@ -97,11 +104,19 @@ export function transformPages(
       skipped.push({ record: source, reason: `Duplicate page slug: ${slug}` });
       continue;
     }
-    slugs.add(slug);
-
     const pageReferenceId = deterministicProviderId(SHOPIFY_PROVIDER, "page", sourceId);
     const sourceFingerprint = providerFingerprint(SHOPIFY_PROVIDER, "page", sourceId);
-    const { html, media } = rewriteAndSanitizeHtml(source.body_html ?? "", pageReferenceId, "page-inline");
+    const { html, media } = rewriteAndSanitizeHtml(
+      source.body_html ?? "",
+      allowedMediaHosts,
+      pageReferenceId,
+      "page-inline",
+    );
+    if (!html.trim() || html.length > 100_000 || !fitsEscapedSqlText(html)) {
+      skipped.push({ record: source, reason: "Page content is empty or exceeds the SQL-safe text limit" });
+      continue;
+    }
+    slugs.add(slug);
     const publishedAt = unixTimestamp(source.published_at);
     if (source.published_at && publishedAt === null) {
       warnings.push(`Page ${sourceFingerprint} has an invalid publication time and was imported as draft`);

--- a/scripts/shopify-migration/transformers/products.ts
+++ b/scripts/shopify-migration/transformers/products.ts
@@ -1,0 +1,379 @@
+import type {
+  ShopifyCollect,
+  ShopifyProduct,
+  ShopifyProductImage,
+  ShopifyProductVariant,
+} from "../lib/types.js";
+import { deterministicProviderId, providerFingerprint } from "../lib/ids.js";
+import {
+  SHOPIFY_PROVIDER,
+  clampInventory,
+  hasValidTimestamp,
+  isoTimestamp,
+  majorToStoredMoney,
+  mediaRewrite,
+  normalizeSlug,
+  plainText,
+  requireSupportedCurrency,
+  requiredMigrationTime,
+  uniqueStrings,
+  type MediaRewrite,
+  type PureTransformResult,
+} from "./_shared.js";
+
+type ProductStatus = "active" | "inactive" | "archived" | "draft";
+type VariantStatus = "active" | "inactive" | "discontinued";
+
+export interface ProductInsertRecord {
+  id: string;
+  name: string;
+  description: string | null;
+  type: string | null;
+  status: ProductStatus;
+  slug: string;
+  brand: string | null;
+  categories: string | null;
+  tags: string | null;
+  options: string | null;
+  default_variant_id: string;
+  fulfillment_type: "physical" | "digital" | "service";
+  tax_category: string | null;
+  primary_image: string | null;
+  media: string | null;
+  seo: string | null;
+  rating: null;
+  related_products: null;
+  external_references: string;
+  extensions: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface VariantInsertRecord {
+  id: string;
+  product_id: string;
+  sku: string;
+  status: VariantStatus;
+  position: number;
+  option_values: string;
+  price: string;
+  compare_at_price: string | null;
+  cost: null;
+  weight: string | null;
+  dimensions: null;
+  barcode: string | null;
+  inventory: string;
+  tax_category: string | null;
+  shipping_required: boolean;
+  media: string;
+  attributes: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface InventoryInsertRecord {
+  id: string;
+  sku_id: string;
+  location_id: string;
+  quantities: string;
+  status: "active" | "inactive";
+  stock_status: "in_stock" | "out_of_stock" | "backorder";
+  external_references: string;
+  created_at: string;
+  updated_at: string;
+  policy_id: null;
+  backorderable: boolean;
+  backorder_eta: null;
+  safety_stock: number;
+  version: number;
+  extensions: string;
+}
+
+export interface ProductTransformRecord {
+  sourceFingerprint: string;
+  product: ProductInsertRecord;
+  variants: VariantInsertRecord[];
+  inventory: InventoryInsertRecord[];
+  media: MediaRewrite[];
+}
+
+export interface ProductTransformOptions {
+  currency: string;
+  generatedAt: string;
+  inventoryLocationId: string;
+  fulfillmentType: "physical" | "digital" | "service";
+  taxCategory?: string;
+  categoryIdsByProduct?: ReadonlyMap<string, readonly string[]>;
+}
+
+function productStatus(product: ShopifyProduct): ProductStatus {
+  const status = product.status?.trim().toLowerCase();
+  if (status === "archived") return "archived";
+  if (status === "draft") return "draft";
+  if (
+    status !== "active" || product.published_at === null ||
+    (product.published_at !== undefined && !hasValidTimestamp(product.published_at))
+  ) return "inactive";
+  return "active";
+}
+
+function variantStatus(status: ProductStatus): VariantStatus {
+  if (status === "archived") return "discontinued";
+  return status === "active" ? "active" : "inactive";
+}
+
+function weight(variant: ShopifyProductVariant): string | null {
+  const value = variant.grams ?? variant.weight;
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) return null;
+  const unit = variant.grams !== undefined ? "g" : variant.weight_unit?.trim().toLowerCase();
+  if (!unit || !["g", "kg", "oz", "lb"].includes(unit)) return null;
+  return JSON.stringify({ value, unit });
+}
+
+function machMedia(
+  image: ShopifyProductImage,
+  sourceId: string,
+  ownerId: string,
+  position: number,
+): { embedded: Record<string, unknown>; plan: MediaRewrite } | null {
+  const plan = mediaRewrite(image.src, ownerId, "product", position, {
+    altText: image.alt?.trim() || undefined,
+    width: image.width,
+    height: image.height,
+  });
+  if (!plan) return null;
+  return {
+    plan,
+    embedded: {
+      id: deterministicProviderId(SHOPIFY_PROVIDER, "media", `${sourceId}:${String(image.id ?? position)}`),
+      type: "image",
+      status: "active",
+      external_references: {
+        shopify_fingerprint: providerFingerprint(
+          SHOPIFY_PROVIDER,
+          "media",
+          `${sourceId}:${String(image.id ?? position)}`,
+        ),
+      },
+      file: {
+        url: plan.publicPath,
+        format: plan.objectKey.split(".").at(-1) ?? "jpg",
+        ...(image.width ? { width: image.width } : {}),
+        ...(image.height ? { height: image.height } : {}),
+      },
+      accessibility: { alt_text: plan.altText },
+    },
+  };
+}
+
+export function collectionMembershipByProduct(
+  collects: readonly ShopifyCollect[],
+  categoryIdBySourceFingerprint: ReadonlyMap<string, string>,
+): Map<string, string[]> {
+  const result = new Map<string, string[]>();
+  for (const collect of collects) {
+    const categoryId = categoryIdBySourceFingerprint.get(
+      providerFingerprint(SHOPIFY_PROVIDER, "category", collect.collection_id),
+    );
+    if (!categoryId) continue;
+    const productId = providerFingerprint(SHOPIFY_PROVIDER, "product", collect.product_id);
+    const existing = result.get(productId) ?? [];
+    if (!existing.includes(categoryId)) existing.push(categoryId);
+    result.set(productId, existing);
+  }
+  return result;
+}
+
+export function transformProducts(
+  products: readonly ShopifyProduct[],
+  options: ProductTransformOptions,
+): PureTransformResult<ShopifyProduct, ProductTransformRecord> {
+  const currency = requireSupportedCurrency(options.currency);
+  const generatedAt = requiredMigrationTime(options.generatedAt);
+  const locationId = options.inventoryLocationId.trim();
+  if (!locationId) throw new TypeError("inventoryLocationId is required");
+
+  const records: ProductTransformRecord[] = [];
+  const idMap = new Map<string, string>();
+  const skipped: Array<{ record: ShopifyProduct; reason: string }> = [];
+  const warnings: string[] = [];
+  const slugs = new Set<string>();
+  const skus = new Set<string>();
+
+  for (const source of products) {
+    const sourceId = String(source.id ?? "").trim();
+    const slug = normalizeSlug(source.handle ?? "");
+    const name = source.title?.trim();
+    if (!sourceId || !slug || !name) {
+      skipped.push({ record: source, reason: "Product requires an id, title, and valid handle" });
+      continue;
+    }
+    if (slugs.has(slug)) {
+      skipped.push({ record: source, reason: `Duplicate product slug: ${slug}` });
+      continue;
+    }
+
+    const productId = deterministicProviderId(SHOPIFY_PROVIDER, "product", sourceId);
+    const sourceFingerprint = providerFingerprint(SHOPIFY_PROVIDER, "product", sourceId);
+    const status = productStatus(source);
+    const optionDefinitions = (source.options ?? []).slice(0, 3).map((option, position) => ({
+      id: deterministicProviderId(SHOPIFY_PROVIDER, "option", `${sourceId}:${String(option.id ?? position + 1)}`),
+      name: option.name.trim(),
+      values: uniqueStrings(option.values ?? []),
+      position: option.position ?? position + 1,
+    })).filter((option) => option.name && option.values.length > 0);
+
+    const imageResults = (source.images ?? []).flatMap((image, index) => {
+      const result = machMedia(image, sourceId, productId, index + 1);
+      if (!result) {
+        warnings.push(
+          `Product ${sourceFingerprint} image ${index + 1} omitted: invalid or unsupported image URL`,
+        );
+        return [];
+      }
+      return [{ ...result, sourceImageId: image.id === undefined ? null : String(image.id) }];
+    });
+    const mediaBySourceId = new Map(imageResults.flatMap(({ sourceImageId, embedded }) =>
+      sourceImageId === null ? [] : [[sourceImageId, embedded] as const]));
+
+    const variants: VariantInsertRecord[] = [];
+    const inventory: InventoryInsertRecord[] = [];
+    for (let index = 0; index < source.variants.length; index += 1) {
+      const variant = source.variants[index];
+      const sku = variant.sku?.trim() || `${slug}-${index + 1}`;
+      const naturalKey = variant.sku?.trim() || [variant.option1, variant.option2, variant.option3]
+        .filter((value): value is string => Boolean(value?.trim()))
+        .join("|") || variant.barcode?.trim() || `position:${index + 1}`;
+      const variantSourceId = String(variant.id ?? `${sourceId}:${naturalKey}`);
+      const variantFingerprint = providerFingerprint(SHOPIFY_PROVIDER, "variant", variantSourceId);
+      if (skus.has(sku.toLocaleLowerCase("en-US"))) {
+        warnings.push(`Product ${sourceFingerprint} variant ${variantFingerprint} omitted: duplicate SKU`);
+        continue;
+      }
+      let price;
+      try {
+        price = majorToStoredMoney(variant.price, currency);
+      } catch {
+        warnings.push(`Product ${sourceFingerprint} variant ${variantFingerprint} omitted: invalid price`);
+        continue;
+      }
+      let compareAt = null;
+      if (variant.compare_at_price !== null && variant.compare_at_price !== undefined && variant.compare_at_price !== "") {
+        try {
+          compareAt = JSON.stringify(majorToStoredMoney(variant.compare_at_price, currency));
+        } catch {
+          warnings.push(`Product ${sourceFingerprint} variant ${variantFingerprint} has invalid compare-at price; value omitted`);
+        }
+      }
+
+      skus.add(sku.toLocaleLowerCase("en-US"));
+      const variantId = deterministicProviderId(SHOPIFY_PROVIDER, "variant", variantSourceId);
+      const quantity = clampInventory(variant.inventory_quantity);
+      const allowBackorder = variant.inventory_policy === "continue";
+      const selectedMedia = variant.image_id === null || variant.image_id === undefined
+        ? []
+        : [mediaBySourceId.get(String(variant.image_id))].filter(Boolean);
+      const optionValues = optionDefinitions.flatMap((option, optionIndex) => {
+        const value = variant[`option${optionIndex + 1}` as "option1" | "option2" | "option3"]?.trim();
+        return value ? [{ option_id: option.id, value }] : [];
+      });
+      const createdAt = isoTimestamp(variant.created_at, isoTimestamp(source.created_at, generatedAt));
+      const updatedAt = isoTimestamp(variant.updated_at, isoTimestamp(source.updated_at, generatedAt));
+      variants.push({
+        id: variantId,
+        product_id: productId,
+        sku,
+        status: variantStatus(status),
+        position: variant.position ?? index + 1,
+        option_values: JSON.stringify(optionValues),
+        price: JSON.stringify(price),
+        compare_at_price: compareAt,
+        cost: null,
+        weight: weight(variant),
+        dimensions: null,
+        barcode: variant.barcode?.trim() || null,
+        inventory: JSON.stringify({
+          track_inventory: Boolean(variant.inventory_management),
+          quantity,
+          allow_backorder: allowBackorder,
+        }),
+        tax_category: variant.taxable === false ? null : options.taxCategory?.trim() || null,
+        shipping_required: variant.requires_shipping !== false,
+        media: JSON.stringify(selectedMedia),
+        attributes: JSON.stringify({
+          shopify: {
+            fulfillment_service: variant.fulfillment_service ?? null,
+            taxable: variant.taxable ?? null,
+          },
+        }),
+        created_at: createdAt,
+        updated_at: updatedAt,
+      });
+      inventory.push({
+        id: deterministicProviderId(SHOPIFY_PROVIDER, "inventory", `${variantSourceId}:${locationId}`),
+        sku_id: variantId,
+        location_id: locationId,
+        quantities: JSON.stringify({ on_hand: quantity, reserved: 0, available: quantity }),
+        status: status === "active" ? "active" : "inactive",
+        stock_status: quantity > 0 ? "in_stock" : allowBackorder ? "backorder" : "out_of_stock",
+        external_references: JSON.stringify({
+          shopify_fingerprint: variantFingerprint,
+        }),
+        created_at: createdAt,
+        updated_at: updatedAt,
+        policy_id: null,
+        backorderable: allowBackorder,
+        backorder_eta: null,
+        safety_stock: 0,
+        version: 0,
+        extensions: "{}",
+      });
+    }
+
+    if (variants.length === 0) {
+      skipped.push({ record: source, reason: "Product has no importable variants" });
+      continue;
+    }
+    slugs.add(slug);
+    const tags = uniqueStrings((source.tags ?? "").split(","));
+    const categoryIds = uniqueStrings([...(options.categoryIdsByProduct?.get(sourceFingerprint) ?? [])]);
+    const embeddedMedia = imageResults.map(({ embedded }) => embedded);
+    const seo = source.seo_title || source.seo_description
+      ? { meta_title: source.seo_title?.trim() || name, meta_description: source.seo_description?.trim() || undefined }
+      : null;
+
+    records.push({
+      sourceFingerprint,
+      variants,
+      inventory,
+      media: imageResults.map(({ plan }) => plan),
+      product: {
+        id: productId,
+        name,
+        description: source.body_html ? JSON.stringify({ en: plainText(source.body_html) }) : null,
+        type: source.product_type?.trim() || null,
+        status,
+        slug,
+        brand: source.vendor?.trim() || null,
+        categories: categoryIds.length ? JSON.stringify(categoryIds) : null,
+        tags: tags.length ? JSON.stringify(tags) : null,
+        options: optionDefinitions.length ? JSON.stringify(optionDefinitions) : null,
+        default_variant_id: variants[0].id,
+        fulfillment_type: options.fulfillmentType,
+        tax_category: options.taxCategory?.trim() || null,
+        primary_image: embeddedMedia[0] ? JSON.stringify(embeddedMedia[0]) : null,
+        media: embeddedMedia.length ? JSON.stringify(embeddedMedia) : null,
+        seo: seo ? JSON.stringify(seo) : null,
+        rating: null,
+        related_products: null,
+        external_references: JSON.stringify({ shopify_fingerprint: sourceFingerprint }),
+        extensions: JSON.stringify({ shopify: { product_type: source.product_type ?? null } }),
+        created_at: isoTimestamp(source.created_at, generatedAt),
+        updated_at: isoTimestamp(source.updated_at, generatedAt),
+      },
+    });
+    idMap.set(sourceFingerprint, productId);
+  }
+
+  return { records, idMap, skipped, warnings };
+}

--- a/scripts/shopify-migration/transformers/products.ts
+++ b/scripts/shopify-migration/transformers/products.ts
@@ -7,10 +7,14 @@ import type {
 import { deterministicProviderId, providerFingerprint } from "../lib/ids.js";
 import {
   SHOPIFY_PROVIDER,
+  boundedPositiveInteger,
   clampInventory,
+  escapedSqlUtf8Bytes,
+  fitsEscapedSqlText,
   hasValidTimestamp,
   isoTimestamp,
   majorToStoredMoney,
+  mediaHostAllowlist,
   mediaRewrite,
   normalizeSlug,
   plainText,
@@ -23,6 +27,16 @@ import {
 
 type ProductStatus = "active" | "inactive" | "archived" | "draft";
 type VariantStatus = "active" | "inactive" | "discontinued";
+
+const MAX_PRODUCT_TITLE = 500;
+const MAX_PRODUCT_BODY = 100_000;
+const MAX_PRODUCT_VARIANTS = 2_048;
+const MAX_PRODUCT_IMAGES = 250;
+const MAX_PRODUCT_CATEGORIES = 100;
+const MAX_TAGS = 100;
+const MAX_TAG_LENGTH = 100;
+const MAX_OPTION_VALUES = 250;
+const MAX_OPTION_TEXT = 200;
 
 export interface ProductInsertRecord {
   id: string;
@@ -103,6 +117,7 @@ export interface ProductTransformOptions {
   inventoryLocationId: string;
   fulfillmentType: "physical" | "digital" | "service";
   taxCategory?: string;
+  allowedMediaHosts: readonly string[];
   categoryIdsByProduct?: ReadonlyMap<string, readonly string[]>;
 }
 
@@ -124,7 +139,7 @@ function variantStatus(status: ProductStatus): VariantStatus {
 
 function weight(variant: ShopifyProductVariant): string | null {
   const value = variant.grams ?? variant.weight;
-  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) return null;
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0 || value > 1_000_000_000) return null;
   const unit = variant.grams !== undefined ? "g" : variant.weight_unit?.trim().toLowerCase();
   if (!unit || !["g", "kg", "oz", "lb"].includes(unit)) return null;
   return JSON.stringify({ value, unit });
@@ -132,14 +147,15 @@ function weight(variant: ShopifyProductVariant): string | null {
 
 function machMedia(
   image: ShopifyProductImage,
+  allowedMediaHosts: ReturnType<typeof mediaHostAllowlist>,
   sourceId: string,
   ownerId: string,
   position: number,
 ): { embedded: Record<string, unknown>; plan: MediaRewrite } | null {
-  const plan = mediaRewrite(image.src, ownerId, "product", position, {
-    altText: image.alt?.trim() || undefined,
-    width: image.width,
-    height: image.height,
+  const plan = mediaRewrite(image.src, allowedMediaHosts, ownerId, "product", position, {
+    altText: image.alt?.trim().slice(0, 300) || undefined,
+    width: boundedPositiveInteger(image.width),
+    height: boundedPositiveInteger(image.height),
   });
   if (!plan) return null;
   return {
@@ -178,7 +194,7 @@ export function collectionMembershipByProduct(
     if (!categoryId) continue;
     const productId = providerFingerprint(SHOPIFY_PROVIDER, "product", collect.product_id);
     const existing = result.get(productId) ?? [];
-    if (!existing.includes(categoryId)) existing.push(categoryId);
+    if (!existing.includes(categoryId) && existing.length < MAX_PRODUCT_CATEGORIES) existing.push(categoryId);
     result.set(productId, existing);
   }
   return result;
@@ -190,8 +206,10 @@ export function transformProducts(
 ): PureTransformResult<ShopifyProduct, ProductTransformRecord> {
   const currency = requireSupportedCurrency(options.currency);
   const generatedAt = requiredMigrationTime(options.generatedAt);
+  const allowedMediaHosts = mediaHostAllowlist(options.allowedMediaHosts);
   const locationId = options.inventoryLocationId.trim();
-  if (!locationId) throw new TypeError("inventoryLocationId is required");
+  if (!locationId || locationId.length > 200) throw new TypeError("inventoryLocationId must be 1-200 characters");
+  if ((options.taxCategory?.trim().length ?? 0) > 200) throw new TypeError("taxCategory must not exceed 200 characters");
 
   const records: ProductTransformRecord[] = [];
   const idMap = new Map<string, string>();
@@ -204,7 +222,25 @@ export function transformProducts(
     const sourceId = String(source.id ?? "").trim();
     const slug = normalizeSlug(source.handle ?? "");
     const name = source.title?.trim();
-    if (!sourceId || !slug || !name) {
+    const rawTags = source.tags ?? "";
+    const tags = rawTags.length <= 20_000 ? uniqueStrings(rawTags.split(",")) : [];
+    const optionsAreBounded = (source.options ?? []).every((option) =>
+      (option.id === undefined || String(option.id).length <= 128) &&
+      option.name.trim().length > 0 && option.name.trim().length <= 120 &&
+      option.values.length <= MAX_OPTION_VALUES &&
+      option.values.every((value) => value.trim().length > 0 && value.trim().length <= MAX_OPTION_TEXT));
+    const imagesAreBounded = source.images.every((image) =>
+      (image.id === undefined || String(image.id).length <= 128) &&
+      image.src.length <= 2_048 && (image.alt?.length ?? 0) <= 10_000);
+    if (
+      !sourceId || sourceId.length > 256 || !slug || slug.length > 160 || !name || name.length > MAX_PRODUCT_TITLE ||
+      (source.body_html?.length ?? 0) > MAX_PRODUCT_BODY || (source.vendor?.length ?? 0) > 200 ||
+      (source.product_type?.length ?? 0) > 200 || (source.tags?.length ?? 0) > 20_000 ||
+      (source.seo_title?.length ?? 0) > 200 || (source.seo_description?.length ?? 0) > 500 ||
+      tags.length > MAX_TAGS || tags.some((tag) => tag.length > MAX_TAG_LENGTH) ||
+      source.variants.length > MAX_PRODUCT_VARIANTS || source.images.length > MAX_PRODUCT_IMAGES ||
+      (source.options?.length ?? 0) > 3 || !optionsAreBounded || !imagesAreBounded
+    ) {
       skipped.push({ record: source, reason: "Product requires an id, title, and valid handle" });
       continue;
     }
@@ -220,11 +256,11 @@ export function transformProducts(
       id: deterministicProviderId(SHOPIFY_PROVIDER, "option", `${sourceId}:${String(option.id ?? position + 1)}`),
       name: option.name.trim(),
       values: uniqueStrings(option.values ?? []),
-      position: option.position ?? position + 1,
+      position: boundedPositiveInteger(option.position, 3) ?? position + 1,
     })).filter((option) => option.name && option.values.length > 0);
 
     const imageResults = (source.images ?? []).flatMap((image, index) => {
-      const result = machMedia(image, sourceId, productId, index + 1);
+      const result = machMedia(image, allowedMediaHosts, sourceId, productId, index + 1);
       if (!result) {
         warnings.push(
           `Product ${sourceFingerprint} image ${index + 1} omitted: invalid or unsupported image URL`,
@@ -241,6 +277,23 @@ export function transformProducts(
     for (let index = 0; index < source.variants.length; index += 1) {
       const variant = source.variants[index];
       const sku = variant.sku?.trim() || `${slug}-${index + 1}`;
+      const rawValues = [variant.option1, variant.option2, variant.option3].filter(
+        (value): value is string => value !== null && value !== undefined,
+      );
+      const rawVariantId = variant.id === undefined ? "" : String(variant.id);
+      const identity = rawVariantId && rawVariantId.length <= 256
+        ? rawVariantId
+        : `${sourceId}:position:${index + 1}`;
+      const preliminaryFingerprint = providerFingerprint(SHOPIFY_PROVIDER, "variant", identity);
+      if (
+        rawVariantId.length > 256 || sku.length > 255 || (variant.barcode?.length ?? 0) > 255 ||
+        (variant.price?.length ?? 0) > 100 || (variant.compare_at_price?.length ?? 0) > 100 ||
+        rawValues.some((value) => value.trim().length > MAX_OPTION_TEXT) ||
+        (variant.fulfillment_service?.length ?? 0) > 200
+      ) {
+        warnings.push(`Product ${sourceFingerprint} variant ${preliminaryFingerprint} omitted: fields exceed limits`);
+        continue;
+      }
       const naturalKey = variant.sku?.trim() || [variant.option1, variant.option2, variant.option3]
         .filter((value): value is string => Boolean(value?.trim()))
         .join("|") || variant.barcode?.trim() || `position:${index + 1}`;
@@ -284,7 +337,7 @@ export function transformProducts(
         product_id: productId,
         sku,
         status: variantStatus(status),
-        position: variant.position ?? index + 1,
+        position: boundedPositiveInteger(variant.position, MAX_PRODUCT_VARIANTS) ?? index + 1,
         option_values: JSON.stringify(optionValues),
         price: JSON.stringify(price),
         compare_at_price: compareAt,
@@ -310,7 +363,7 @@ export function transformProducts(
         updated_at: updatedAt,
       });
       inventory.push({
-        id: deterministicProviderId(SHOPIFY_PROVIDER, "inventory", `${variantSourceId}:${locationId}`),
+        id: deterministicProviderId(SHOPIFY_PROVIDER, "inventory", `${variantFingerprint}:${locationId}`),
         sku_id: variantId,
         location_id: locationId,
         quantities: JSON.stringify({ on_hand: quantity, reserved: 0, available: quantity }),
@@ -335,12 +388,34 @@ export function transformProducts(
       continue;
     }
     slugs.add(slug);
-    const tags = uniqueStrings((source.tags ?? "").split(","));
     const categoryIds = uniqueStrings([...(options.categoryIdsByProduct?.get(sourceFingerprint) ?? [])]);
+    if (
+      categoryIds.length > MAX_PRODUCT_CATEGORIES ||
+      categoryIds.some((categoryId) => categoryId.length > 200)
+    ) {
+      skipped.push({ record: source, reason: "Product category references exceed migration limits" });
+      continue;
+    }
     const embeddedMedia = imageResults.map(({ embedded }) => embedded);
     const seo = source.seo_title || source.seo_description
       ? { meta_title: source.seo_title?.trim() || name, meta_description: source.seo_description?.trim() || undefined }
       : null;
+    const description = source.body_html ? JSON.stringify({ en: plainText(source.body_html) }) : null;
+    const categoriesJson = categoryIds.length ? JSON.stringify(categoryIds) : null;
+    const tagsJson = tags.length ? JSON.stringify(tags) : null;
+    const optionsJson = optionDefinitions.length ? JSON.stringify(optionDefinitions) : null;
+    const primaryImageJson = embeddedMedia[0] ? JSON.stringify(embeddedMedia[0]) : null;
+    const mediaJson = embeddedMedia.length ? JSON.stringify(embeddedMedia) : null;
+    const seoJson = seo ? JSON.stringify(seo) : null;
+    const boundedJson = [description, categoriesJson, tagsJson, optionsJson, primaryImageJson, mediaJson, seoJson]
+      .filter((value): value is string => value !== null);
+    if (
+      boundedJson.some((value) => !fitsEscapedSqlText(value)) ||
+      boundedJson.reduce((total, value) => total + escapedSqlUtf8Bytes(value), 0) > 80 * 1024
+    ) {
+      skipped.push({ record: source, reason: "Product record exceeds SQL-safe text limits" });
+      continue;
+    }
 
     records.push({
       sourceFingerprint,
@@ -350,20 +425,20 @@ export function transformProducts(
       product: {
         id: productId,
         name,
-        description: source.body_html ? JSON.stringify({ en: plainText(source.body_html) }) : null,
+        description,
         type: source.product_type?.trim() || null,
         status,
         slug,
         brand: source.vendor?.trim() || null,
-        categories: categoryIds.length ? JSON.stringify(categoryIds) : null,
-        tags: tags.length ? JSON.stringify(tags) : null,
-        options: optionDefinitions.length ? JSON.stringify(optionDefinitions) : null,
+        categories: categoriesJson,
+        tags: tagsJson,
+        options: optionsJson,
         default_variant_id: variants[0].id,
         fulfillment_type: options.fulfillmentType,
         tax_category: options.taxCategory?.trim() || null,
-        primary_image: embeddedMedia[0] ? JSON.stringify(embeddedMedia[0]) : null,
-        media: embeddedMedia.length ? JSON.stringify(embeddedMedia) : null,
-        seo: seo ? JSON.stringify(seo) : null,
+        primary_image: primaryImageJson,
+        media: mediaJson,
+        seo: seoJson,
         rating: null,
         related_products: null,
         external_references: JSON.stringify({ shopify_fingerprint: sourceFingerprint }),

--- a/scripts/shopify-migration/transformers/products.ts
+++ b/scripts/shopify-migration/transformers/products.ts
@@ -9,6 +9,7 @@ import {
   SHOPIFY_PROVIDER,
   UNKNOWN_SOURCE_TIMESTAMP,
   boundedPositiveInteger,
+  canonicalProviderRecords,
   clampInventory,
   escapedSqlUtf8Bytes,
   fitsEscapedSqlText,
@@ -188,7 +189,8 @@ export function collectionMembershipByProduct(
   categoryIdBySourceFingerprint: ReadonlyMap<string, string>,
 ): Map<string, string[]> {
   const result = new Map<string, string[]>();
-  for (const collect of collects) {
+  const canonical = canonicalProviderRecords(collects, "collect", (collect) => collect.id);
+  for (const collect of canonical.records) {
     const categoryId = categoryIdBySourceFingerprint.get(
       providerFingerprint(SHOPIFY_PROVIDER, "category", collect.collection_id),
     );
@@ -198,6 +200,7 @@ export function collectionMembershipByProduct(
     if (!existing.includes(categoryId) && existing.length < MAX_PRODUCT_CATEGORIES) existing.push(categoryId);
     result.set(productId, existing);
   }
+  for (const categories of result.values()) categories.sort();
   return result;
 }
 
@@ -216,10 +219,10 @@ export function transformProducts(
   const idMap = new Map<string, string>();
   const skipped: Array<{ record: ShopifyProduct; reason: string }> = [];
   const warnings: string[] = [];
-  const slugs = new Set<string>();
-  const skus = new Set<string>();
+  const sourceByFingerprint = new Map<string, ShopifyProduct>();
 
-  for (const source of products) {
+  const canonical = canonicalProviderRecords(products, "product", (product) => product.id);
+  for (const source of canonical.records) {
     const sourceId = String(source.id ?? "").trim();
     const slug = normalizeSlug(source.handle ?? "");
     const name = source.title?.trim();
@@ -245,22 +248,27 @@ export function transformProducts(
       skipped.push({ record: source, reason: "Product requires an id, title, and valid handle" });
       continue;
     }
-    if (slugs.has(slug)) {
-      skipped.push({ record: source, reason: `Duplicate product slug: ${slug}` });
+    const sourceFingerprint = providerFingerprint(SHOPIFY_PROVIDER, "product", sourceId);
+    if (canonical.duplicateFingerprints.has(sourceFingerprint)) {
+      skipped.push({ record: source, reason: "Duplicate product source identity" });
       continue;
     }
-
     const productId = deterministicProviderId(SHOPIFY_PROVIDER, "product", sourceId);
-    const sourceFingerprint = providerFingerprint(SHOPIFY_PROVIDER, "product", sourceId);
     const status = productStatus(source);
-    const optionDefinitions = (source.options ?? []).slice(0, 3).map((option, position) => ({
+    const sourceOptions = [...(source.options ?? [])].sort((left, right) =>
+      (left.position ?? Number.MAX_SAFE_INTEGER) - (right.position ?? Number.MAX_SAFE_INTEGER) ||
+      String(left.id ?? left.name).localeCompare(String(right.id ?? right.name)));
+    const optionDefinitions = sourceOptions.slice(0, 3).map((option, position) => ({
       id: deterministicProviderId(SHOPIFY_PROVIDER, "option", `${sourceId}:${String(option.id ?? position + 1)}`),
       name: option.name.trim(),
       values: uniqueStrings(option.values ?? []),
       position: boundedPositiveInteger(option.position, 3) ?? position + 1,
     })).filter((option) => option.name && option.values.length > 0);
 
-    const imageResults = (source.images ?? []).flatMap((image, index) => {
+    const sourceImages = [...(source.images ?? [])].sort((left, right) =>
+      (left.position ?? Number.MAX_SAFE_INTEGER) - (right.position ?? Number.MAX_SAFE_INTEGER) ||
+      String(left.id ?? left.src).localeCompare(String(right.id ?? right.src)));
+    const imageResults = sourceImages.flatMap((image, index) => {
       const result = machMedia(image, allowedMediaHosts, sourceId, productId, index + 1);
       if (!result) {
         warnings.push(
@@ -276,8 +284,11 @@ export function transformProducts(
     const variants: VariantInsertRecord[] = [];
     const inventory: InventoryInsertRecord[] = [];
     const candidateSkus = new Set<string>();
-    for (let index = 0; index < source.variants.length; index += 1) {
-      const variant = source.variants[index];
+    const sourceVariants = [...source.variants].sort((left, right) =>
+      (left.position ?? Number.MAX_SAFE_INTEGER) - (right.position ?? Number.MAX_SAFE_INTEGER) ||
+      String(left.id ?? left.sku ?? left.barcode ?? "").localeCompare(String(right.id ?? right.sku ?? right.barcode ?? "")));
+    for (let index = 0; index < sourceVariants.length; index += 1) {
+      const variant = sourceVariants[index];
       const sku = variant.sku?.trim() || `${slug}-${index + 1}`;
       const rawValues = [variant.option1, variant.option2, variant.option3].filter(
         (value): value is string => value !== null && value !== undefined,
@@ -302,7 +313,7 @@ export function transformProducts(
       const variantSourceId = String(variant.id ?? `${sourceId}:${naturalKey}`);
       const variantFingerprint = providerFingerprint(SHOPIFY_PROVIDER, "variant", variantSourceId);
       const normalizedSku = sku.toLocaleLowerCase("en-US");
-      if (skus.has(normalizedSku) || candidateSkus.has(normalizedSku)) {
+      if (candidateSkus.has(normalizedSku)) {
         warnings.push(`Product ${sourceFingerprint} variant ${variantFingerprint} omitted: duplicate SKU`);
         continue;
       }
@@ -419,8 +430,7 @@ export function transformProducts(
       continue;
     }
 
-    slugs.add(slug);
-    candidateSkus.forEach((sku) => skus.add(sku));
+    sourceByFingerprint.set(sourceFingerprint, source);
     records.push({
       sourceFingerprint,
       variants,
@@ -451,8 +461,31 @@ export function transformProducts(
         updated_at: isoTimestamp(source.updated_at, UNKNOWN_SOURCE_TIMESTAMP),
       },
     });
-    idMap.set(sourceFingerprint, productId);
   }
-
-  return { records, idMap, skipped, warnings };
+  const slugCounts = new Map<string, number>();
+  const skuProducts = new Map<string, Set<string>>();
+  for (const record of records) {
+    slugCounts.set(record.product.slug, (slugCounts.get(record.product.slug) ?? 0) + 1);
+    for (const variant of record.variants) {
+      const normalizedSku = variant.sku.toLocaleLowerCase("en-US");
+      const productsForSku = skuProducts.get(normalizedSku) ?? new Set<string>();
+      productsForSku.add(record.sourceFingerprint);
+      skuProducts.set(normalizedSku, productsForSku);
+    }
+  }
+  const accepted = records.flatMap((record) => {
+    const ambiguousSlug = (slugCounts.get(record.product.slug) ?? 0) > 1;
+    const ambiguousSku = record.variants.some((variant) =>
+      (skuProducts.get(variant.sku.toLocaleLowerCase("en-US"))?.size ?? 0) > 1);
+    if (!ambiguousSlug && !ambiguousSku) return [record];
+    const reason = ambiguousSlug && ambiguousSku
+      ? "Product participates in ambiguous duplicate slug and cross-product SKU conflicts"
+      : ambiguousSlug
+        ? `Ambiguous duplicate product slug: ${record.product.slug}`
+        : "Product participates in an ambiguous cross-product SKU conflict";
+    skipped.push({ record: sourceByFingerprint.get(record.sourceFingerprint)!, reason });
+    return [];
+  });
+  for (const record of accepted) idMap.set(record.sourceFingerprint, record.product.id);
+  return { records: accepted, idMap, skipped, warnings };
 }

--- a/scripts/shopify-migration/transformers/products.ts
+++ b/scripts/shopify-migration/transformers/products.ts
@@ -151,6 +151,7 @@ function machMedia(
   image: ShopifyProductImage,
   allowedMediaHosts: ReturnType<typeof mediaHostAllowlist>,
   sourceId: string,
+  imageSourceId: string,
   ownerId: string,
   position: number,
 ): { embedded: Record<string, unknown>; plan: MediaRewrite } | null {
@@ -163,14 +164,14 @@ function machMedia(
   return {
     plan,
     embedded: {
-      id: deterministicProviderId(SHOPIFY_PROVIDER, "media", `${sourceId}:${String(image.id ?? position)}`),
+      id: deterministicProviderId(SHOPIFY_PROVIDER, "media", `${sourceId}:${imageSourceId}`),
       type: "image",
       status: "active",
       external_references: {
         shopify_fingerprint: providerFingerprint(
           SHOPIFY_PROVIDER,
           "media",
-          `${sourceId}:${String(image.id ?? position)}`,
+          `${sourceId}:${imageSourceId}`,
         ),
       },
       file: {
@@ -184,12 +185,55 @@ function machMedia(
   };
 }
 
+function nestedIdentity(explicitId: unknown, fallback: string): string | null {
+  if (explicitId !== undefined && explicitId !== null) {
+    const value = String(explicitId).trim();
+    return value && value.length <= 256 ? value : null;
+  }
+  const value = fallback.trim();
+  return value ? `natural:${value}` : null;
+}
+
+function optionIdentity(option: NonNullable<ShopifyProduct["options"]>[number]): string | null {
+  return nestedIdentity(option.id, option.name.trim().toLocaleLowerCase("en-US"));
+}
+
+function imageIdentity(image: ShopifyProductImage): string | null {
+  return nestedIdentity(image.id, image.src.trim());
+}
+
+function variantNaturalKey(variant: ShopifyProductVariant): string {
+  return variant.sku?.trim() || [variant.option1, variant.option2, variant.option3]
+    .filter((value): value is string => Boolean(value?.trim()))
+    .map((value) => value.trim())
+    .join("|") || variant.barcode?.trim() ||
+    (boundedPositiveInteger(variant.position, MAX_PRODUCT_VARIANTS) ? `position:${variant.position}` : "");
+}
+
+function variantIdentity(variant: ShopifyProductVariant): string | null {
+  return nestedIdentity(variant.id, variantNaturalKey(variant));
+}
+
+function hasAmbiguousNestedIdentities<T>(records: readonly T[], identity: (record: T) => string | null): boolean {
+  const seen = new Set<string>();
+  for (const record of records) {
+    const value = identity(record);
+    if (!value || seen.has(value)) return true;
+    seen.add(value);
+  }
+  return false;
+}
+
 export function collectionMembershipByProduct(
   collects: readonly ShopifyCollect[],
   categoryIdBySourceFingerprint: ReadonlyMap<string, string>,
 ): Map<string, string[]> {
   const result = new Map<string, string[]>();
   const canonical = canonicalProviderRecords(collects, "collect", (collect) => collect.id);
+  if (
+    canonical.duplicateFingerprints.size > 0 ||
+    canonical.records.some((collect) => !String(collect.id ?? "").trim())
+  ) throw new TypeError("Collect input contains ambiguous duplicate or missing source identities");
   for (const collect of canonical.records) {
     const categoryId = categoryIdBySourceFingerprint.get(
       providerFingerprint(SHOPIFY_PROVIDER, "category", collect.collection_id),
@@ -248,6 +292,14 @@ export function transformProducts(
       skipped.push({ record: source, reason: "Product requires an id, title, and valid handle" });
       continue;
     }
+    if (
+      hasAmbiguousNestedIdentities(source.options ?? [], optionIdentity) ||
+      hasAmbiguousNestedIdentities(source.images, imageIdentity) ||
+      hasAmbiguousNestedIdentities(source.variants, variantIdentity)
+    ) {
+      skipped.push({ record: source, reason: "Product contains ambiguous duplicate or missing nested source identities" });
+      continue;
+    }
     const sourceFingerprint = providerFingerprint(SHOPIFY_PROVIDER, "product", sourceId);
     if (canonical.duplicateFingerprints.has(sourceFingerprint)) {
       skipped.push({ record: source, reason: "Duplicate product source identity" });
@@ -257,9 +309,9 @@ export function transformProducts(
     const status = productStatus(source);
     const sourceOptions = [...(source.options ?? [])].sort((left, right) =>
       (left.position ?? Number.MAX_SAFE_INTEGER) - (right.position ?? Number.MAX_SAFE_INTEGER) ||
-      String(left.id ?? left.name).localeCompare(String(right.id ?? right.name)));
+      optionIdentity(left)!.localeCompare(optionIdentity(right)!));
     const optionDefinitions = sourceOptions.slice(0, 3).map((option, position) => ({
-      id: deterministicProviderId(SHOPIFY_PROVIDER, "option", `${sourceId}:${String(option.id ?? position + 1)}`),
+      id: deterministicProviderId(SHOPIFY_PROVIDER, "option", `${sourceId}:${optionIdentity(option)!}`),
       name: option.name.trim(),
       values: uniqueStrings(option.values ?? []),
       position: boundedPositiveInteger(option.position, 3) ?? position + 1,
@@ -267,9 +319,9 @@ export function transformProducts(
 
     const sourceImages = [...(source.images ?? [])].sort((left, right) =>
       (left.position ?? Number.MAX_SAFE_INTEGER) - (right.position ?? Number.MAX_SAFE_INTEGER) ||
-      String(left.id ?? left.src).localeCompare(String(right.id ?? right.src)));
+      imageIdentity(left)!.localeCompare(imageIdentity(right)!));
     const imageResults = sourceImages.flatMap((image, index) => {
-      const result = machMedia(image, allowedMediaHosts, sourceId, productId, index + 1);
+      const result = machMedia(image, allowedMediaHosts, sourceId, imageIdentity(image)!, productId, index + 1);
       if (!result) {
         warnings.push(
           `Product ${sourceFingerprint} image ${index + 1} omitted: invalid or unsupported image URL`,
@@ -286,7 +338,7 @@ export function transformProducts(
     const candidateSkus = new Set<string>();
     const sourceVariants = [...source.variants].sort((left, right) =>
       (left.position ?? Number.MAX_SAFE_INTEGER) - (right.position ?? Number.MAX_SAFE_INTEGER) ||
-      String(left.id ?? left.sku ?? left.barcode ?? "").localeCompare(String(right.id ?? right.sku ?? right.barcode ?? "")));
+      variantIdentity(left)!.localeCompare(variantIdentity(right)!));
     for (let index = 0; index < sourceVariants.length; index += 1) {
       const variant = sourceVariants[index];
       const sku = variant.sku?.trim() || `${slug}-${index + 1}`;
@@ -307,10 +359,10 @@ export function transformProducts(
         warnings.push(`Product ${sourceFingerprint} variant ${preliminaryFingerprint} omitted: fields exceed limits`);
         continue;
       }
-      const naturalKey = variant.sku?.trim() || [variant.option1, variant.option2, variant.option3]
-        .filter((value): value is string => Boolean(value?.trim()))
-        .join("|") || variant.barcode?.trim() || `position:${index + 1}`;
-      const variantSourceId = String(variant.id ?? `${sourceId}:${naturalKey}`);
+      const sourceVariantIdentity = variantIdentity(variant)!;
+      const variantSourceId = variant.id === undefined || variant.id === null
+        ? `${sourceId}:${sourceVariantIdentity}`
+        : sourceVariantIdentity;
       const variantFingerprint = providerFingerprint(SHOPIFY_PROVIDER, "variant", variantSourceId);
       const normalizedSku = sku.toLocaleLowerCase("en-US");
       if (candidateSkus.has(normalizedSku)) {

--- a/scripts/shopify-migration/transformers/products.ts
+++ b/scripts/shopify-migration/transformers/products.ts
@@ -275,6 +275,7 @@ export function transformProducts(
 
     const variants: VariantInsertRecord[] = [];
     const inventory: InventoryInsertRecord[] = [];
+    const candidateSkus = new Set<string>();
     for (let index = 0; index < source.variants.length; index += 1) {
       const variant = source.variants[index];
       const sku = variant.sku?.trim() || `${slug}-${index + 1}`;
@@ -300,7 +301,8 @@ export function transformProducts(
         .join("|") || variant.barcode?.trim() || `position:${index + 1}`;
       const variantSourceId = String(variant.id ?? `${sourceId}:${naturalKey}`);
       const variantFingerprint = providerFingerprint(SHOPIFY_PROVIDER, "variant", variantSourceId);
-      if (skus.has(sku.toLocaleLowerCase("en-US"))) {
+      const normalizedSku = sku.toLocaleLowerCase("en-US");
+      if (skus.has(normalizedSku) || candidateSkus.has(normalizedSku)) {
         warnings.push(`Product ${sourceFingerprint} variant ${variantFingerprint} omitted: duplicate SKU`);
         continue;
       }
@@ -320,7 +322,7 @@ export function transformProducts(
         }
       }
 
-      skus.add(sku.toLocaleLowerCase("en-US"));
+      candidateSkus.add(normalizedSku);
       const variantId = deterministicProviderId(SHOPIFY_PROVIDER, "variant", variantSourceId);
       const quantity = clampInventory(variant.inventory_quantity);
       const allowBackorder = variant.inventory_policy === "continue";
@@ -388,7 +390,6 @@ export function transformProducts(
       skipped.push({ record: source, reason: "Product has no importable variants" });
       continue;
     }
-    slugs.add(slug);
     const categoryIds = uniqueStrings([...(options.categoryIdsByProduct?.get(sourceFingerprint) ?? [])]);
     if (
       categoryIds.length > MAX_PRODUCT_CATEGORIES ||
@@ -418,6 +419,8 @@ export function transformProducts(
       continue;
     }
 
+    slugs.add(slug);
+    candidateSkus.forEach((sku) => skus.add(sku));
     records.push({
       sourceFingerprint,
       variants,

--- a/scripts/shopify-migration/transformers/products.ts
+++ b/scripts/shopify-migration/transformers/products.ts
@@ -7,6 +7,7 @@ import type {
 import { deterministicProviderId, providerFingerprint } from "../lib/ids.js";
 import {
   SHOPIFY_PROVIDER,
+  UNKNOWN_SOURCE_TIMESTAMP,
   boundedPositiveInteger,
   clampInventory,
   escapedSqlUtf8Bytes,
@@ -205,7 +206,7 @@ export function transformProducts(
   options: ProductTransformOptions,
 ): PureTransformResult<ShopifyProduct, ProductTransformRecord> {
   const currency = requireSupportedCurrency(options.currency);
-  const generatedAt = requiredMigrationTime(options.generatedAt);
+  requiredMigrationTime(options.generatedAt);
   const allowedMediaHosts = mediaHostAllowlist(options.allowedMediaHosts);
   const locationId = options.inventoryLocationId.trim();
   if (!locationId || locationId.length > 200) throw new TypeError("inventoryLocationId must be 1-200 characters");
@@ -330,8 +331,8 @@ export function transformProducts(
         const value = variant[`option${optionIndex + 1}` as "option1" | "option2" | "option3"]?.trim();
         return value ? [{ option_id: option.id, value }] : [];
       });
-      const createdAt = isoTimestamp(variant.created_at, isoTimestamp(source.created_at, generatedAt));
-      const updatedAt = isoTimestamp(variant.updated_at, isoTimestamp(source.updated_at, generatedAt));
+      const createdAt = isoTimestamp(variant.created_at, isoTimestamp(source.created_at, UNKNOWN_SOURCE_TIMESTAMP));
+      const updatedAt = isoTimestamp(variant.updated_at, isoTimestamp(source.updated_at, UNKNOWN_SOURCE_TIMESTAMP));
       variants.push({
         id: variantId,
         product_id: productId,
@@ -443,8 +444,8 @@ export function transformProducts(
         related_products: null,
         external_references: JSON.stringify({ shopify_fingerprint: sourceFingerprint }),
         extensions: JSON.stringify({ shopify: { product_type: source.product_type ?? null } }),
-        created_at: isoTimestamp(source.created_at, generatedAt),
-        updated_at: isoTimestamp(source.updated_at, generatedAt),
+        created_at: isoTimestamp(source.created_at, UNKNOWN_SOURCE_TIMESTAMP),
+        updated_at: isoTimestamp(source.updated_at, UNKNOWN_SOURCE_TIMESTAMP),
       },
     });
     idMap.set(sourceFingerprint, productId);

--- a/scripts/shopify-migration/transformers/redirects.ts
+++ b/scripts/shopify-migration/transformers/redirects.ts
@@ -1,0 +1,188 @@
+import type { ShopifyRedirect } from "../lib/types.js";
+import { providerFingerprint } from "../lib/ids.js";
+import { SHOPIFY_PROVIDER, type TransformFailure } from "./_shared.js";
+
+export type RedirectEntityType = "product" | "collection" | "page" | "blog" | "shopify-redirect";
+
+export interface RedirectCandidate {
+  sourcePath: string;
+  targetPath: string;
+  statusCode: 301 | 308;
+  entityType: RedirectEntityType;
+  sourceFingerprint?: string;
+}
+
+export interface PublicEntityRoute {
+  /** The exact historical Shopify path segment, never a provider or Mercora ID. */
+  legacyHandle: string;
+  /** The verified public Mercora slug, never inferred from a generated entity ID. */
+  publicSlug: string;
+}
+
+export interface RedirectTransformOptions {
+  generated?: readonly RedirectCandidate[];
+  protectedSourcePaths?: ReadonlySet<string>;
+}
+
+export interface RedirectTransformResult {
+  records: RedirectCandidate[];
+  idMap: Map<string, string>;
+  skipped: Array<TransformFailure<ShopifyRedirect | RedirectCandidate>>;
+  warnings: string[];
+}
+
+function validInternalPath(value: string, source: boolean): boolean {
+  if (value.length < (source ? 3 : 1) || value.length > 2_048) return false;
+  if (!value.startsWith("/") || value.startsWith("//")) return false;
+  if (/[\\?#\u0000-\u001f\u007f]/u.test(value)) return false;
+  if (/%(?:00|0[ad]|2e|2f|5c)/iu.test(value)) return false;
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(value);
+  } catch {
+    return false;
+  }
+  if (!decoded.startsWith("/") || decoded.startsWith("//") || decoded.includes("\\")) return false;
+  return !decoded.split("/").some((segment) => segment === "." || segment === "..");
+}
+
+function routeSegment(value: string): string {
+  const segment = value.trim();
+  if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/u.test(segment)) {
+    throw new Error(`Invalid public route segment: ${value}`);
+  }
+  return segment;
+}
+
+export function productRedirects(routes: readonly PublicEntityRoute[]): RedirectCandidate[] {
+  return routes.map(({ legacyHandle, publicSlug }) => ({
+    sourcePath: `/products/${routeSegment(legacyHandle)}`,
+    targetPath: `/product/${routeSegment(publicSlug)}`,
+    statusCode: 301,
+    entityType: "product",
+  }));
+}
+
+export function collectionRedirects(routes: readonly PublicEntityRoute[]): RedirectCandidate[] {
+  return routes.map(({ legacyHandle, publicSlug }) => ({
+    sourcePath: `/collections/${routeSegment(legacyHandle)}`,
+    targetPath: `/category/${routeSegment(publicSlug)}`,
+    statusCode: 301,
+    entityType: "collection",
+  }));
+}
+
+export function pageRedirects(routes: readonly PublicEntityRoute[]): RedirectCandidate[] {
+  return routes.map(({ legacyHandle, publicSlug }) => ({
+    sourcePath: `/pages/${routeSegment(legacyHandle)}`,
+    targetPath: `/${routeSegment(publicSlug)}`,
+    statusCode: 301,
+    entityType: "page",
+  }));
+}
+
+function cyclicSources(records: readonly RedirectCandidate[]): Set<string> {
+  const next = new Map(records.map((record) => [record.sourcePath, record.targetPath]));
+  const cyclic = new Set<string>();
+  for (const start of next.keys()) {
+    const order: string[] = [];
+    const indexes = new Map<string, number>();
+    let current: string | undefined = start;
+    while (current && next.has(current)) {
+      const prior = indexes.get(current);
+      if (prior !== undefined) {
+        order.slice(prior).forEach((path) => cyclic.add(path));
+        break;
+      }
+      indexes.set(current, order.length);
+      order.push(current);
+      current = next.get(current);
+    }
+  }
+  for (const start of next.keys()) {
+    const visited = new Set<string>();
+    let current: string | undefined = start;
+    while (current && next.has(current) && !visited.has(current)) {
+      if (cyclic.has(current)) {
+        visited.forEach((path) => cyclic.add(path));
+        break;
+      }
+      visited.add(current);
+      current = next.get(current);
+    }
+  }
+  return cyclic;
+}
+
+export function transformRedirects(
+  redirects: readonly ShopifyRedirect[],
+  options: RedirectTransformOptions = {},
+): RedirectTransformResult {
+  const skipped: Array<TransformFailure<ShopifyRedirect | RedirectCandidate>> = [];
+  const warnings: string[] = [];
+  const idMap = new Map<string, string>();
+  const candidates: Array<{ source: ShopifyRedirect | RedirectCandidate; record: RedirectCandidate }> = [];
+
+  for (const source of redirects) {
+    const fingerprint = providerFingerprint(SHOPIFY_PROVIDER, "redirect", source.id);
+    const record: RedirectCandidate = {
+      sourcePath: source.path.trim(),
+      targetPath: source.target.trim(),
+      statusCode: 301,
+      entityType: "shopify-redirect",
+      sourceFingerprint: fingerprint,
+    };
+    candidates.push({ source, record });
+  }
+  for (const record of options.generated ?? []) candidates.push({ source: record, record: { ...record } });
+
+  const valid = candidates.filter(({ source, record }) => {
+    if (!validInternalPath(record.sourcePath, true) || !validInternalPath(record.targetPath, false)) {
+      skipped.push({ record: source, reason: "Redirect source and target must be safe internal paths" });
+      return false;
+    }
+    if (record.sourcePath === record.targetPath) {
+      skipped.push({ record: source, reason: "Redirect cannot target itself" });
+      return false;
+    }
+    if (options.protectedSourcePaths?.has(record.sourcePath)) {
+      skipped.push({ record: source, reason: `Redirect source collides with a protected storefront path: ${record.sourcePath}` });
+      return false;
+    }
+    return true;
+  });
+
+  const bySource = new Map<string, typeof valid>();
+  valid.forEach((candidate) => {
+    const matches = bySource.get(candidate.record.sourcePath) ?? [];
+    matches.push(candidate);
+    bySource.set(candidate.record.sourcePath, matches);
+  });
+
+  const deduplicated: typeof valid = [];
+  for (const [sourcePath, matches] of bySource) {
+    const destinations = new Set(matches.map(({ record }) => `${record.targetPath}\0${record.statusCode}`));
+    if (destinations.size > 1) {
+      matches.forEach(({ source }) => skipped.push({
+        record: source,
+        reason: `Redirect source has conflicting targets: ${sourcePath}`,
+      }));
+      continue;
+    }
+    deduplicated.push(matches[0]);
+    if (matches.length > 1) warnings.push(`Removed ${matches.length - 1} duplicate redirect(s) for ${sourcePath}`);
+  }
+
+  const cycles = cyclicSources(deduplicated.map(({ record }) => record));
+  const records = deduplicated.flatMap(({ source, record }) => {
+    if (!cycles.has(record.sourcePath)) return [record];
+    skipped.push({ record: source, reason: `Redirect participates in a cycle: ${record.sourcePath}` });
+    return [];
+  }).sort((left, right) => left.sourcePath.localeCompare(right.sourcePath));
+
+  for (const record of records) {
+    if (record.sourceFingerprint) idMap.set(record.sourceFingerprint, record.sourcePath);
+  }
+
+  return { records, idMap, skipped, warnings };
+}

--- a/scripts/shopify-migration/transformers/redirects.ts
+++ b/scripts/shopify-migration/transformers/redirects.ts
@@ -1,3 +1,7 @@
+import {
+  isLegacyRedirectLookupPath,
+  validateRedirectCandidate,
+} from "../../../lib/redirects/policy.js";
 import type { ShopifyRedirect } from "../lib/types.js";
 import { providerFingerprint } from "../lib/ids.js";
 import { SHOPIFY_PROVIDER, type TransformFailure } from "./_shared.js";
@@ -29,21 +33,6 @@ export interface RedirectTransformResult {
   idMap: Map<string, string>;
   skipped: Array<TransformFailure<ShopifyRedirect | RedirectCandidate>>;
   warnings: string[];
-}
-
-function validInternalPath(value: string, source: boolean): boolean {
-  if (value.length < (source ? 3 : 1) || value.length > 2_048) return false;
-  if (!value.startsWith("/") || value.startsWith("//")) return false;
-  if (/[\\?#\u0000-\u001f\u007f]/u.test(value)) return false;
-  if (/%(?:00|0[ad]|2e|2f|5c)/iu.test(value)) return false;
-  let decoded: string;
-  try {
-    decoded = decodeURIComponent(value);
-  } catch {
-    return false;
-  }
-  if (!decoded.startsWith("/") || decoded.startsWith("//") || decoded.includes("\\")) return false;
-  return !decoded.split("/").some((segment) => segment === "." || segment === "..");
 }
 
 function routeSegment(value: string): string {
@@ -124,7 +113,15 @@ export function transformRedirects(
   const candidates: Array<{ source: ShopifyRedirect | RedirectCandidate; record: RedirectCandidate }> = [];
 
   for (const source of redirects) {
-    const fingerprint = providerFingerprint(SHOPIFY_PROVIDER, "redirect", source.id);
+    const sourceId = source.id === null || source.id === undefined ? "" : String(source.id).trim();
+    if (
+      !sourceId || sourceId.length > 512 || typeof source.path !== "string" ||
+      typeof source.target !== "string"
+    ) {
+      skipped.push({ record: source, reason: "Shopify redirect requires a bounded source ID and text paths" });
+      continue;
+    }
+    const fingerprint = providerFingerprint(SHOPIFY_PROVIDER, "redirect", sourceId);
     const record: RedirectCandidate = {
       sourcePath: source.path.trim(),
       targetPath: source.target.trim(),
@@ -135,14 +132,21 @@ export function transformRedirects(
     candidates.push({ source, record });
   }
   for (const record of options.generated ?? []) candidates.push({ source: record, record: { ...record } });
+  const inputCycles = cyclicSources(candidates.map(({ record }) => record));
 
   const valid = candidates.filter(({ source, record }) => {
-    if (!validInternalPath(record.sourcePath, true) || !validInternalPath(record.targetPath, false)) {
-      skipped.push({ record: source, reason: "Redirect source and target must be safe internal paths" });
+    if (inputCycles.has(record.sourcePath)) {
+      skipped.push({ record: source, reason: `Redirect participates in a cycle: ${record.sourcePath}` });
       return false;
     }
-    if (record.sourcePath === record.targetPath) {
-      skipped.push({ record: source, reason: "Redirect cannot target itself" });
+    if (
+      !isLegacyRedirectLookupPath(record.sourcePath) ||
+      !validateRedirectCandidate(record.sourcePath, record)
+    ) {
+      skipped.push({
+        record: source,
+        reason: "Redirect must satisfy the exact legacy-source and safe-runtime target policy",
+      });
       return false;
     }
     if (options.protectedSourcePaths?.has(record.sourcePath)) {
@@ -178,7 +182,14 @@ export function transformRedirects(
     if (!cycles.has(record.sourcePath)) return [record];
     skipped.push({ record: source, reason: `Redirect participates in a cycle: ${record.sourcePath}` });
     return [];
-  }).sort((left, right) => left.sourcePath.localeCompare(right.sourcePath));
+  }).map((record) => ({
+    ...record,
+    sourceFingerprint: record.sourceFingerprint ?? providerFingerprint(
+      SHOPIFY_PROVIDER,
+      "redirect_path",
+      record.sourcePath,
+    ),
+  })).sort((left, right) => left.sourcePath.localeCompare(right.sourcePath));
 
   for (const record of records) {
     if (record.sourceFingerprint) idMap.set(record.sourceFingerprint, record.sourcePath);

--- a/scripts/shopify-migration/transformers/sensitive/_shared.ts
+++ b/scripts/shopify-migration/transformers/sensitive/_shared.ts
@@ -65,6 +65,12 @@ export function safeTargetId(value: string | undefined): string | null {
   return normalized && SAFE_TARGET_ID.test(normalized) ? normalized : null;
 }
 
+/** Clerk ownership IDs are the only valid customer primary/foreign keys. */
+export function safeClerkUserId(value: string | undefined): string | null {
+  const normalized = value?.trim();
+  return normalized && /^user_[A-Za-z0-9]{8,250}$/.test(normalized) ? normalized : null;
+}
+
 export function resolvedProviderId(
   mappings: ReadonlyMap<string, string> | undefined,
   entity: string,

--- a/scripts/shopify-migration/transformers/sensitive/_shared.ts
+++ b/scripts/shopify-migration/transformers/sensitive/_shared.ts
@@ -1,0 +1,98 @@
+import { providerFingerprint } from "../../lib/ids.js";
+import { SHOPIFY_PROVIDER } from "../_shared.js";
+
+export const MAX_SENSITIVE_RECORDS = 100_000;
+export const MAX_ADDRESSES = 25;
+export const MAX_ORDER_ITEMS = 500;
+
+export interface SensitiveTransformResult<TRecord> {
+  records: TRecord[];
+  idMap: Map<string, string>;
+  skipped: Array<{ sourceFingerprint: string | null; reason: string }>;
+  warnings: string[];
+}
+
+const FORBIDDEN_CONTROL = /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/;
+const SAFE_TARGET_ID = /^[A-Za-z0-9][A-Za-z0-9:_-]{0,255}$/;
+
+export function assertBatchSize(length: number): void {
+  if (!Number.isSafeInteger(length) || length < 0 || length > MAX_SENSITIVE_RECORDS) {
+    throw new RangeError(`Sensitive transform batches may contain at most ${MAX_SENSITIVE_RECORDS} records`);
+  }
+}
+
+export function sourceId(value: string | number): string {
+  const normalized = String(value).trim();
+  if (!normalized || normalized.length > 512 || FORBIDDEN_CONTROL.test(normalized)) {
+    throw new TypeError("Provider source ID is invalid");
+  }
+  return normalized;
+}
+
+export function boundedText(
+  value: unknown,
+  maxLength: number,
+  options: { required?: boolean; multiline?: boolean } = {},
+): string | null {
+  if (value === undefined || value === null) {
+    if (options.required) throw new TypeError("Required text is missing");
+    return null;
+  }
+  if (typeof value !== "string" || FORBIDDEN_CONTROL.test(value)) {
+    throw new TypeError("Text contains an invalid value");
+  }
+  const normalized = options.multiline
+    ? value.replace(/\r\n?/g, "\n").trim()
+    : value.replace(/\s+/g, " ").trim();
+  if (!normalized) {
+    if (options.required) throw new TypeError("Required text is empty");
+    return null;
+  }
+  if (normalized.length > maxLength) throw new RangeError(`Text exceeds ${maxLength} characters`);
+  return normalized;
+}
+
+export function normalizedEmail(value: unknown, required = false): string | null {
+  const email = boundedText(value, 254, { required })?.toLowerCase() ?? null;
+  if (email && !/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(email)) {
+    throw new TypeError("Email address is invalid");
+  }
+  return email;
+}
+
+export function safeTargetId(value: string | undefined): string | null {
+  const normalized = value?.trim();
+  return normalized && SAFE_TARGET_ID.test(normalized) ? normalized : null;
+}
+
+export function resolvedProviderId(
+  mappings: ReadonlyMap<string, string> | undefined,
+  entity: string,
+  providerSourceId: string | number,
+): string | null {
+  return safeTargetId(mappings?.get(
+    providerFingerprint(SHOPIFY_PROVIDER, entity, providerSourceId),
+  ));
+}
+
+export function emailFingerprint(email: string): string {
+  return providerFingerprint(SHOPIFY_PROVIDER, "customer_email", email.toLowerCase());
+}
+
+export function boundedTags(value: unknown): string[] {
+  if (value === undefined || value === null || value === "") return [];
+  if (typeof value !== "string" || value.length > 10_000) throw new TypeError("Tags are invalid");
+  const seen = new Set<string>();
+  const tags: string[] = [];
+  for (const raw of value.split(",")) {
+    const tag = boundedText(raw, 100);
+    if (!tag) continue;
+    const key = tag.toLocaleLowerCase("en-US");
+    if (!seen.has(key)) {
+      seen.add(key);
+      tags.push(tag);
+    }
+    if (tags.length > 50) throw new RangeError("Customer has too many tags");
+  }
+  return tags;
+}

--- a/scripts/shopify-migration/transformers/sensitive/_shared.ts
+++ b/scripts/shopify-migration/transformers/sensitive/_shared.ts
@@ -4,6 +4,8 @@ import { SHOPIFY_PROVIDER } from "../_shared.js";
 export const MAX_SENSITIVE_RECORDS = 100_000;
 export const MAX_ADDRESSES = 25;
 export const MAX_ORDER_ITEMS = 500;
+/** Stable explicit fallback when a source record has no usable timestamp. */
+export const UNKNOWN_SOURCE_TIMESTAMP = "1970-01-01T00:00:00.000Z";
 
 export interface SensitiveTransformResult<TRecord> {
   records: TRecord[];

--- a/scripts/shopify-migration/transformers/sensitive/customers.ts
+++ b/scripts/shopify-migration/transformers/sensitive/customers.ts
@@ -13,6 +13,7 @@ import {
   boundedText,
   emailFingerprint,
   normalizedEmail,
+  safeClerkUserId,
   type SensitiveTransformResult,
   sourceId,
 } from "./_shared.js";
@@ -31,18 +32,28 @@ export interface CustomerInsertRecord {
   extensions: string;
 }
 
-export interface CustomerTransformRecord {
+export type CustomerInsertFields = Omit<CustomerInsertRecord, "id">;
+
+export interface CustomerProvisioningPlan {
   sourceFingerprint: string;
   emailFingerprint: string;
-  customer: CustomerInsertRecord;
+  /** Stable operator reference only. It is never a Mercora customer ID. */
+  provisioningReference: string;
+  customerFields: CustomerInsertFields;
 }
 
 export interface CustomerTransformOptions {
   generatedAt: string;
 }
 
-export interface CustomerTransformResult
-  extends SensitiveTransformResult<CustomerTransformRecord> {
+export interface CustomerProvisioningResult {
+  records: CustomerProvisioningPlan[];
+  skipped: Array<{ sourceFingerprint: string | null; reason: string }>;
+  warnings: string[];
+}
+
+export interface MaterializedCustomerResult
+  extends SensitiveTransformResult<CustomerInsertRecord> {
   emailIdMap: Map<string, string>;
 }
 
@@ -92,12 +103,10 @@ function customerAddress(
 export function transformCustomers(
   customers: readonly ShopifyCustomer[],
   options: CustomerTransformOptions,
-): CustomerTransformResult {
+): CustomerProvisioningResult {
   assertBatchSize(customers.length);
   const generatedAt = requiredMigrationTime(options.generatedAt);
-  const records: CustomerTransformRecord[] = [];
-  const idMap = new Map<string, string>();
-  const emailIdMap = new Map<string, string>();
+  const records: CustomerProvisioningPlan[] = [];
   const skipped: Array<{ sourceFingerprint: string | null; reason: string }> = [];
   const warnings: string[] = [];
   const seenSources = new Set<string>();
@@ -113,7 +122,11 @@ export function transformCustomers(
       if (seenSources.has(sourceFingerprint)) throw new TypeError("Duplicate customer source identity");
       if (seenEmails.has(email)) throw new TypeError("Duplicate normalized customer email");
 
-      const id = deterministicProviderId(SHOPIFY_PROVIDER, "customer", providerId);
+      const provisioningReference = deterministicProviderId(
+        SHOPIFY_PROVIDER,
+        "customer_provisioning",
+        providerId,
+      );
       const sourceAddresses = customer.addresses ?? (customer.default_address ? [customer.default_address] : []);
       if (sourceAddresses.length > MAX_ADDRESSES) throw new RangeError("Customer has too many addresses");
       const addresses = sourceAddresses.flatMap((address, position) => {
@@ -146,8 +159,8 @@ export function transformCustomers(
       records.push({
         sourceFingerprint,
         emailFingerprint: emailKey,
-        customer: {
-          id,
+        provisioningReference,
+        customerFields: {
           type: "person",
           status: customer.verified_email === true ? "active" : "pending_verification",
           external_references: JSON.stringify({ shopify_fingerprint: sourceFingerprint }),
@@ -185,8 +198,6 @@ export function transformCustomers(
       });
       seenSources.add(sourceFingerprint);
       seenEmails.add(email);
-      idMap.set(sourceFingerprint, id);
-      emailIdMap.set(emailKey, id);
     } catch (error) {
       skipped.push({
         sourceFingerprint: failedFingerprint,
@@ -195,5 +206,47 @@ export function transformCustomers(
     }
   }
 
-  return { records, idMap, emailIdMap, skipped, warnings };
+  return { records, skipped, warnings };
+}
+
+/**
+ * Materialize insertable rows only after the operator provisions Clerk users.
+ * A missing or non-Clerk mapping never becomes a customer primary key.
+ */
+export function materializeCustomers(
+  plans: readonly CustomerProvisioningPlan[],
+  clerkUserIds: ReadonlyMap<string, string>,
+): MaterializedCustomerResult {
+  assertBatchSize(plans.length);
+  const records: CustomerInsertRecord[] = [];
+  const idMap = new Map<string, string>();
+  const emailIdMap = new Map<string, string>();
+  const skipped: Array<{ sourceFingerprint: string | null; reason: string }> = [];
+  const seenClerkIds = new Set<string>();
+  const seenEmailFingerprints = new Set<string>();
+
+  for (const plan of plans) {
+    const clerkId = safeClerkUserId(clerkUserIds.get(plan.sourceFingerprint));
+    if (!clerkId) {
+      skipped.push({
+        sourceFingerprint: plan.sourceFingerprint,
+        reason: "Customer requires a resolved Clerk user ID",
+      });
+      continue;
+    }
+    if (seenClerkIds.has(clerkId) || seenEmailFingerprints.has(plan.emailFingerprint)) {
+      skipped.push({
+        sourceFingerprint: plan.sourceFingerprint,
+        reason: "Customer provisioning resolution is duplicated",
+      });
+      continue;
+    }
+    records.push({ ...plan.customerFields, id: clerkId });
+    idMap.set(plan.sourceFingerprint, clerkId);
+    emailIdMap.set(plan.emailFingerprint, clerkId);
+    seenClerkIds.add(clerkId);
+    seenEmailFingerprints.add(plan.emailFingerprint);
+  }
+
+  return { records, idMap, emailIdMap, skipped, warnings: [] };
 }

--- a/scripts/shopify-migration/transformers/sensitive/customers.ts
+++ b/scripts/shopify-migration/transformers/sensitive/customers.ts
@@ -8,6 +8,7 @@ import {
 } from "../_shared.js";
 import {
   MAX_ADDRESSES,
+  UNKNOWN_SOURCE_TIMESTAMP,
   assertBatchSize,
   boundedTags,
   boundedText,
@@ -105,7 +106,7 @@ export function transformCustomers(
   options: CustomerTransformOptions,
 ): CustomerProvisioningResult {
   assertBatchSize(customers.length);
-  const generatedAt = requiredMigrationTime(options.generatedAt);
+  requiredMigrationTime(options.generatedAt);
   const records: CustomerProvisioningPlan[] = [];
   const skipped: Array<{ sourceFingerprint: string | null; reason: string }> = [];
   const warnings: string[] = [];
@@ -149,7 +150,7 @@ export function transformCustomers(
         return { ...address, is_default: isDefault };
       });
       const tags = boundedTags(customer.tags);
-      const createdAt = isoTimestamp(customer.created_at, generatedAt);
+      const createdAt = isoTimestamp(customer.created_at, UNKNOWN_SOURCE_TIMESTAMP);
       const updatedAt = isoTimestamp(customer.updated_at, createdAt);
       const firstName = boundedText(customer.first_name, 100);
       const lastName = boundedText(customer.last_name, 100);
@@ -185,7 +186,6 @@ export function transformCustomers(
             migration: {
               provider: SHOPIFY_PROVIDER,
               imported: true,
-              generated_at: generatedAt,
               source_fingerprint: sourceFingerprint,
             },
             source_summary: {

--- a/scripts/shopify-migration/transformers/sensitive/customers.ts
+++ b/scripts/shopify-migration/transformers/sensitive/customers.ts
@@ -1,0 +1,199 @@
+import type { MACHAddress } from "../../../../lib/types/mach/Address.js";
+import type { ShopifyCustomer, ShopifyCustomerAddress } from "../../lib/types.js";
+import { deterministicProviderId, providerFingerprint } from "../../lib/ids.js";
+import {
+  SHOPIFY_PROVIDER,
+  isoTimestamp,
+  requiredMigrationTime,
+} from "../_shared.js";
+import {
+  MAX_ADDRESSES,
+  assertBatchSize,
+  boundedTags,
+  boundedText,
+  emailFingerprint,
+  normalizedEmail,
+  type SensitiveTransformResult,
+  sourceId,
+} from "./_shared.js";
+
+export interface CustomerInsertRecord {
+  id: string;
+  type: "person";
+  status: "active" | "pending_verification";
+  external_references: string;
+  created_at: string;
+  updated_at: string;
+  person: string;
+  addresses: string | null;
+  communication_preferences: string;
+  tags: string | null;
+  extensions: string;
+}
+
+export interface CustomerTransformRecord {
+  sourceFingerprint: string;
+  emailFingerprint: string;
+  customer: CustomerInsertRecord;
+}
+
+export interface CustomerTransformOptions {
+  generatedAt: string;
+}
+
+export interface CustomerTransformResult
+  extends SensitiveTransformResult<CustomerTransformRecord> {
+  emailIdMap: Map<string, string>;
+}
+
+function countryCode(address: ShopifyCustomerAddress): string | null {
+  const value = address.country_code ?? address.country;
+  const normalized = boundedText(value, 2)?.toUpperCase() ?? null;
+  return normalized && /^[A-Z]{2}$/.test(normalized) ? normalized : null;
+}
+
+function customerAddress(
+  address: ShopifyCustomerAddress,
+  customerSourceId: string,
+  position: number,
+): { id: string; type: "shipping" | "other"; address: MACHAddress; is_default: boolean; verification_status: "unverified" } | null {
+  const line1 = boundedText(address.address1, 300);
+  const city = boundedText(address.city, 200);
+  const country = countryCode(address);
+  if (!line1 || !city || !country) return null;
+  const firstName = boundedText(address.first_name, 100);
+  const lastName = boundedText(address.last_name, 100);
+  const recipient = [firstName, lastName].filter(Boolean).join(" ") || undefined;
+  const providerAddressId = address.id === undefined
+    ? `${customerSourceId}:position:${position}`
+    : `${customerSourceId}:address:${sourceId(address.id)}`;
+  return {
+    id: deterministicProviderId(SHOPIFY_PROVIDER, "customer_address", providerAddressId),
+    type: address.default ? "shipping" : "other",
+    is_default: address.default === true,
+    verification_status: "unverified",
+    address: {
+      line1,
+      city,
+      country,
+      status: "unverified",
+      ...(boundedText(address.address2, 300) ? { line2: boundedText(address.address2, 300)! } : {}),
+      ...(boundedText(address.province ?? address.province_code, 200)
+        ? { region: boundedText(address.province ?? address.province_code, 200)! }
+        : {}),
+      ...(boundedText(address.zip, 32) ? { postal_code: boundedText(address.zip, 32)! } : {}),
+      ...(boundedText(address.company, 200) ? { company: boundedText(address.company, 200)! } : {}),
+      ...(boundedText(address.phone, 50) ? { phone: boundedText(address.phone, 50)! } : {}),
+      ...(recipient ? { recipient } : {}),
+    },
+  };
+}
+
+export function transformCustomers(
+  customers: readonly ShopifyCustomer[],
+  options: CustomerTransformOptions,
+): CustomerTransformResult {
+  assertBatchSize(customers.length);
+  const generatedAt = requiredMigrationTime(options.generatedAt);
+  const records: CustomerTransformRecord[] = [];
+  const idMap = new Map<string, string>();
+  const emailIdMap = new Map<string, string>();
+  const skipped: Array<{ sourceFingerprint: string | null; reason: string }> = [];
+  const warnings: string[] = [];
+  const seenSources = new Set<string>();
+  const seenEmails = new Set<string>();
+
+  for (const customer of customers) {
+    let failedFingerprint: string | null = null;
+    try {
+      const providerId = sourceId(customer.id);
+      const sourceFingerprint = providerFingerprint(SHOPIFY_PROVIDER, "customer", providerId);
+      failedFingerprint = sourceFingerprint;
+      const email = normalizedEmail(customer.email, true)!;
+      if (seenSources.has(sourceFingerprint)) throw new TypeError("Duplicate customer source identity");
+      if (seenEmails.has(email)) throw new TypeError("Duplicate normalized customer email");
+
+      const id = deterministicProviderId(SHOPIFY_PROVIDER, "customer", providerId);
+      const sourceAddresses = customer.addresses ?? (customer.default_address ? [customer.default_address] : []);
+      if (sourceAddresses.length > MAX_ADDRESSES) throw new RangeError("Customer has too many addresses");
+      const addresses = sourceAddresses.flatMap((address, position) => {
+        try {
+          const transformed = customerAddress(address, providerId, position + 1);
+          if (!transformed) {
+            warnings.push(`Customer ${sourceFingerprint} has an incomplete address; address omitted`);
+            return [];
+          }
+          return [transformed];
+        } catch {
+          warnings.push(`Customer ${sourceFingerprint} has an invalid address; address omitted`);
+          return [];
+        }
+      });
+      let defaultSeen = false;
+      const normalizedAddresses = addresses.map((address) => {
+        const isDefault = address.is_default && !defaultSeen;
+        if (isDefault) defaultSeen = true;
+        return { ...address, is_default: isDefault };
+      });
+      const tags = boundedTags(customer.tags);
+      const createdAt = isoTimestamp(customer.created_at, generatedAt);
+      const updatedAt = isoTimestamp(customer.updated_at, createdAt);
+      const firstName = boundedText(customer.first_name, 100);
+      const lastName = boundedText(customer.last_name, 100);
+      const fullName = [firstName, lastName].filter(Boolean).join(" ") || null;
+      const emailKey = emailFingerprint(email);
+
+      records.push({
+        sourceFingerprint,
+        emailFingerprint: emailKey,
+        customer: {
+          id,
+          type: "person",
+          status: customer.verified_email === true ? "active" : "pending_verification",
+          external_references: JSON.stringify({ shopify_fingerprint: sourceFingerprint }),
+          created_at: createdAt,
+          updated_at: updatedAt,
+          person: JSON.stringify({
+            email,
+            ...(firstName ? { first_name: firstName } : {}),
+            ...(lastName ? { last_name: lastName } : {}),
+            ...(fullName ? { full_name: fullName } : {}),
+            ...(boundedText(customer.phone, 50) ? { phone: boundedText(customer.phone, 50)! } : {}),
+          }),
+          addresses: normalizedAddresses.length ? JSON.stringify(normalizedAddresses) : null,
+          communication_preferences: JSON.stringify({
+            email: {
+              opted_in: customer.accepts_marketing === true,
+              verified: customer.verified_email === true,
+            },
+          }),
+          tags: tags.length ? JSON.stringify(tags) : null,
+          extensions: JSON.stringify({
+            migration: {
+              provider: SHOPIFY_PROVIDER,
+              imported: true,
+              generated_at: generatedAt,
+              source_fingerprint: sourceFingerprint,
+            },
+            source_summary: {
+              orders_count: Number.isSafeInteger(customer.orders_count) && (customer.orders_count ?? -1) >= 0
+                ? customer.orders_count
+                : null,
+            },
+          }),
+        },
+      });
+      seenSources.add(sourceFingerprint);
+      seenEmails.add(email);
+      idMap.set(sourceFingerprint, id);
+      emailIdMap.set(emailKey, id);
+    } catch (error) {
+      skipped.push({
+        sourceFingerprint: failedFingerprint,
+        reason: error instanceof Error ? error.message : "Customer is invalid",
+      });
+    }
+  }
+
+  return { records, idMap, emailIdMap, skipped, warnings };
+}

--- a/scripts/shopify-migration/transformers/sensitive/index.ts
+++ b/scripts/shopify-migration/transformers/sensitive/index.ts
@@ -1,0 +1,3 @@
+export * from "./customers.js";
+export * from "./orders.js";
+export * from "./reviews.js";

--- a/scripts/shopify-migration/transformers/sensitive/orders.ts
+++ b/scripts/shopify-migration/transformers/sensitive/orders.ts
@@ -1,0 +1,248 @@
+import type { MACHAddress } from "../../../../lib/types/mach/Address.js";
+import type { OrderItem, OrderStatus, PaymentStatus } from "../../../../lib/types/order.js";
+import type { ShopifyCustomerAddress, ShopifyOrder, ShopifyOrderLineItem } from "../../lib/types.js";
+import { deterministicProviderId, providerFingerprint } from "../../lib/ids.js";
+import {
+  SHOPIFY_PROVIDER,
+  isoTimestamp,
+  majorToStoredMoney,
+  requiredMigrationTime,
+  requireSupportedCurrency,
+} from "../_shared.js";
+import {
+  MAX_ORDER_ITEMS,
+  assertBatchSize,
+  boundedText,
+  normalizedEmail,
+  resolvedProviderId,
+  type SensitiveTransformResult,
+  sourceId,
+} from "./_shared.js";
+
+export interface HistoricalOrderInsertRecord {
+  id: string;
+  customer_id: string | null;
+  status: OrderStatus;
+  total_amount: string;
+  currency_code: string;
+  shipping_address: string | null;
+  billing_address: string | null;
+  items: string;
+  shipping_method: null;
+  shipping_carrier: null;
+  payment_method: null;
+  payment_status: PaymentStatus;
+  tracking_number: null;
+  shipped_at: null;
+  delivered_at: null;
+  notes: string | null;
+  external_references: string;
+  extensions: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface HistoricalOrderTransformRecord {
+  sourceFingerprint: string;
+  order: HistoricalOrderInsertRecord;
+}
+
+export interface HistoricalOrderTransformOptions {
+  generatedAt: string;
+  customerIds?: ReadonlyMap<string, string>;
+  productIds?: ReadonlyMap<string, string>;
+  variantIds?: ReadonlyMap<string, string>;
+}
+
+function address(value: ShopifyCustomerAddress | null | undefined): MACHAddress | null {
+  if (!value) return null;
+  const line1 = boundedText(value.address1, 300);
+  const city = boundedText(value.city, 200);
+  const rawCountry = boundedText(value.country_code ?? value.country, 2)?.toUpperCase();
+  if (!line1 || !city || !rawCountry || !/^[A-Z]{2}$/.test(rawCountry)) return null;
+  const firstName = boundedText(value.first_name, 100);
+  const lastName = boundedText(value.last_name, 100);
+  const recipient = [firstName, lastName].filter(Boolean).join(" ") || null;
+  const line2 = boundedText(value.address2, 300);
+  const region = boundedText(value.province ?? value.province_code, 200);
+  const postalCode = boundedText(value.zip, 32);
+  const company = boundedText(value.company, 200);
+  const phone = boundedText(value.phone, 50);
+  return {
+    line1,
+    city,
+    country: rawCountry,
+    status: "unverified",
+    ...(line2 ? { line2 } : {}),
+    ...(region ? { region } : {}),
+    ...(postalCode ? { postal_code: postalCode } : {}),
+    ...(company ? { company } : {}),
+    ...(recipient ? { recipient } : {}),
+    ...(phone ? { phone } : {}),
+  };
+}
+
+function conservativeOrderStatus(order: ShopifyOrder): OrderStatus {
+  const financial = order.financial_status?.trim().toLowerCase();
+  const fulfillment = order.fulfillment_status?.trim().toLowerCase();
+  if (order.cancelled_at || financial === "voided" || financial === "cancelled") return "cancelled";
+  if (financial === "refunded") return "refunded";
+  if (fulfillment === "fulfilled" || fulfillment === "partial") return "shipped";
+  if (financial === "paid" || financial === "partially_paid") return "processing";
+  return "pending";
+}
+
+/** Never mark external history paid: paid is Mercora's Stripe/effect authority. */
+function nonAuthoritativePaymentStatus(order: ShopifyOrder): PaymentStatus {
+  const financial = order.financial_status?.trim().toLowerCase();
+  if (financial === "refunded") return "refunded";
+  if (financial === "voided" || financial === "cancelled") return "failed";
+  return "pending";
+}
+
+function checkedLineItem(
+  item: ShopifyOrderLineItem,
+  orderSourceId: string,
+  position: number,
+  currency: string,
+  options: HistoricalOrderTransformOptions,
+): OrderItem {
+  if (!Number.isSafeInteger(item.quantity) || item.quantity < 1 || item.quantity > 1_000_000) {
+    throw new RangeError("Order item quantity is invalid");
+  }
+  const itemSource = item.id === undefined ? `position:${position}` : sourceId(item.id);
+  const lineIdentity = `${orderSourceId}:line:${itemSource}`;
+  const productSource = item.product_id === null || item.product_id === undefined
+    ? lineIdentity
+    : sourceId(item.product_id);
+  const productId = item.product_id === null || item.product_id === undefined
+    ? deterministicProviderId(SHOPIFY_PROVIDER, "historical_product", productSource)
+    : resolvedProviderId(options.productIds, "product", productSource)
+      ?? deterministicProviderId(SHOPIFY_PROVIDER, "historical_product", productSource);
+  const variantSource = item.variant_id === null || item.variant_id === undefined
+    ? null
+    : sourceId(item.variant_id);
+  const variantId = variantSource
+    ? resolvedProviderId(options.variantIds, "variant", variantSource)
+      ?? deterministicProviderId(SHOPIFY_PROVIDER, "historical_variant", variantSource)
+    : undefined;
+  const unitPrice = majorToStoredMoney(item.price, currency);
+  const gross = unitPrice.amount * item.quantity;
+  if (!Number.isSafeInteger(gross)) throw new RangeError("Order item total overflows safe money storage");
+  const discount = item.total_discount ? majorToStoredMoney(item.total_discount, currency).amount : 0;
+  if (discount > gross) throw new RangeError("Order item discount exceeds its gross total");
+  const id = deterministicProviderId(SHOPIFY_PROVIDER, "order_item", lineIdentity);
+  return {
+    id,
+    product_id: productId,
+    ...(variantId ? { variant_id: variantId } : {}),
+    sku: boundedText(item.sku, 128)
+      ?? `IMPORTED-${providerFingerprint(SHOPIFY_PROVIDER, "order_item", lineIdentity).slice(0, 12).toUpperCase()}`,
+    quantity: item.quantity,
+    unit_price: unitPrice,
+    total_price: { amount: gross - discount, currency },
+    product_name: boundedText(item.title, 300, { required: true })!,
+  };
+}
+
+export function transformHistoricalOrders(
+  orders: readonly ShopifyOrder[],
+  options: HistoricalOrderTransformOptions,
+): SensitiveTransformResult<HistoricalOrderTransformRecord> {
+  assertBatchSize(orders.length);
+  const generatedAt = requiredMigrationTime(options.generatedAt);
+  const records: HistoricalOrderTransformRecord[] = [];
+  const idMap = new Map<string, string>();
+  const skipped: Array<{ sourceFingerprint: string | null; reason: string }> = [];
+  const warnings: string[] = [];
+  const seenSources = new Set<string>();
+
+  for (const order of orders) {
+    let failedFingerprint: string | null = null;
+    try {
+      const providerId = sourceId(order.id);
+      const sourceFingerprint = providerFingerprint(SHOPIFY_PROVIDER, "order", providerId);
+      failedFingerprint = sourceFingerprint;
+      if (seenSources.has(sourceFingerprint)) throw new TypeError("Duplicate order source identity");
+      if (!Array.isArray(order.line_items) || !order.line_items.length || order.line_items.length > MAX_ORDER_ITEMS) {
+        throw new RangeError(`Orders require 1-${MAX_ORDER_ITEMS} line items`);
+      }
+      const currency = requireSupportedCurrency(boundedText(order.currency, 3, { required: true })!);
+      const total = majorToStoredMoney(order.total_price, currency);
+      const items = order.line_items.map((item, position) =>
+        checkedLineItem(item, providerId, position + 1, currency, options));
+      const customerId = order.customer?.id === undefined
+        ? null
+        : resolvedProviderId(options.customerIds, "customer", sourceId(order.customer.id));
+      if (order.customer?.id !== undefined && !customerId) {
+        warnings.push(`Order ${sourceFingerprint} has no imported customer mapping; retained as guest history`);
+      }
+      const shippingAddress = address(order.shipping_address);
+      const billingAddress = address(order.billing_address);
+      if (order.shipping_address && !shippingAddress) {
+        warnings.push(`Order ${sourceFingerprint} has an incomplete shipping address; address omitted`);
+      }
+      if (order.billing_address && !billingAddress) {
+        warnings.push(`Order ${sourceFingerprint} has an incomplete billing address; address omitted`);
+      }
+      const email = normalizedEmail(order.email);
+      const createdAt = isoTimestamp(order.created_at, generatedAt);
+      const updatedAt = isoTimestamp(order.updated_at, createdAt);
+      const id = deterministicProviderId(SHOPIFY_PROVIDER, "order", providerId);
+      const sourceFinancialStatus = boundedText(order.financial_status, 64)?.toLowerCase() ?? null;
+      const sourceFulfillmentStatus = boundedText(order.fulfillment_status, 64)?.toLowerCase() ?? null;
+
+      records.push({
+        sourceFingerprint,
+        order: {
+          id,
+          customer_id: customerId,
+          status: conservativeOrderStatus(order),
+          total_amount: JSON.stringify(total),
+          currency_code: currency,
+          shipping_address: shippingAddress ? JSON.stringify(shippingAddress) : null,
+          billing_address: billingAddress ? JSON.stringify(billingAddress) : null,
+          items: JSON.stringify(items),
+          shipping_method: null,
+          shipping_carrier: null,
+          payment_method: null,
+          payment_status: nonAuthoritativePaymentStatus(order),
+          tracking_number: null,
+          shipped_at: null,
+          delivered_at: null,
+          notes: boundedText(order.note, 2_000, { multiline: true }),
+          external_references: JSON.stringify({ shopify_fingerprint: sourceFingerprint }),
+          extensions: JSON.stringify({
+            migration: {
+              provider: SHOPIFY_PROVIDER,
+              imported: true,
+              historical: true,
+              read_only: true,
+              generated_at: generatedAt,
+              source_fingerprint: sourceFingerprint,
+            },
+            payment_provenance: {
+              authority: "external_unverified",
+              refundable: false,
+              paid_effects_eligible: false,
+              source_status: sourceFinancialStatus,
+            },
+            fulfillment_provenance: { source_status: sourceFulfillmentStatus },
+            ...(email ? { email } : {}),
+          }),
+          created_at: createdAt,
+          updated_at: updatedAt,
+        },
+      });
+      seenSources.add(sourceFingerprint);
+      idMap.set(sourceFingerprint, id);
+    } catch (error) {
+      skipped.push({
+        sourceFingerprint: failedFingerprint,
+        reason: error instanceof Error ? error.message : "Order is invalid",
+      });
+    }
+  }
+
+  return { records, idMap, skipped, warnings };
+}

--- a/scripts/shopify-migration/transformers/sensitive/orders.ts
+++ b/scripts/shopify-migration/transformers/sensitive/orders.ts
@@ -11,6 +11,7 @@ import {
 } from "../_shared.js";
 import {
   MAX_ORDER_ITEMS,
+  UNKNOWN_SOURCE_TIMESTAMP,
   assertBatchSize,
   boundedText,
   normalizedEmail,
@@ -155,7 +156,7 @@ export function transformHistoricalOrders(
   if (options.unresolvedCustomer !== "reject" && options.unresolvedCustomer !== "guest") {
     throw new TypeError("unresolvedCustomer must explicitly be reject or guest");
   }
-  const generatedAt = requiredMigrationTime(options.generatedAt);
+  requiredMigrationTime(options.generatedAt);
   const records: HistoricalOrderTransformRecord[] = [];
   const idMap = new Map<string, string>();
   const skipped: Array<{ sourceFingerprint: string | null; reason: string }> = [];
@@ -197,7 +198,7 @@ export function transformHistoricalOrders(
         warnings.push(`Order ${sourceFingerprint} has an incomplete billing address; address omitted`);
       }
       const email = normalizedEmail(order.email);
-      const createdAt = isoTimestamp(order.created_at, generatedAt);
+      const createdAt = isoTimestamp(order.created_at, UNKNOWN_SOURCE_TIMESTAMP);
       const updatedAt = isoTimestamp(order.updated_at, createdAt);
       const id = deterministicProviderId(SHOPIFY_PROVIDER, "order", providerId);
       const sourceFinancialStatus = boundedText(order.financial_status, 64)?.toLowerCase() ?? null;
@@ -229,7 +230,6 @@ export function transformHistoricalOrders(
               imported: true,
               historical: true,
               read_only: true,
-              generated_at: generatedAt,
               source_fingerprint: sourceFingerprint,
             },
             payment_provenance: {

--- a/scripts/shopify-migration/transformers/sensitive/orders.ts
+++ b/scripts/shopify-migration/transformers/sensitive/orders.ts
@@ -15,6 +15,7 @@ import {
   boundedText,
   normalizedEmail,
   resolvedProviderId,
+  safeClerkUserId,
   type SensitiveTransformResult,
   sourceId,
 } from "./_shared.js";
@@ -52,6 +53,7 @@ export interface HistoricalOrderTransformOptions {
   customerIds?: ReadonlyMap<string, string>;
   productIds?: ReadonlyMap<string, string>;
   variantIds?: ReadonlyMap<string, string>;
+  unresolvedCustomer: "reject" | "guest";
 }
 
 function address(value: ShopifyCustomerAddress | null | undefined): MACHAddress | null {
@@ -150,6 +152,9 @@ export function transformHistoricalOrders(
   options: HistoricalOrderTransformOptions,
 ): SensitiveTransformResult<HistoricalOrderTransformRecord> {
   assertBatchSize(orders.length);
+  if (options.unresolvedCustomer !== "reject" && options.unresolvedCustomer !== "guest") {
+    throw new TypeError("unresolvedCustomer must explicitly be reject or guest");
+  }
   const generatedAt = requiredMigrationTime(options.generatedAt);
   const records: HistoricalOrderTransformRecord[] = [];
   const idMap = new Map<string, string>();
@@ -171,11 +176,17 @@ export function transformHistoricalOrders(
       const total = majorToStoredMoney(order.total_price, currency);
       const items = order.line_items.map((item, position) =>
         checkedLineItem(item, providerId, position + 1, currency, options));
-      const customerId = order.customer?.id === undefined
-        ? null
-        : resolvedProviderId(options.customerIds, "customer", sourceId(order.customer.id));
-      if (order.customer?.id !== undefined && !customerId) {
-        warnings.push(`Order ${sourceFingerprint} has no imported customer mapping; retained as guest history`);
+      let customerId: string | null = null;
+      if (order.customer?.id !== undefined) {
+        const customerSource = sourceId(order.customer.id);
+        const customerFingerprint = providerFingerprint(SHOPIFY_PROVIDER, "customer", customerSource);
+        customerId = safeClerkUserId(options.customerIds?.get(customerFingerprint));
+        if (!customerId) {
+          if (options.unresolvedCustomer === "reject") {
+            throw new TypeError("Order customer requires a resolved Clerk user ID");
+          }
+          warnings.push(`Order ${sourceFingerprint} has no resolved Clerk customer; retained as explicit guest history`);
+        }
       }
       const shippingAddress = address(order.shipping_address);
       const billingAddress = address(order.billing_address);

--- a/scripts/shopify-migration/transformers/sensitive/reviews.ts
+++ b/scripts/shopify-migration/transformers/sensitive/reviews.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import type { ReviewStatus } from "../../../../lib/types/review.js";
-import type { JudgeMeReview } from "../../lib/types.js";
+import type { JudgeMeFileRow, JudgeMeReview } from "../../lib/types.js";
 import { deterministicProviderId, providerFingerprint } from "../../lib/ids.js";
 import {
   SHOPIFY_PROVIDER,
@@ -18,6 +18,12 @@ import {
 } from "./_shared.js";
 
 const REVIEW_PROVIDER = "judge_me";
+
+export interface JudgeMeNormalizationResult {
+  records: JudgeMeReview[];
+  skipped: Array<{ sourceFingerprint: string | null; reason: string }>;
+  warnings: string[];
+}
 
 export interface ImportedReviewInsertRecord {
   id: string;
@@ -73,6 +79,68 @@ export function judgeMeReviewFingerprint(review: JudgeMeReview): string {
   ]);
   const materialDigest = createHash("sha256").update(material, "utf8").digest("hex");
   return providerFingerprint(REVIEW_PROVIDER, "review", materialDigest);
+}
+
+/**
+ * Convert one bounded CSV row into the typed input accepted by the review
+ * transform. Unknown CSV columns and raw row objects never cross this seam.
+ */
+export function normalizeJudgeMeFileRow(row: JudgeMeFileRow): JudgeMeReview {
+  const ratingText = boundedText(row.rating, 8, { required: true })!;
+  if (!/^[1-5]$/.test(ratingText)) {
+    throw new RangeError("Review rating must be an integer from 1 to 5");
+  }
+  const body = boundedText(row.body, 10_000, { required: true, multiline: true })!;
+  const reviewDate = boundedText(row.review_date ?? row.created_at, 100);
+  const title = boundedText(row.title, 200);
+  const reviewerName = boundedText(row.reviewer_name, 200);
+  const reviewerEmail = normalizedEmail(row.reviewer_email);
+  const productId = boundedText(row.product_id, 512);
+  const productHandle = boundedText(row.product_handle, 255);
+  if (!productId && !productHandle) {
+    throw new TypeError("Review product identity is missing");
+  }
+  const reply = boundedText(row.reply, 5_000, { multiline: true });
+  const pictureUrls = boundedText(row.picture_urls, 10_000, { multiline: true });
+  const source = boundedText(row.source, 100);
+  const status = boundedText(row.status, 64);
+
+  return {
+    body,
+    rating: Number(ratingText),
+    ...(title ? { title } : {}),
+    ...(reviewDate ? { review_date: reviewDate } : {}),
+    ...(reviewerName ? { reviewer_name: reviewerName } : {}),
+    ...(reviewerEmail ? { reviewer_email: reviewerEmail } : {}),
+    ...(productId ? { product_id: productId } : {}),
+    ...(productHandle ? { product_handle: productHandle } : {}),
+    ...(reply ? { reply } : {}),
+    ...(pictureUrls ? { picture_urls: pictureUrls } : {}),
+    ...(source ? { source } : {}),
+    ...(status ? { status } : {}),
+  };
+}
+
+/** Batch normalizer with privacy-safe failure reporting for operator tooling. */
+export function normalizeJudgeMeFileRows(
+  rows: readonly JudgeMeFileRow[],
+): JudgeMeNormalizationResult {
+  assertBatchSize(rows.length);
+  const records: JudgeMeReview[] = [];
+  const skipped: JudgeMeNormalizationResult["skipped"] = [];
+
+  for (const row of rows) {
+    try {
+      records.push(normalizeJudgeMeFileRow(row));
+    } catch (error) {
+      skipped.push({
+        sourceFingerprint: null,
+        reason: error instanceof Error ? error.message : "Judge.me file row is invalid",
+      });
+    }
+  }
+
+  return { records, skipped, warnings: [] };
 }
 
 function resolvedProductId(review: JudgeMeReview, mappings: ReadonlyMap<string, string>): string | null {

--- a/scripts/shopify-migration/transformers/sensitive/reviews.ts
+++ b/scripts/shopify-migration/transformers/sensitive/reviews.ts
@@ -1,0 +1,200 @@
+import { createHash } from "node:crypto";
+import type { ReviewStatus } from "../../../../lib/types/review.js";
+import type { JudgeMeReview } from "../../lib/types.js";
+import { deterministicProviderId, providerFingerprint } from "../../lib/ids.js";
+import {
+  SHOPIFY_PROVIDER,
+  isoTimestamp,
+  normalizeSlug,
+  requiredMigrationTime,
+} from "../_shared.js";
+import {
+  assertBatchSize,
+  boundedText,
+  emailFingerprint,
+  normalizedEmail,
+  safeTargetId,
+  type SensitiveTransformResult,
+} from "./_shared.js";
+
+const REVIEW_PROVIDER = "judge_me";
+
+export interface ImportedReviewInsertRecord {
+  id: string;
+  product_id: string;
+  order_id: string;
+  order_item_id: string | null;
+  customer_id: string;
+  rating: number;
+  title: string | null;
+  body: string;
+  status: ReviewStatus;
+  is_verified: boolean;
+  automated_moderation: null;
+  moderation_notes: null;
+  admin_response: string | null;
+  response_author_id: null;
+  responded_at: null;
+  submitted_at: string;
+  published_at: string | null;
+  created_at: string;
+  updated_at: string;
+  metadata: string;
+}
+
+export interface ImportedReviewTransformRecord {
+  sourceFingerprint: string;
+  review: ImportedReviewInsertRecord;
+}
+
+export interface VerifiedReviewProvenance {
+  verified: true;
+  productId: string;
+  orderId: string;
+  customerId: string;
+  orderItemId?: string;
+}
+
+export interface ReviewTransformOptions {
+  generatedAt: string;
+  productIds: ReadonlyMap<string, string>;
+  customerIdsByEmailFingerprint?: ReadonlyMap<string, string>;
+  verifiedPurchases?: ReadonlyMap<string, VerifiedReviewProvenance>;
+}
+
+export function judgeMeReviewFingerprint(review: JudgeMeReview): string {
+  const material = JSON.stringify([
+    review.product_id ?? "",
+    normalizeSlug(review.product_handle ?? ""),
+    review.review_date ?? "",
+    review.reviewer_email?.trim().toLowerCase() ?? "",
+    review.rating,
+    review.body,
+  ]);
+  const materialDigest = createHash("sha256").update(material, "utf8").digest("hex");
+  return providerFingerprint(REVIEW_PROVIDER, "review", materialDigest);
+}
+
+function resolvedProductId(review: JudgeMeReview, mappings: ReadonlyMap<string, string>): string | null {
+  const handle = normalizeSlug(review.product_handle ?? "");
+  const byHandle = handle
+    ? safeTargetId(mappings.get(providerFingerprint(SHOPIFY_PROVIDER, "product_handle", handle)))
+    : null;
+  const byId = review.product_id
+    ? safeTargetId(mappings.get(providerFingerprint(SHOPIFY_PROVIDER, "product", review.product_id)))
+    : null;
+  if (byHandle && byId && byHandle !== byId) return null;
+  return byHandle ?? byId;
+}
+
+function reviewStatus(value: string | undefined): ReviewStatus {
+  const status = value?.trim().toLowerCase();
+  if (status === "published" || status === "approved") return "published";
+  if (status === "hidden" || status === "rejected" || status === "spam") return "suppressed";
+  return "pending";
+}
+
+function validProof(
+  proof: VerifiedReviewProvenance | undefined,
+  productId: string,
+  customerId: string | null,
+): VerifiedReviewProvenance | null {
+  if (!proof || proof.verified !== true) return null;
+  const product = safeTargetId(proof.productId);
+  const order = safeTargetId(proof.orderId);
+  const customer = safeTargetId(proof.customerId);
+  const item = proof.orderItemId === undefined ? null : safeTargetId(proof.orderItemId);
+  if (!product || !order || !customer || product !== productId || (customerId && customer !== customerId)) return null;
+  if (proof.orderItemId !== undefined && !item) return null;
+  return { verified: true, productId: product, orderId: order, customerId: customer, ...(item ? { orderItemId: item } : {}) };
+}
+
+export function transformJudgeMeReviews(
+  reviews: readonly JudgeMeReview[],
+  options: ReviewTransformOptions,
+): SensitiveTransformResult<ImportedReviewTransformRecord> {
+  assertBatchSize(reviews.length);
+  const generatedAt = requiredMigrationTime(options.generatedAt);
+  const records: ImportedReviewTransformRecord[] = [];
+  const idMap = new Map<string, string>();
+  const skipped: Array<{ sourceFingerprint: string | null; reason: string }> = [];
+  const warnings: string[] = [];
+  const seen = new Set<string>();
+
+  for (const review of reviews) {
+    let failedFingerprint: string | null = null;
+    try {
+      const sourceFingerprint = judgeMeReviewFingerprint(review);
+      failedFingerprint = sourceFingerprint;
+      if (seen.has(sourceFingerprint)) throw new TypeError("Duplicate review source identity");
+      if (!Number.isSafeInteger(review.rating) || review.rating < 1 || review.rating > 5) {
+        throw new RangeError("Review rating must be an integer from 1 to 5");
+      }
+      const productId = resolvedProductId(review, options.productIds);
+      if (!productId) throw new TypeError("Review product mapping is missing or ambiguous");
+      const email = normalizedEmail(review.reviewer_email);
+      const customerId = email
+        ? safeTargetId(options.customerIdsByEmailFingerprint?.get(emailFingerprint(email)))
+        : null;
+      const proof = validProof(options.verifiedPurchases?.get(sourceFingerprint), productId, customerId);
+      if (options.verifiedPurchases?.has(sourceFingerprint) && !proof) {
+        warnings.push(`Review ${sourceFingerprint} has invalid verified-purchase provenance; imported unverified`);
+      }
+      if (review.picture_urls?.trim()) {
+        warnings.push(`Review ${sourceFingerprint} has external media that requires a separate verified media import; media omitted`);
+      }
+      const status = reviewStatus(review.status);
+      const submittedAt = isoTimestamp(review.review_date, generatedAt);
+      const id = deterministicProviderId(REVIEW_PROVIDER, "review", sourceFingerprint);
+      const reviewerName = boundedText(review.reviewer_name, 200);
+      const orderId = proof?.orderId
+        ?? deterministicProviderId(REVIEW_PROVIDER, "imported_order", sourceFingerprint);
+      const resolvedCustomerId = proof?.customerId ?? customerId
+        ?? deterministicProviderId(REVIEW_PROVIDER, "imported_customer", sourceFingerprint);
+
+      records.push({
+        sourceFingerprint,
+        review: {
+          id,
+          product_id: productId,
+          order_id: orderId,
+          order_item_id: proof?.orderItemId ?? null,
+          customer_id: resolvedCustomerId,
+          rating: review.rating,
+          title: boundedText(review.title, 200),
+          body: boundedText(review.body, 10_000, { required: true, multiline: true })!,
+          status,
+          is_verified: proof !== null,
+          automated_moderation: null,
+          moderation_notes: null,
+          admin_response: boundedText(review.reply, 5_000, { multiline: true }),
+          response_author_id: null,
+          responded_at: null,
+          submitted_at: submittedAt,
+          published_at: status === "published" ? submittedAt : null,
+          created_at: submittedAt,
+          updated_at: generatedAt,
+          metadata: JSON.stringify({
+            migration: {
+              provider: REVIEW_PROVIDER,
+              imported: true,
+              generated_at: generatedAt,
+              source_fingerprint: sourceFingerprint,
+            },
+            verified_purchase_provenance: proof ? "explicit_order_match" : "none",
+            ...(reviewerName ? { reviewer_name: reviewerName } : {}),
+          }),
+        },
+      });
+      seen.add(sourceFingerprint);
+      idMap.set(sourceFingerprint, id);
+    } catch (error) {
+      skipped.push({
+        sourceFingerprint: failedFingerprint,
+        reason: error instanceof Error ? error.message : "Review is invalid",
+      });
+    }
+  }
+
+  return { records, idMap, skipped, warnings };
+}

--- a/scripts/shopify-migration/transformers/sensitive/reviews.ts
+++ b/scripts/shopify-migration/transformers/sensitive/reviews.ts
@@ -13,8 +13,10 @@ import {
   boundedText,
   emailFingerprint,
   normalizedEmail,
+  safeClerkUserId,
   safeTargetId,
   type SensitiveTransformResult,
+  UNKNOWN_SOURCE_TIMESTAMP,
 } from "./_shared.js";
 
 const REVIEW_PROVIDER = "judge_me";
@@ -61,10 +63,19 @@ export interface VerifiedReviewProvenance {
   orderItemId?: string;
 }
 
+export interface ImportedReviewAttribution {
+  productId: string;
+  orderId: string;
+  customerId: string;
+  orderItemId?: string;
+}
+
 export interface ReviewTransformOptions {
   generatedAt: string;
   productIds: ReadonlyMap<string, string>;
   customerIdsByEmailFingerprint?: ReadonlyMap<string, string>;
+  /** Real imported IDs keyed by judgeMeReviewFingerprint; synthetic IDs are forbidden. */
+  reviewAttributions: ReadonlyMap<string, ImportedReviewAttribution>;
   verifiedPurchases?: ReadonlyMap<string, VerifiedReviewProvenance>;
 }
 
@@ -164,17 +175,39 @@ function reviewStatus(value: string | undefined): ReviewStatus {
 
 function validProof(
   proof: VerifiedReviewProvenance | undefined,
-  productId: string,
-  customerId: string | null,
+  attribution: ImportedReviewAttribution,
 ): VerifiedReviewProvenance | null {
   if (!proof || proof.verified !== true) return null;
   const product = safeTargetId(proof.productId);
   const order = safeTargetId(proof.orderId);
-  const customer = safeTargetId(proof.customerId);
+  const customer = safeClerkUserId(proof.customerId);
   const item = proof.orderItemId === undefined ? null : safeTargetId(proof.orderItemId);
-  if (!product || !order || !customer || product !== productId || (customerId && customer !== customerId)) return null;
+  if (
+    !product || !order || !customer ||
+    product !== attribution.productId || order !== attribution.orderId || customer !== attribution.customerId
+  ) return null;
+  if ((item ?? null) !== (attribution.orderItemId ?? null)) return null;
   if (proof.orderItemId !== undefined && !item) return null;
   return { verified: true, productId: product, orderId: order, customerId: customer, ...(item ? { orderItemId: item } : {}) };
+}
+
+function validAttribution(
+  attribution: ImportedReviewAttribution | undefined,
+  productId: string,
+  emailCustomerId: string | null,
+): ImportedReviewAttribution | null {
+  if (!attribution) return null;
+  const product = safeTargetId(attribution.productId);
+  const order = safeTargetId(attribution.orderId);
+  const customer = safeClerkUserId(attribution.customerId);
+  const item = attribution.orderItemId === undefined ? null : safeTargetId(attribution.orderItemId);
+  if (
+    !product || !order || !customer || product !== productId ||
+    order.startsWith(`${REVIEW_PROVIDER}_imported_order_`)
+  ) return null;
+  if (emailCustomerId && emailCustomerId !== customer) return null;
+  if (attribution.orderItemId !== undefined && !item) return null;
+  return { productId: product, orderId: order, customerId: customer, ...(item ? { orderItemId: item } : {}) };
 }
 
 export function transformJudgeMeReviews(
@@ -182,7 +215,7 @@ export function transformJudgeMeReviews(
   options: ReviewTransformOptions,
 ): SensitiveTransformResult<ImportedReviewTransformRecord> {
   assertBatchSize(reviews.length);
-  const generatedAt = requiredMigrationTime(options.generatedAt);
+  requiredMigrationTime(options.generatedAt);
   const records: ImportedReviewTransformRecord[] = [];
   const idMap = new Map<string, string>();
   const skipped: Array<{ sourceFingerprint: string | null; reason: string }> = [];
@@ -201,10 +234,20 @@ export function transformJudgeMeReviews(
       const productId = resolvedProductId(review, options.productIds);
       if (!productId) throw new TypeError("Review product mapping is missing or ambiguous");
       const email = normalizedEmail(review.reviewer_email);
-      const customerId = email
-        ? safeTargetId(options.customerIdsByEmailFingerprint?.get(emailFingerprint(email)))
-        : null;
-      const proof = validProof(options.verifiedPurchases?.get(sourceFingerprint), productId, customerId);
+      const mappedEmailCustomer = email
+        ? options.customerIdsByEmailFingerprint?.get(emailFingerprint(email))
+        : undefined;
+      const emailCustomerId = safeClerkUserId(mappedEmailCustomer);
+      if (mappedEmailCustomer !== undefined && !emailCustomerId) {
+        throw new TypeError("Review email mapping must resolve to a Clerk user ID");
+      }
+      const attribution = validAttribution(
+        options.reviewAttributions.get(sourceFingerprint),
+        productId,
+        emailCustomerId,
+      );
+      if (!attribution) throw new TypeError("Review requires real matching order and Clerk customer attribution");
+      const proof = validProof(options.verifiedPurchases?.get(sourceFingerprint), attribution);
       if (options.verifiedPurchases?.has(sourceFingerprint) && !proof) {
         warnings.push(`Review ${sourceFingerprint} has invalid verified-purchase provenance; imported unverified`);
       }
@@ -212,22 +255,18 @@ export function transformJudgeMeReviews(
         warnings.push(`Review ${sourceFingerprint} has external media that requires a separate verified media import; media omitted`);
       }
       const status = reviewStatus(review.status);
-      const submittedAt = isoTimestamp(review.review_date, generatedAt);
+      const submittedAt = isoTimestamp(review.review_date, UNKNOWN_SOURCE_TIMESTAMP);
       const id = deterministicProviderId(REVIEW_PROVIDER, "review", sourceFingerprint);
       const reviewerName = boundedText(review.reviewer_name, 200);
-      const orderId = proof?.orderId
-        ?? deterministicProviderId(REVIEW_PROVIDER, "imported_order", sourceFingerprint);
-      const resolvedCustomerId = proof?.customerId ?? customerId
-        ?? deterministicProviderId(REVIEW_PROVIDER, "imported_customer", sourceFingerprint);
 
       records.push({
         sourceFingerprint,
         review: {
           id,
           product_id: productId,
-          order_id: orderId,
-          order_item_id: proof?.orderItemId ?? null,
-          customer_id: resolvedCustomerId,
+          order_id: attribution.orderId,
+          order_item_id: attribution.orderItemId ?? null,
+          customer_id: attribution.customerId,
           rating: review.rating,
           title: boundedText(review.title, 200),
           body: boundedText(review.body, 10_000, { required: true, multiline: true })!,
@@ -241,12 +280,11 @@ export function transformJudgeMeReviews(
           submitted_at: submittedAt,
           published_at: status === "published" ? submittedAt : null,
           created_at: submittedAt,
-          updated_at: generatedAt,
+          updated_at: submittedAt,
           metadata: JSON.stringify({
             migration: {
               provider: REVIEW_PROVIDER,
               imported: true,
-              generated_at: generatedAt,
               source_fingerprint: sourceFingerprint,
             },
             verified_purchase_provenance: proof ? "explicit_order_match" : "none",

--- a/tests/integration/d1-harness.test.ts
+++ b/tests/integration/d1-harness.test.ts
@@ -32,7 +32,56 @@ describe('real D1 Workers harness', () => {
       '0017_add_product_recommendations.sql',
       '0018_add_email_preferences.sql',
       '0019_add_content_publishing.sql',
+      '0020_add_redirect_map.sql',
     ]);
+  });
+
+  it('adds an empty redirect map without changing a populated baseline', async () => {
+    const customerId = 'O05-POPULATED-CUSTOMER';
+    await env.DB.prepare(`
+      INSERT OR IGNORE INTO customers (id, type, person, created_at, updated_at)
+      VALUES (?, 'person', ?, ?, ?)
+    `).bind(
+      customerId,
+      JSON.stringify({ email: 'existing-o05@example.com' }),
+      '2026-08-01T00:00:00.000Z',
+      '2026-08-01T00:00:00.000Z',
+    ).run();
+
+    const customer = await env.DB.prepare(
+      'SELECT id FROM customers WHERE id = ?',
+    ).bind(customerId).first<{ id: string }>();
+    const redirects = await env.DB.prepare(
+      'SELECT COUNT(*) AS count FROM redirect_map',
+    ).first<{ count: number }>();
+
+    expect(customer?.id).toBe(customerId);
+    expect(redirects?.count).toBe(0);
+  });
+
+  it('enforces redirect safety constraints in D1', async () => {
+    await env.DB.prepare(`
+      INSERT INTO redirect_map (source_path, target_path, status_code, entity_type)
+      VALUES ('/products/old-handle', '/product/new-handle', 308, 'product')
+    `).run();
+
+    const row = await env.DB.prepare(
+      "SELECT target_path, status_code FROM redirect_map WHERE source_path = '/products/old-handle'",
+    ).first<{ target_path: string; status_code: number }>();
+    expect(row).toEqual({ target_path: '/product/new-handle', status_code: 308 });
+
+    await expect(env.DB.prepare(
+      "INSERT INTO redirect_map (source_path, target_path) VALUES ('/products/loop', '/products/loop')",
+    ).run()).rejects.toThrow();
+    await expect(env.DB.prepare(
+      "INSERT INTO redirect_map (source_path, target_path) VALUES ('/products/external', '//example.test')",
+    ).run()).rejects.toThrow();
+    await expect(env.DB.prepare(
+      "INSERT INTO redirect_map (source_path, target_path, status_code) VALUES ('/products/temp', '/product/temp', 302)",
+    ).run()).rejects.toThrow();
+    await expect(env.DB.prepare(
+      "INSERT INTO redirect_map (source_path, target_path) VALUES ('/products/chain', '/pages/other')",
+    ).run()).rejects.toThrow();
   });
 
   it('adds empty email preference state without changing a populated baseline', async () => {

--- a/tests/integration/redirect-map-migration.test.ts
+++ b/tests/integration/redirect-map-migration.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { env } from "cloudflare:workers";
+import { applyD1Migrations } from "cloudflare:test";
+
+describe("redirect map migration ordering", () => {
+  it("preserves a populated 0019 baseline byte-for-byte before adding empty state", async () => {
+    const throughContentPublishing = env.TEST_MIGRATIONS.slice(0, -1);
+    const redirectMigration = env.TEST_MIGRATIONS.slice(-1);
+    expect(redirectMigration.map(({ name }) => name)).toEqual(["0020_add_redirect_map.sql"]);
+
+    await applyD1Migrations(env.DB, throughContentPublishing);
+    await env.DB.prepare(`
+      INSERT INTO customers (id, type, person, created_at, updated_at)
+      VALUES ('O05-BASELINE-CUSTOMER', 'person', '{"email":"baseline@example.com"}',
+        '2026-08-01T00:00:00.000Z', '2026-08-01T00:00:00.000Z')
+    `).run();
+    await env.DB.prepare(`
+      INSERT INTO blog_categories (name, slug, description)
+      VALUES ('Baseline', 'baseline', 'Existing category')
+    `).run();
+    await env.DB.prepare(`
+      INSERT INTO blog_posts (title, slug, author, status, html, category_id)
+      VALUES ('Existing post', 'existing-post', 'Editor', 'published', '<p>Existing</p>', 1)
+    `).run();
+
+    const snapshot = async () => ({
+      customers: (await env.DB.prepare(
+        "SELECT * FROM customers ORDER BY id",
+      ).all()).results,
+      pages: (await env.DB.prepare(
+        "SELECT * FROM pages ORDER BY id",
+      ).all()).results,
+      blogCategories: (await env.DB.prepare(
+        "SELECT * FROM blog_categories ORDER BY id",
+      ).all()).results,
+      blogPosts: (await env.DB.prepare(
+        "SELECT * FROM blog_posts ORDER BY id",
+      ).all()).results,
+    });
+    const before = JSON.stringify(await snapshot());
+
+    await applyD1Migrations(env.DB, redirectMigration);
+
+    expect(JSON.stringify(await snapshot())).toBe(before);
+    const redirects = await env.DB.prepare(
+      "SELECT COUNT(*) AS count FROM redirect_map",
+    ).first<{ count: number }>();
+    expect(redirects?.count).toBe(0);
+  });
+});

--- a/tests/unit/app/media-route.test.ts
+++ b/tests/unit/app/media-route.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getCloudflareContext, bucket } = vi.hoisted(() => ({
+  getCloudflareContext: vi.fn(),
+  bucket: { get: vi.fn(), head: vi.fn() },
+}));
+
+vi.mock("@opennextjs/cloudflare", () => ({ getCloudflareContext }));
+
+import { GET, HEAD, resolvePublicMediaKey } from "@/app/media/[...key]/route";
+
+function context(...key: string[]) {
+  return { params: Promise.resolve({ key }) };
+}
+
+function object(overrides: Record<string, unknown> = {}) {
+  return {
+    key: "products/example.png",
+    size: 4,
+    etag: "abc123",
+    httpEtag: '"abc123"',
+    uploaded: new Date("2026-08-01T00:00:00.000Z"),
+    httpMetadata: { contentType: "image/png" },
+    customMetadata: {},
+    range: undefined,
+    checksums: {},
+    storageClass: "Standard",
+    ssecKeyMd5: undefined,
+    body: new ReadableStream({
+      start(controller) {
+        controller.enqueue(new Uint8Array([1, 2, 3, 4]));
+        controller.close();
+      },
+    }),
+    bodyUsed: false,
+    arrayBuffer: vi.fn(),
+    bytes: vi.fn(),
+    text: vi.fn(),
+    json: vi.fn(),
+    blob: vi.fn(),
+    writeHttpMetadata: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("same-origin public media route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getCloudflareContext.mockResolvedValue({ env: { MEDIA: bucket } });
+    bucket.get.mockResolvedValue(object());
+    bucket.head.mockResolvedValue(object({ body: undefined }));
+  });
+
+  it.each(["products", "categories", "blog", "pages"])(
+    "allows the %s public prefix",
+    (prefix) => expect(resolvePublicMediaKey([prefix, "image.png"])).toBe(`${prefix}/image.png`),
+  );
+
+  it.each([
+    ["knowledge_md", "secret.md"],
+    ["products_md", "secret.md"],
+    ["products", "..", "secret.png"],
+    ["products", "%252e%252e", "secret.png"],
+    ["products", "nested\\secret.png"],
+    ["products", "line\nbreak.png"],
+  ])("rejects private or malformed keys: %s", (...segments) => {
+    expect(resolvePublicMediaKey(segments)).toBeNull();
+  });
+
+  it("streams verified image metadata with immutable defensive headers", async () => {
+    const response = await GET(new Request("https://shop.example/media/products/example.png"), context("products", "example.png"));
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("image/png");
+    expect(response.headers.get("content-length")).toBe("4");
+    expect(response.headers.get("etag")).toBe('"abc123"');
+    expect(response.headers.get("cache-control")).toBe("public, max-age=31536000, immutable");
+    expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+    expect(new Uint8Array(await response.arrayBuffer())).toEqual(new Uint8Array([1, 2, 3, 4]));
+  });
+
+  it("serves HEAD without reading the object body", async () => {
+    const response = await HEAD(new Request("https://shop.example/media/products/example.png", { method: "HEAD" }), context("products", "example.png"));
+    expect(response.status).toBe(200);
+    expect(response.body).toBeNull();
+    expect(bucket.head).toHaveBeenCalledWith("products/example.png");
+    expect(bucket.get).not.toHaveBeenCalled();
+
+    bucket.head.mockResolvedValueOnce(null);
+    const missing = await HEAD(new Request("https://shop.example/media/products/missing.png", { method: "HEAD" }), context("products", "missing.png"));
+    expect(missing.status).toBe(404);
+    expect(missing.body).toBeNull();
+  });
+
+  it("returns a bodyless 304 for matching strong, weak, or list ETags", async () => {
+    for (const value of ['"abc123"', 'W/"abc123"', '"other", W/"abc123"']) {
+      const response = await GET(new Request("https://shop.example/media/products/example.png", {
+        headers: { "If-None-Match": value },
+      }), context("products", "example.png"));
+      expect(response.status).toBe(304);
+      expect(response.body).toBeNull();
+    }
+  });
+
+  it("hides missing objects, invalid metadata, and private keys", async () => {
+    bucket.get.mockResolvedValueOnce(null);
+    expect((await GET(new Request("https://shop.example/media/products/missing.png"), context("products", "missing.png"))).status).toBe(404);
+
+    bucket.get.mockResolvedValueOnce(object({ httpMetadata: { contentType: "text/html" } }));
+    expect((await GET(new Request("https://shop.example/media/products/example.png"), context("products", "example.png"))).status).toBe(404);
+
+    expect((await GET(new Request("https://shop.example/media/knowledge_md/secret.md"), context("knowledge_md", "secret.md"))).status).toBe(404);
+  });
+
+  it("returns a generic unavailable response for a missing binding or R2 error", async () => {
+    getCloudflareContext.mockResolvedValueOnce({ env: {} });
+    let response = await GET(new Request("https://shop.example/media/products/example.png"), context("products", "example.png"));
+    expect(response.status).toBe(503);
+    expect(await response.text()).toBe("Service unavailable");
+
+    bucket.get.mockRejectedValueOnce(new Error("sensitive bucket detail"));
+    response = await GET(new Request("https://shop.example/media/products/example.png"), context("products", "example.png"));
+    expect(response.status).toBe(503);
+    expect(await response.text()).not.toContain("sensitive");
+  });
+});

--- a/tests/unit/app/media-route.test.ts
+++ b/tests/unit/app/media-route.test.ts
@@ -67,13 +67,13 @@ describe("same-origin public media route", () => {
     expect(resolvePublicMediaKey(segments)).toBeNull();
   });
 
-  it("streams verified image metadata with immutable defensive headers", async () => {
+  it("streams verified image metadata with revalidating defensive headers", async () => {
     const response = await GET(new Request("https://shop.example/media/products/example.png"), context("products", "example.png"));
     expect(response.status).toBe(200);
     expect(response.headers.get("content-type")).toBe("image/png");
     expect(response.headers.get("content-length")).toBe("4");
     expect(response.headers.get("etag")).toBe('"abc123"');
-    expect(response.headers.get("cache-control")).toBe("public, max-age=31536000, immutable");
+    expect(response.headers.get("cache-control")).toBe("public, max-age=0, must-revalidate");
     expect(response.headers.get("content-security-policy")).toBe("default-src 'none'; sandbox");
     expect(response.headers.get("x-content-type-options")).toBe("nosniff");
     expect(new Uint8Array(await response.arrayBuffer())).toEqual(new Uint8Array([1, 2, 3, 4]));

--- a/tests/unit/app/media-route.test.ts
+++ b/tests/unit/app/media-route.test.ts
@@ -74,6 +74,7 @@ describe("same-origin public media route", () => {
     expect(response.headers.get("content-length")).toBe("4");
     expect(response.headers.get("etag")).toBe('"abc123"');
     expect(response.headers.get("cache-control")).toBe("public, max-age=31536000, immutable");
+    expect(response.headers.get("content-security-policy")).toBe("default-src 'none'; sandbox");
     expect(response.headers.get("x-content-type-options")).toBe("nosniff");
     expect(new Uint8Array(await response.arrayBuffer())).toEqual(new Uint8Array([1, 2, 3, 4]));
   });

--- a/tests/unit/app/media-route.test.ts
+++ b/tests/unit/app/media-route.test.ts
@@ -7,7 +7,10 @@ const { getCloudflareContext, bucket } = vi.hoisted(() => ({
 
 vi.mock("@opennextjs/cloudflare", () => ({ getCloudflareContext }));
 
-import { GET, HEAD, resolvePublicMediaKey } from "@/app/media/[...key]/route";
+import * as mediaRoute from "@/app/media/[...key]/route";
+import { resolvePublicMediaKey } from "@/lib/media/public-key";
+
+const { GET, HEAD } = mediaRoute;
 
 function context(...key: string[]) {
   return { params: Promise.resolve({ key }) };
@@ -49,6 +52,10 @@ describe("same-origin public media route", () => {
     getCloudflareContext.mockResolvedValue({ env: { MEDIA: bucket } });
     bucket.get.mockResolvedValue(object());
     bucket.head.mockResolvedValue(object({ body: undefined }));
+  });
+
+  it("exports only Next-compatible route handlers", () => {
+    expect(Object.keys(mediaRoute).sort()).toEqual(["GET", "HEAD"]);
   });
 
   it.each(["products", "categories", "blog", "pages"])(

--- a/tests/unit/app/redirect-middleware-source.test.ts
+++ b/tests/unit/app/redirect-middleware-source.test.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("legacy redirect middleware integration", () => {
+  it("uses the exact fail-open resolver and the typed redirect schema", () => {
+    const source = readFileSync("middleware.ts", "utf8");
+    expect(source).toContain("resolveLegacyRedirect(req.url");
+    expect(source).toContain("eq(redirectMap.sourcePath, sourcePath)");
+    expect(source).toContain("NextResponse.redirect(redirect.url, redirect.statusCode)");
+    expect(source).not.toMatch(/pathname\.startsWith\('\/products\/\'[\s\S]*?destination/);
+  });
+});

--- a/tests/unit/app/redirect-middleware-source.test.ts
+++ b/tests/unit/app/redirect-middleware-source.test.ts
@@ -5,6 +5,8 @@ describe("legacy redirect middleware integration", () => {
   it("uses the exact fail-open resolver and the typed redirect schema", () => {
     const source = readFileSync("middleware.ts", "utf8");
     expect(source).toContain("resolveLegacyRedirect(req.url");
+    expect(source).toContain("isLegacyRedirectLookupPath(pathname)");
+    expect(source).toContain("!isLegacyRedirectPath &&");
     expect(source).toContain("eq(redirectMap.sourcePath, sourcePath)");
     expect(source).toContain("NextResponse.redirect(redirect.url, redirect.statusCode)");
     expect(source).toContain('"/(products|collections|pages|blogs|policies)/(.*)"');

--- a/tests/unit/app/redirect-middleware-source.test.ts
+++ b/tests/unit/app/redirect-middleware-source.test.ts
@@ -7,6 +7,7 @@ describe("legacy redirect middleware integration", () => {
     expect(source).toContain("resolveLegacyRedirect(req.url");
     expect(source).toContain("eq(redirectMap.sourcePath, sourcePath)");
     expect(source).toContain("NextResponse.redirect(redirect.url, redirect.statusCode)");
+    expect(source).toContain('"/(products|collections|pages|blogs|policies)/(.*)"');
     expect(source).not.toMatch(/pathname\.startsWith\('\/products\/\'[\s\S]*?destination/);
   });
 });

--- a/tests/unit/lib/redirects/policy.test.ts
+++ b/tests/unit/lib/redirects/policy.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import {
+  isLegacyRedirectLookupPath,
+  validateRedirectCandidate,
+} from "@/lib/redirects/policy";
+
+describe("legacy redirect policy", () => {
+  it.each([
+    "/products/old-handle",
+    "/collections/old-handle",
+    "/pages/old-handle",
+    "/blogs/news/old-handle",
+    "/policies/refund-policy",
+  ])("permits an exact canonical legacy path: %s", (pathname) => {
+    expect(isLegacyRedirectLookupPath(pathname)).toBe(true);
+  });
+
+  it.each([
+    "/product/current-handle",
+    "/products/",
+    "/products/../admin",
+    "/products/%2e%2e/admin",
+    "/products/old%2fadmin",
+    "/products/old\\admin",
+    "/products/old?next=/admin",
+  ])("rejects a noncanonical lookup path: %s", (pathname) => {
+    expect(isLegacyRedirectLookupPath(pathname)).toBe(false);
+  });
+
+  it("allows only internal permanent non-legacy targets", () => {
+    expect(validateRedirectCandidate("/products/old", {
+      targetPath: "/product/new",
+      statusCode: 308,
+    })).toEqual({ targetPath: "/product/new", statusCode: 308 });
+
+    for (const targetPath of [
+      "https://attacker.example/path",
+      "//attacker.example/path",
+      "/products/other",
+      "/product/../admin",
+      "/product/%2e%2e/admin",
+      "/products/old",
+    ]) {
+      expect(validateRedirectCandidate("/products/old", { targetPath, statusCode: 301 })).toBeNull();
+    }
+    expect(validateRedirectCandidate("/products/old", {
+      targetPath: "/product/new",
+      statusCode: 302,
+    })).toBeNull();
+  });
+});

--- a/tests/unit/lib/redirects/resolver.test.ts
+++ b/tests/unit/lib/redirects/resolver.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveLegacyRedirect } from "@/lib/redirects/resolver";
+
+describe("legacy redirect resolver", () => {
+  it("looks up the exact pathname and preserves the request query", async () => {
+    const lookup = vi.fn().mockResolvedValue({ targetPath: "/product/new", statusCode: 301 });
+    const result = await resolveLegacyRedirect(
+      "https://shop.example/products/old?utm_source=archive",
+      lookup,
+    );
+
+    expect(lookup).toHaveBeenCalledOnce();
+    expect(lookup).toHaveBeenCalledWith("/products/old");
+    expect(result?.url.href).toBe("https://shop.example/product/new?utm_source=archive");
+    expect(result?.statusCode).toBe(301);
+  });
+
+  it("does not guess when the exact map has no row", async () => {
+    const lookup = vi.fn().mockResolvedValue(null);
+    await expect(resolveLegacyRedirect("https://shop.example/products/unchanged", lookup))
+      .resolves.toBeNull();
+  });
+
+  it("fails open when D1 is unavailable", async () => {
+    const lookup = vi.fn().mockRejectedValue(new Error("binding unavailable"));
+    await expect(resolveLegacyRedirect("https://shop.example/pages/about", lookup))
+      .resolves.toBeNull();
+  });
+
+  it("skips D1 entirely for unrelated and malformed paths", async () => {
+    const lookup = vi.fn();
+    await expect(resolveLegacyRedirect("https://shop.example/product/current", lookup))
+      .resolves.toBeNull();
+    await expect(resolveLegacyRedirect("https://shop.example/products/%252e%252e/admin", lookup))
+      .resolves.toBeNull();
+    expect(lookup).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/migrations/shopify-redirect-map.test.ts
+++ b/tests/unit/migrations/shopify-redirect-map.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { inspectMigration } from "@/scripts/lib/migration-safety.mjs";
+
+const migrationPath = "migrations/0020_add_redirect_map.sql";
+const migration = readFileSync(migrationPath, "utf8");
+
+describe("0020 redirect map migration", () => {
+  it("is an additive, empty-state-safe migration", () => {
+    expect(inspectMigration(migrationPath, migration).status).toBe("expand");
+    expect(migration).not.toMatch(/\b(?:ALTER|DROP|DELETE|UPDATE)\b/i);
+    expect(migration).not.toMatch(/INSERT\s+INTO\s+redirect_map/i);
+  });
+
+  it("constrains internal paths, direct loops, and permanent status codes", () => {
+    expect(migration).toContain("source_path TEXT NOT NULL UNIQUE");
+    expect(migration).toContain("substr(source_path, 1, 2) != '//'");
+    expect(migration).toContain("substr(target_path, 1, 2) != '//'");
+    expect(migration).toContain("source_path != target_path");
+    expect(migration).toContain("target_path NOT LIKE '/products/%'");
+    expect(migration).toContain("status_code IN (301, 308)");
+    expect(migration).toContain("length(trim(entity_type)) BETWEEN 1 AND 64");
+    expect(migration).toContain("created_at >= 0");
+    expect(migration).toContain("redirect_map_source_path_idx");
+  });
+});

--- a/tests/unit/scripts/shopify-migration/adapters/clerk.test.ts
+++ b/tests/unit/scripts/shopify-migration/adapters/clerk.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import {
-  provisionClerkCustomers,
+  ClerkRetryableRequestError,
+  provisionClerkCustomers as runClerkProvisioning,
   type ClerkMigrationClient,
   type ClerkMigrationUser,
+  type ClerkProvisioningOptions,
 } from "@/scripts/shopify-migration/adapters/clerk";
 import type { ExecutionPlan } from "@/scripts/shopify-migration/lib/config";
 import { transformCustomers } from "@/scripts/shopify-migration/transformers/sensitive/customers";
@@ -66,6 +68,23 @@ function mockClient(options: {
   };
 }
 
+const directOperation: NonNullable<ClerkProvisioningOptions["runOperation"]> = async (operation) => (
+  await operation(new AbortController().signal)
+);
+
+function provisionClerkCustomers(
+  plans: Parameters<typeof runClerkProvisioning>[0],
+  planExecution: Parameters<typeof runClerkProvisioning>[1],
+  client: Parameters<typeof runClerkProvisioning>[2],
+  options: ClerkProvisioningOptions = {},
+) {
+  return runClerkProvisioning(plans, planExecution, client, {
+    runOperation: directOperation,
+    sleep: async () => {},
+    ...options,
+  });
+}
+
 describe("Clerk migration adapter", () => {
   it("rejects dry runs before touching the injected client", async () => {
     const mocked = mockClient();
@@ -101,7 +120,7 @@ describe("Clerk migration adapter", () => {
     expect(mocked.getUserList).toHaveBeenCalledWith({
       externalId: [customer.sourceFingerprint],
       limit: 2,
-    });
+    }, { signal: expect.any(AbortSignal) });
     expect(mocked.createUser).not.toHaveBeenCalled();
   });
 
@@ -118,7 +137,7 @@ describe("Clerk migration adapter", () => {
     expect(mocked.getUserList).toHaveBeenNthCalledWith(2, {
       emailAddress: ["customer@example.com"],
       limit: 2,
-    });
+    }, { signal: expect.any(AbortSignal) });
     expect(mocked.createUser).not.toHaveBeenCalled();
   });
 
@@ -135,7 +154,7 @@ describe("Clerk migration adapter", () => {
       lastName: "Lovelace",
       externalId: customer.sourceFingerprint,
       skipLegalChecks: true,
-    });
+    }, { signal: expect.any(AbortSignal) });
     expect(mocked.createUser.mock.calls[0][0]).not.toHaveProperty("password");
     expect(mocked.createUser.mock.calls[0][0]).not.toHaveProperty("notify");
     expect(mocked.createUser.mock.calls[0][0]).not.toHaveProperty("sendInvite");
@@ -151,6 +170,8 @@ describe("Clerk migration adapter", () => {
       sourceFingerprint: customer.sourceFingerprint,
       reason: "source-email-unverified",
     });
+    expect(mocked.getUserList).toHaveBeenCalledOnce();
+    expect(mocked.getUserList.mock.calls[0][0]).not.toHaveProperty("emailAddress");
     expect(mocked.createUser).not.toHaveBeenCalled();
   });
 
@@ -164,6 +185,8 @@ describe("Clerk migration adapter", () => {
     );
 
     expect(result.reconciliation[0].reason).toBe("creation-not-authorized");
+    expect(mocked.getUserList).toHaveBeenCalledOnce();
+    expect(mocked.getUserList.mock.calls[0][0]).not.toHaveProperty("emailAddress");
     expect(mocked.createUser).not.toHaveBeenCalled();
   });
 
@@ -228,5 +251,75 @@ describe("Clerk migration adapter", () => {
     expect(result.reconciliation[0].reason).toBe("external-identity-invalid");
     expect(mocked.getUserList).toHaveBeenCalledOnce();
     expect(mocked.createUser).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [execution({ target: "preview", confirmedPreview: false }), "preview confirmation"],
+    [execution({ target: "production", confirmedProduction: false }), "production confirmation"],
+    [execution({ createClerkUsers: false, confirmedClerkAutoVerification: true }), "requires identity creation"],
+    [execution({ target: "local", confirmedPreview: true }), "does not match"],
+  ] as const)("rejects inconsistent execution confirmations before client access", async (planExecution, message) => {
+    const mocked = mockClient();
+    await expect(provisionClerkCustomers([plan()], planExecution, mocked.client)).rejects.toThrow(message);
+    expect(mocked.getUserList).not.toHaveBeenCalled();
+    expect(mocked.createUser).not.toHaveBeenCalled();
+  });
+
+  it("uses bounded retries and honors a bounded Retry-After duration", async () => {
+    const customer = plan();
+    const mocked = mockClient({
+      external: [{ ...VERIFIED_USER, externalId: customer.sourceFingerprint }],
+    });
+    mocked.getUserList.mockRejectedValueOnce(new ClerkRetryableRequestError(50_000));
+    const sleep = vi.fn(async () => {});
+    const operationTimeouts: number[] = [];
+    const runOperation: NonNullable<ClerkProvisioningOptions["runOperation"]> = async (operation, timeoutMs) => {
+      operationTimeouts.push(timeoutMs);
+      return await directOperation(operation, timeoutMs);
+    };
+
+    const result = await provisionClerkCustomers([customer], execution(), mocked.client, {
+      runOperation,
+      sleep,
+    });
+
+    expect(result.existing).toBe(1);
+    expect(mocked.getUserList).toHaveBeenCalledTimes(2);
+    expect(operationTimeouts).toEqual([10_000, 10_000]);
+    expect(sleep).toHaveBeenCalledOnce();
+    expect(sleep).toHaveBeenCalledWith(5_000);
+  });
+
+  it("caps retry attempts and exposes only a stable failure reason", async () => {
+    const customer = plan();
+    const mocked = mockClient();
+    mocked.getUserList.mockRejectedValue(new ClerkRetryableRequestError(1));
+    const sleep = vi.fn(async () => {});
+
+    const result = await provisionClerkCustomers([customer], execution(), mocked.client, { sleep });
+
+    expect(mocked.getUserList).toHaveBeenCalledTimes(3);
+    expect(sleep).toHaveBeenCalledTimes(2);
+    expect(result.reconciliation).toEqual([{
+      sourceFingerprint: customer.sourceFingerprint,
+      reason: "provider-request-failed",
+    }]);
+  });
+
+  it("bounds operation configuration and customer batch size before client access", async () => {
+    const customer = plan();
+    const mocked = mockClient();
+    await expect(provisionClerkCustomers(
+      [customer], execution(), mocked.client, { operationTimeoutMs: 30_001 },
+    )).rejects.toThrow("between 1 and 30000");
+    await expect(provisionClerkCustomers(
+      Array.from({ length: 1_001 }, (_, index) => ({
+        ...customer,
+        sourceFingerprint: index.toString(16).padStart(64, "0"),
+      })),
+      execution(),
+      mocked.client,
+    )).rejects.toThrow("batch is too large");
+    expect(mocked.getUserList).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/scripts/shopify-migration/adapters/clerk.test.ts
+++ b/tests/unit/scripts/shopify-migration/adapters/clerk.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  provisionClerkCustomers,
+  type ClerkMigrationClient,
+  type ClerkMigrationUser,
+} from "@/scripts/shopify-migration/adapters/clerk";
+import type { ExecutionPlan } from "@/scripts/shopify-migration/lib/config";
+import { transformCustomers } from "@/scripts/shopify-migration/transformers/sensitive/customers";
+
+const VERIFIED_USER: ClerkMigrationUser = {
+  id: "user_abcdefgh12345678",
+  externalId: null,
+};
+
+function execution(overrides: Partial<ExecutionPlan> = {}): ExecutionPlan {
+  return {
+    dryRun: false,
+    apply: true,
+    target: "local",
+    includeSensitive: true,
+    overwrite: false,
+    confirmedSensitiveData: true,
+    confirmedPreview: false,
+    confirmedProduction: false,
+    confirmedOverwrite: false,
+    createClerkUsers: true,
+    confirmedClerkAutoVerification: true,
+    ...overrides,
+  };
+}
+
+function plan(verifiedEmail = true) {
+  return transformCustomers([{
+    id: 42,
+    email: "Customer@Example.com",
+    first_name: "Ada",
+    last_name: "Lovelace",
+    verified_email: verifiedEmail,
+    accepts_marketing: false,
+    created_at: "2020-01-02T03:04:05Z",
+    updated_at: "2020-01-03T03:04:05Z",
+  }], { generatedAt: "2026-01-01T00:00:00Z" }).records[0];
+}
+
+function mockClient(options: {
+  external?: readonly ClerkMigrationUser[];
+  email?: readonly ClerkMigrationUser[];
+  created?: ClerkMigrationUser;
+} = {}) {
+  const getUserList = vi.fn(async (params: {
+    externalId?: readonly string[];
+    emailAddress?: readonly string[];
+    limit: number;
+  }) => ({ data: params.externalId ? (options.external ?? []) : (options.email ?? []) }));
+  const createUser = vi.fn(async (params: {
+    emailAddress: readonly [string];
+    firstName?: string;
+    lastName?: string;
+    externalId: string;
+    skipLegalChecks: true;
+  }) => options.created ?? { ...VERIFIED_USER, externalId: params.externalId });
+  return {
+    client: { users: { getUserList, createUser } } satisfies ClerkMigrationClient,
+    getUserList,
+    createUser,
+  };
+}
+
+describe("Clerk migration adapter", () => {
+  it("rejects dry runs before touching the injected client", async () => {
+    const mocked = mockClient();
+    await expect(provisionClerkCustomers(
+      [plan()],
+      execution({ dryRun: true, apply: false, createClerkUsers: false, confirmedClerkAutoVerification: false }),
+      mocked.client,
+    )).rejects.toThrow("disabled during dry runs");
+    expect(mocked.getUserList).not.toHaveBeenCalled();
+    expect(mocked.createUser).not.toHaveBeenCalled();
+  });
+
+  it("rejects unconfirmed sensitive access before touching the client", async () => {
+    const mocked = mockClient();
+    await expect(provisionClerkCustomers(
+      [plan()],
+      execution({ includeSensitive: false, confirmedSensitiveData: false }),
+      mocked.client,
+    )).rejects.toThrow("confirmed sensitive-data access");
+    expect(mocked.getUserList).not.toHaveBeenCalled();
+  });
+
+  it("maps only an exact external fingerprint to a valid Clerk user ID", async () => {
+    const customer = plan();
+    const mocked = mockClient({
+      external: [{ ...VERIFIED_USER, externalId: customer.sourceFingerprint }],
+    });
+    const result = await provisionClerkCustomers([customer], execution(), mocked.client);
+
+    expect(result.idMap).toEqual(new Map([[customer.sourceFingerprint, VERIFIED_USER.id]]));
+    expect(result).toMatchObject({ created: 0, existing: 1, reconciliation: [] });
+    expect(mocked.getUserList).toHaveBeenCalledOnce();
+    expect(mocked.getUserList).toHaveBeenCalledWith({
+      externalId: [customer.sourceFingerprint],
+      limit: 2,
+    });
+    expect(mocked.createUser).not.toHaveBeenCalled();
+  });
+
+  it("never links by email and sends an existing email owner to reconciliation", async () => {
+    const customer = plan();
+    const mocked = mockClient({ email: [VERIFIED_USER] });
+    const result = await provisionClerkCustomers([customer], execution(), mocked.client);
+
+    expect(result.idMap.size).toBe(0);
+    expect(result.reconciliation).toEqual([{
+      sourceFingerprint: customer.sourceFingerprint,
+      reason: "email-conflict",
+    }]);
+    expect(mocked.getUserList).toHaveBeenNthCalledWith(2, {
+      emailAddress: ["customer@example.com"],
+      limit: 2,
+    });
+    expect(mocked.createUser).not.toHaveBeenCalled();
+  });
+
+  it("creates only a source-verified identity with the minimal explicitly authorized payload", async () => {
+    const customer = plan();
+    const mocked = mockClient();
+    const result = await provisionClerkCustomers([customer], execution(), mocked.client);
+
+    expect(result.idMap).toEqual(new Map([[customer.sourceFingerprint, VERIFIED_USER.id]]));
+    expect(result).toMatchObject({ created: 1, existing: 0, reconciliation: [] });
+    expect(mocked.createUser).toHaveBeenCalledWith({
+      emailAddress: ["customer@example.com"],
+      firstName: "Ada",
+      lastName: "Lovelace",
+      externalId: customer.sourceFingerprint,
+      skipLegalChecks: true,
+    });
+    expect(mocked.createUser.mock.calls[0][0]).not.toHaveProperty("password");
+    expect(mocked.createUser.mock.calls[0][0]).not.toHaveProperty("notify");
+    expect(mocked.createUser.mock.calls[0][0]).not.toHaveProperty("sendInvite");
+  });
+
+  it("does not create identities for unverified source email", async () => {
+    const customer = plan(false);
+    const mocked = mockClient();
+    const result = await provisionClerkCustomers([customer], execution(), mocked.client);
+
+    expect(result.idMap.size).toBe(0);
+    expect(result.reconciliation[0]).toEqual({
+      sourceFingerprint: customer.sourceFingerprint,
+      reason: "source-email-unverified",
+    });
+    expect(mocked.createUser).not.toHaveBeenCalled();
+  });
+
+  it("requires the independent creation flag after safe identity lookups", async () => {
+    const customer = plan();
+    const mocked = mockClient();
+    const result = await provisionClerkCustomers(
+      [customer],
+      execution({ createClerkUsers: false, confirmedClerkAutoVerification: false }),
+      mocked.client,
+    );
+
+    expect(result.reconciliation[0].reason).toBe("creation-not-authorized");
+    expect(mocked.createUser).not.toHaveBeenCalled();
+  });
+
+  it("returns stable redacted failure reasons instead of provider messages", async () => {
+    const customer = plan();
+    const mocked = mockClient();
+    mocked.getUserList.mockRejectedValueOnce(new Error("Customer@Example.com secret payload"));
+    const result = await provisionClerkCustomers([customer], execution(), mocked.client);
+
+    expect(result.reconciliation).toEqual([{
+      sourceFingerprint: customer.sourceFingerprint,
+      reason: "provider-request-failed",
+    }]);
+    expect(JSON.stringify(result)).not.toContain("Customer@Example.com");
+    expect(JSON.stringify(result)).not.toContain("secret payload");
+  });
+
+  it("rejects invalid or ambiguous provider identities without creating users", async () => {
+    const customer = plan();
+    const ambiguous = mockClient({
+      external: [
+        { ...VERIFIED_USER, externalId: customer.sourceFingerprint },
+        { id: "user_zyxwvuts87654321", externalId: customer.sourceFingerprint },
+      ],
+    });
+    const badCreated = mockClient({
+      created: { id: "not-a-clerk-user", externalId: customer.sourceFingerprint },
+    });
+
+    const ambiguousResult = await provisionClerkCustomers([customer], execution(), ambiguous.client);
+    const createdResult = await provisionClerkCustomers([customer], execution(), badCreated.client);
+    expect(ambiguousResult.reconciliation[0].reason).toBe("external-identity-ambiguous");
+    expect(ambiguous.createUser).not.toHaveBeenCalled();
+    expect(createdResult.reconciliation[0].reason).toBe("created-identity-invalid");
+    expect(createdResult.idMap.size).toBe(0);
+  });
+
+  it("rejects malformed or duplicate fingerprints before any provider access", async () => {
+    const customer = plan();
+    const mocked = mockClient();
+    await expect(provisionClerkCustomers(
+      [{ ...customer, sourceFingerprint: "customer@example.com" }],
+      execution(),
+      mocked.client,
+    )).rejects.toThrow("invalid source fingerprint");
+    await expect(provisionClerkCustomers(
+      [customer, customer],
+      execution(),
+      mocked.client,
+    )).rejects.toThrow("duplicate source fingerprint");
+    expect(mocked.getUserList).not.toHaveBeenCalled();
+    expect(mocked.createUser).not.toHaveBeenCalled();
+  });
+
+  it("does not create when an external-ID query returns a non-matching identity", async () => {
+    const customer = plan();
+    const mocked = mockClient({
+      external: [{ ...VERIFIED_USER, externalId: "0".repeat(64) }],
+    });
+    const result = await provisionClerkCustomers([customer], execution(), mocked.client);
+
+    expect(result.reconciliation[0].reason).toBe("external-identity-invalid");
+    expect(mocked.getUserList).toHaveBeenCalledOnce();
+    expect(mocked.createUser).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/scripts/shopify-migration/adapters/d1/plan.test.ts
+++ b/tests/unit/scripts/shopify-migration/adapters/d1/plan.test.ts
@@ -39,10 +39,19 @@ function product(productId = "shopify_product_one", variantId = "shopify_variant
 function page(clock = 100, title = "Page"): NonNullable<MaterializedD1Input["pages"]>[number] {
   return {
     sourceFingerprint: "fingerprint",
-    page: { title, slug: "page", content: "<p>Safe</p>", created_by: "importer", parent_id: null, created_at: clock, updated_at: clock },
+    page: {
+      title, slug: "page", content: "<p>Safe</p>", excerpt: null,
+      meta_title: title, meta_description: null, meta_keywords: null,
+      template: "default", created_by: "importer", updated_by: "importer", version: 1,
+      custom_css: null, custom_js: null, parent_id: null, created_at: clock, updated_at: clock,
+    },
     initialVersion: {
       pageReference: { provider: "shopify", sourceFingerprint: "fingerprint", slug: "page" },
-      record: { title, content: "<p>Safe</p>", version: 1, created_by: "importer" },
+      record: {
+        title, content: "<p>Safe</p>", excerpt: null,
+        meta_title: title, meta_description: null, meta_keywords: null,
+        version: 1, created_by: "importer",
+      },
     },
     conflict: { strategy: "insert-only", key: "slug", onConflict: "skip" },
     media: [],
@@ -136,6 +145,24 @@ describe("D1 import plan", () => {
     expect(first).toContain('ELSE NULL END WHERE "slug"');
   });
 
+  it("rejects an initial page version that cannot exactly represent the page snapshot", () => {
+    const wrongVersion = page();
+    (wrongVersion.initialVersion.record as { version: number }).version = 2;
+    expect(() => buildD1ImportPlan({ pages: [wrongVersion] })).toThrow(/page snapshot contract/);
+
+    const wrongActor = page();
+    (wrongActor.initialVersion.record as { created_by: string }).created_by = "other";
+    expect(() => buildD1ImportPlan({ pages: [wrongActor] })).toThrow(/page snapshot contract/);
+
+    const wrongContent = page();
+    (wrongContent.initialVersion.record as { content: string }).content = "<p>Other</p>";
+    expect(() => buildD1ImportPlan({ pages: [wrongContent] })).toThrow(/page snapshot contract/);
+
+    const unsupportedStyling = page();
+    (unsupportedStyling.page as { custom_css: string | null }).custom_css = "body{}";
+    expect(() => buildD1ImportPlan({ pages: [unsupportedStyling] })).toThrow(/page snapshot contract/);
+  });
+
   it("rejects unresolved or duplicated semantic references before execution", () => {
     const broken = product();
     (broken.variants[0] as { product_id: string }).product_id = "missing";
@@ -202,11 +229,14 @@ describe("D1 import plan", () => {
       PRAGMA foreign_keys = ON;
       CREATE TABLE pages (
         id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT NOT NULL, slug TEXT NOT NULL UNIQUE,
-        content TEXT NOT NULL, created_by TEXT, parent_id INTEGER, created_at INTEGER, updated_at INTEGER
+        content TEXT NOT NULL, excerpt TEXT, meta_title TEXT, meta_description TEXT, meta_keywords TEXT,
+        template TEXT, created_by TEXT, updated_by TEXT, version INTEGER, custom_css TEXT, custom_js TEXT,
+        parent_id INTEGER, created_at INTEGER, updated_at INTEGER
       );
       CREATE TABLE page_versions (
         id INTEGER PRIMARY KEY AUTOINCREMENT, page_id INTEGER NOT NULL REFERENCES pages(id),
-        title TEXT NOT NULL, content TEXT NOT NULL, version INTEGER NOT NULL, created_by TEXT NOT NULL
+        title TEXT NOT NULL, content TEXT NOT NULL, excerpt TEXT, meta_title TEXT, meta_description TEXT,
+        meta_keywords TEXT, version INTEGER NOT NULL, created_by TEXT NOT NULL
       );
       CREATE TABLE blog_categories (
         id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, slug TEXT NOT NULL UNIQUE,

--- a/tests/unit/scripts/shopify-migration/adapters/d1/plan.test.ts
+++ b/tests/unit/scripts/shopify-migration/adapters/d1/plan.test.ts
@@ -161,6 +161,10 @@ describe("D1 import plan", () => {
     const unsupportedStyling = page();
     (unsupportedStyling.page as { custom_css: string | null }).custom_css = "body{}";
     expect(() => buildD1ImportPlan({ pages: [unsupportedStyling] })).toThrow(/page snapshot contract/);
+
+    const unsupportedTemplate = page();
+    (unsupportedTemplate.page as { template: string }).template = "alternate";
+    expect(() => buildD1ImportPlan({ pages: [unsupportedTemplate] })).toThrow(/page snapshot contract/);
   });
 
   it("rejects unresolved or duplicated semantic references before execution", () => {

--- a/tests/unit/scripts/shopify-migration/adapters/d1/plan.test.ts
+++ b/tests/unit/scripts/shopify-migration/adapters/d1/plan.test.ts
@@ -1,0 +1,239 @@
+import { DatabaseSync } from "node:sqlite";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  D1_DEPENDENCIES,
+  buildD1ImportPlan,
+  type MaterializedD1Input,
+} from "@/scripts/shopify-migration/adapters/d1/plan";
+
+function category(id = "shopify_category_one", media: string | null = null): NonNullable<MaterializedD1Input["categories"]>[number] {
+  return { category: { id, name: `Name ${id}`, primary_image: media } } as never;
+}
+
+function product(productId = "shopify_product_one", variantId = "shopify_variant_one"): NonNullable<MaterializedD1Input["products"]>[number] {
+  return {
+    product: {
+      id: productId,
+      name: "Product",
+      default_variant_id: variantId,
+      categories: JSON.stringify(["shopify_category_one"]),
+    },
+    variants: [{
+      id: variantId,
+      product_id: productId,
+      sku: `SKU-${variantId}`,
+      option_values: "[]",
+      price: '{"amount":100,"currency":"USD"}',
+    }],
+    inventory: [{
+      id: `inventory_${variantId}`,
+      sku_id: variantId,
+      location_id: "default",
+      quantities: '{"available":1}',
+    }],
+  } as never;
+}
+
+function page(clock = 100, title = "Page"): NonNullable<MaterializedD1Input["pages"]>[number] {
+  return {
+    sourceFingerprint: "fingerprint",
+    page: { title, slug: "page", content: "<p>Safe</p>", created_by: "importer", parent_id: null, created_at: clock, updated_at: clock },
+    initialVersion: {
+      pageReference: { provider: "shopify", sourceFingerprint: "fingerprint", slug: "page" },
+      record: { title, content: "<p>Safe</p>", version: 1, created_by: "importer" },
+    },
+    conflict: { strategy: "insert-only", key: "slug", onConflict: "skip" },
+    media: [],
+  } as never;
+}
+
+function blog(clock = 100, title = "Post"): NonNullable<MaterializedD1Input["blog"]> {
+  return {
+    categories: [{
+      sourceFingerprint: "blog-fingerprint",
+      record: { name: "News", slug: "news", created_at: clock, updated_at: clock },
+      conflict: { strategy: "insert-only", key: "slug", onConflict: "reuse" },
+    }] as never,
+    records: [{
+      sourceFingerprint: "post-fingerprint",
+      categoryReference: { provider: "shopify", sourceFingerprint: "blog-fingerprint", slug: "news" },
+      record: { title, slug: "post", author: "Author", tags: "[]", html: "<p>Safe</p>", reading_time: 1, created_at: clock, updated_at: clock },
+      conflict: { strategy: "insert-only", key: "slug", onConflict: "skip" },
+    }] as never,
+  };
+}
+
+function sensitive() {
+  return {
+    customers: [{ id: "user_12345678", type: "person" }],
+    orders: [{ order: {
+      id: "shopify_order_one",
+      customer_id: "user_12345678",
+      total_amount: '{"amount":100,"currency":"USD"}',
+      currency_code: "USD",
+      items: JSON.stringify([{
+        id: "shopify_order_item_one",
+        product_id: "shopify_product_one",
+        variant_id: "shopify_variant_one",
+      }]),
+    } }],
+    reviews: [{ review: {
+      id: "judge_me_review_one",
+      product_id: "shopify_product_one",
+      order_id: "shopify_order_one",
+      order_item_id: "shopify_order_item_one",
+      customer_id: "user_12345678",
+      rating: 5,
+      body: "Useful",
+      status: "published",
+      is_verified: false,
+    } }],
+  };
+}
+
+describe("D1 import plan", () => {
+  it("emits dependency-ordered SQL and keeps auto-ID operations in one chunk", () => {
+    const plan = buildD1ImportPlan({
+      categories: [category()],
+      products: [product()],
+      pages: [page()],
+      blog: blog(),
+      ...sensitive(),
+      redirects: [{ sourcePath: "/products/old", targetPath: "/product/new", statusCode: 301, entityType: "product" }],
+    });
+    const sql = plan.chunks.join("\n");
+    const positions = [
+      '"categories"', '"products"', '"product_variants"', '"inventory"', '"pages"',
+      '"page_versions"', '"blog_categories"', '"blog_posts"', '"customers"', '"orders"',
+      '"product_reviews"', '"redirect_map"',
+    ].map((table) => sql.indexOf(`INSERT INTO ${table}`));
+    expect(positions.every((position) => position >= 0)).toBe(true);
+    expect(positions).toEqual([...positions].sort((left, right) => left - right));
+    expect(sql).toContain('FROM "pages" WHERE "slug" = \'page\' AND changes() = 1');
+    expect(sql).toContain('FROM "blog_categories" WHERE "slug" = \'news\'');
+    expect(plan.counts).toMatchObject(Object.fromEntries(D1_DEPENDENCIES.map((dependency) => [dependency, 1])));
+  });
+
+  it("uses compare by default and enables overwrite only explicitly", () => {
+    const normal = buildD1ImportPlan({ categories: [category()] }).chunks.join("");
+    const overwrite = buildD1ImportPlan({ categories: [category()] }, { overwrite: true }).chunks.join("");
+    expect(normal).toContain("CASE WHEN");
+    expect(normal).toContain("ELSE NULL END");
+    expect(overwrite).toContain("DO UPDATE SET");
+    expect(overwrite).not.toContain("ELSE NULL END");
+  });
+
+  it("keeps page/blog insert-only rows stable across run clocks and aborts semantic drift", () => {
+    const first = buildD1ImportPlan({ pages: [page(100)], blog: blog(100) }).chunks.join("\n");
+    const second = buildD1ImportPlan({ pages: [page(200)], blog: blog(200) }).chunks.join("\n");
+    const comparisons = (sql: string) => sql.split("\n").filter((line) => line.startsWith("UPDATE "));
+    expect(comparisons(first)).toEqual(comparisons(second));
+    expect(comparisons(first).join(" ")).not.toContain('"created_at" IS');
+    expect(comparisons(buildD1ImportPlan({ pages: [page(200, "Changed")], blog: blog(200, "Changed") }).chunks.join("\n")))
+      .not.toEqual(comparisons(first));
+    expect(first).toContain('ELSE NULL END WHERE "slug"');
+  });
+
+  it("rejects unresolved or duplicated semantic references before execution", () => {
+    const broken = product();
+    (broken.variants[0] as { product_id: string }).product_id = "missing";
+    expect(() => buildD1ImportPlan({ categories: [category()], products: [broken] })).toThrow(/Variant product/);
+    expect(() => buildD1ImportPlan({ categories: [category(), category()] })).toThrow(/Duplicate category/);
+    expect(() => buildD1ImportPlan({
+      categories: [category()], products: [product()],
+      reviews: [{ review: { id: "review", product_id: "shopify_product_one", order_id: "missing", customer_id: "missing", rating: 5, body: "x", status: "published" } }],
+    })).toThrow(/Review product, order, or customer/);
+  });
+
+  it("binds review attribution to the exact planned purchase relation", () => {
+    const base = () => ({ categories: [category()], products: [product()], ...sensitive() });
+    const customerMismatch = base();
+    customerMismatch.customers.push({ id: "user_87654321", type: "person" });
+    customerMismatch.reviews[0].review.customer_id = "user_87654321";
+    expect(() => buildD1ImportPlan(customerMismatch)).toThrow(/Review product, order, or customer/);
+
+    const itemMismatch = base();
+    itemMismatch.reviews[0].review.order_item_id = "arbitrary_existing_item";
+    expect(() => buildD1ImportPlan(itemMismatch)).toThrow(/order-item and product provenance/);
+
+    const productMismatch = base();
+    productMismatch.products.push(product("shopify_product_two", "shopify_variant_two"));
+    productMismatch.reviews[0].review.product_id = "shopify_product_two";
+    productMismatch.reviews[0].review.is_verified = true;
+    expect(() => buildD1ImportPlan(productMismatch)).toThrow(/order-item and product provenance/);
+
+    const verifiedWithoutItem = base();
+    verifiedWithoutItem.reviews[0].review.order_item_id = null as unknown as string;
+    verifiedWithoutItem.reviews[0].review.is_verified = true;
+    expect(() => buildD1ImportPlan(verifiedWithoutItem)).toThrow(/exact order-item/);
+  });
+
+  it("collects only bounded public media references for the apply gate", () => {
+    const path = "/media/categories/shopify_category_one/1.jpg";
+    const plan = buildD1ImportPlan({ categories: [category("shopify_category_one", JSON.stringify({ file: { url: path } }))] });
+    expect(plan.requiredMediaPaths).toEqual([path]);
+  });
+
+  it("materializes redirect creation time as a stable unknown-source epoch", () => {
+    const first = buildD1ImportPlan({
+      redirects: [{ sourcePath: "/products/old", targetPath: "/product/new", statusCode: 301, entityType: "product" }],
+    }).chunks;
+    const second = buildD1ImportPlan({
+      redirects: [{ sourcePath: "/products/old", targetPath: "/product/new", statusCode: 301, entityType: "product" }],
+    }).chunks;
+    expect(first).toEqual(second);
+    expect(first.join("\n")).toContain('"created_at") VALUES (\'/products/old\', \'/product/new\', 301, \'product\', 0)');
+  });
+
+  it("keeps page insert/version/compare atomic when chunking", () => {
+    const plan = buildD1ImportPlan({ pages: [page(), { ...page(), page: { ...page().page, slug: "second" }, initialVersion: { ...page().initialVersion, pageReference: { ...page().initialVersion.pageReference, slug: "second" } } } as never] }, {
+      maxChunkBytes: 2048,
+      maxChunkStatements: 4,
+    });
+    expect(plan.chunks).toHaveLength(2);
+    expect(plan.chunks.every((chunk) => chunk.includes('INSERT INTO "pages"') && chunk.includes('INSERT INTO "page_versions"') && chunk.includes('UPDATE "pages"'))).toBe(true);
+  });
+
+  it("executes page/blog first-run, clock-only rerun, and changed-source conflict in SQLite", () => {
+    const database = new DatabaseSync(":memory:");
+    database.exec(`
+      PRAGMA foreign_keys = ON;
+      CREATE TABLE pages (
+        id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT NOT NULL, slug TEXT NOT NULL UNIQUE,
+        content TEXT NOT NULL, created_by TEXT, parent_id INTEGER, created_at INTEGER, updated_at INTEGER
+      );
+      CREATE TABLE page_versions (
+        id INTEGER PRIMARY KEY AUTOINCREMENT, page_id INTEGER NOT NULL REFERENCES pages(id),
+        title TEXT NOT NULL, content TEXT NOT NULL, version INTEGER NOT NULL, created_by TEXT NOT NULL
+      );
+      CREATE TABLE blog_categories (
+        id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, slug TEXT NOT NULL UNIQUE,
+        created_at INTEGER, updated_at INTEGER
+      );
+      CREATE TABLE blog_posts (
+        id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT NOT NULL, slug TEXT NOT NULL UNIQUE,
+        author TEXT NOT NULL, tags TEXT NOT NULL, html TEXT NOT NULL, reading_time INTEGER NOT NULL,
+        created_at INTEGER, updated_at INTEGER, category_id INTEGER REFERENCES blog_categories(id)
+      );
+    `);
+    const execute = (clock: number, pageTitle = "Page", postTitle = "Post") => {
+      const plan = buildD1ImportPlan({ pages: [page(clock, pageTitle)], blog: blog(clock, postTitle) });
+      plan.chunks.forEach((chunk) => database.exec(chunk));
+    };
+    execute(100);
+    execute(200);
+    const validationPlan = buildD1ImportPlan({ pages: [page(200)], blog: blog(200) });
+    for (const unit of validationPlan.validation) {
+      expect(database.prepare(unit.sql).get()).toMatchObject({ expected_count: 1, actual_count: 1 });
+    }
+    expect(database.prepare("SELECT COUNT(*) AS count FROM pages").get()).toMatchObject({ count: 1 });
+    expect(database.prepare("SELECT COUNT(*) AS count FROM page_versions").get()).toMatchObject({ count: 1 });
+    expect(database.prepare("SELECT COUNT(*) AS count FROM blog_categories").get()).toMatchObject({ count: 1 });
+    expect(database.prepare("SELECT COUNT(*) AS count FROM blog_posts").get()).toMatchObject({ count: 1 });
+    expect(() => execute(300, "Changed page", "Changed post")).toThrow(/NOT NULL/);
+    expect(database.prepare("SELECT title FROM pages").get()).toMatchObject({ title: "Page" });
+    database.close();
+  });
+});

--- a/tests/unit/scripts/shopify-migration/adapters/d1/runner.test.ts
+++ b/tests/unit/scripts/shopify-migration/adapters/d1/runner.test.ts
@@ -1,12 +1,16 @@
+import { EventEmitter } from "node:events";
 import { stat } from "node:fs/promises";
+import { join } from "node:path";
 
 import { describe, expect, it, vi } from "vitest";
 
 import {
   createPrivateSqlFiles,
+  createNodeCommandRunner,
   runD1Import,
   type CommandRunner,
   type PrivateSqlFiles,
+  type SpawnCommand,
 } from "@/scripts/shopify-migration/adapters/d1/runner";
 import type { ExecutionPlan } from "@/scripts/shopify-migration/lib/config";
 
@@ -25,6 +29,7 @@ const validation = JSON.stringify([{ success: true, results: [{ expected_count: 
 const wrangler = JSON.stringify({
   d1_databases: [{ binding: "DB", database_name: "local-db", database_id: "prod-id", preview_database_id: "preview-id" }],
 });
+const wranglerExecutablePath = join(process.cwd(), "node_modules", ".bin", "wrangler");
 
 function execution(overrides: Partial<ExecutionPlan> = {}): ExecutionPlan {
   return {
@@ -70,7 +75,7 @@ describe("D1 runner", () => {
     const { files } = memoryFiles();
     const result = await runD1Import({
       input: input(), execution: execution(), wranglerConfigText: wrangler,
-      wranglerConfigPath: "wrangler.jsonc", commandRunner, privateFiles: files,
+      wranglerConfigPath: "wrangler.jsonc", wranglerExecutablePath, commandRunner, privateFiles: files,
     });
     expect(result.dryRun).toBe(true);
     expect(commandRunner.run).not.toHaveBeenCalled();
@@ -91,15 +96,17 @@ describe("D1 runner", () => {
       input: input(),
       execution: execution({ dryRun: false, apply: true, target: "preview", confirmedPreview: true }),
       wranglerConfigText: wrangler,
-      wranglerConfigPath: "/repo/wrangler.jsonc",
+      wranglerConfigPath: "wrangler.jsonc",
+      wranglerExecutablePath,
       commandRunner,
       privateFiles: files,
     });
     expect(result.dryRun).toBe(false);
     expect(events).toEqual(["preflight", "temp", "chunk", "validation"]);
     const calls = (commandRunner.run as ReturnType<typeof vi.fn>).mock.calls as Array<[string, string[]]>;
-    expect(calls[0][0]).toBe("npx");
-    expect(calls[0][1]).toEqual(expect.arrayContaining(["wrangler", "d1", "execute", "local-db", "--remote", "--preview", "--config", "/repo/wrangler.jsonc", "--json", "--command"]));
+    expect(calls[0][0]).toBe(wranglerExecutablePath);
+    expect(calls[0][1]).toEqual(expect.arrayContaining(["d1", "execute", "local-db", "--remote", "--preview", "--config", "wrangler.jsonc", "--json", "--command"]));
+    expect(calls.flatMap((call) => call[1])).not.toContain("wrangler");
     expect(calls.flatMap((call) => call[1])).not.toContain("--yes");
     expect(files.cleanup).toHaveBeenCalledOnce();
   });
@@ -114,7 +121,7 @@ describe("D1 runner", () => {
       const { files } = memoryFiles();
       await expect(runD1Import({
         input: input(), execution: execution({ dryRun: false, apply: true }), wranglerConfigText: wrangler,
-        wranglerConfigPath: "wrangler.jsonc", commandRunner, privateFiles: files,
+        wranglerConfigPath: "wrangler.jsonc", wranglerExecutablePath, commandRunner, privateFiles: files,
       })).rejects.toThrow(/^D1 preflight failed$/);
       expect(files.createDirectory).not.toHaveBeenCalled();
     }
@@ -130,7 +137,7 @@ describe("D1 runner", () => {
     const { files } = memoryFiles();
     await expect(runD1Import({
       input: input(), execution: execution({ dryRun: false, apply: true }), wranglerConfigText: wrangler,
-      wranglerConfigPath: "wrangler.jsonc", commandRunner, privateFiles: files,
+      wranglerConfigPath: "wrangler.jsonc", wranglerExecutablePath, commandRunner, privateFiles: files,
     })).resolves.toMatchObject({ dryRun: false });
   });
 
@@ -138,11 +145,11 @@ describe("D1 runner", () => {
     const commandRunner: CommandRunner = { run: vi.fn() };
     await expect(runD1Import({
       input: input(), execution: execution({ dryRun: false, apply: true, overwrite: true }),
-      wranglerConfigText: wrangler, wranglerConfigPath: "wrangler.jsonc", commandRunner,
+      wranglerConfigText: wrangler, wranglerConfigPath: "wrangler.jsonc", wranglerExecutablePath, commandRunner,
     })).rejects.toThrow(/Overwrite apply/);
     await expect(runD1Import({
       input: { customers: [{ id: "user_12345678", type: "person" }] },
-      execution: execution(), wranglerConfigText: wrangler, wranglerConfigPath: "wrangler.jsonc", commandRunner,
+      execution: execution(), wranglerConfigText: wrangler, wranglerConfigPath: "wrangler.jsonc", wranglerExecutablePath, commandRunner,
     })).rejects.toThrow(/Sensitive rows/);
   });
 
@@ -155,7 +162,7 @@ describe("D1 runner", () => {
     })) };
     const common = {
       input: input(path), execution: execution({ dryRun: false, apply: true }), wranglerConfigText: wrangler,
-      wranglerConfigPath: "wrangler.jsonc", commandRunner,
+      wranglerConfigPath: "wrangler.jsonc", wranglerExecutablePath, commandRunner,
     };
     await expect(runD1Import({ ...common, mediaEvidence: [{ objectKey: "categories/owner/1.jpg", publicPath: path, status: "planned" } as never] }))
       .rejects.toThrow(/cryptographically verified/);
@@ -191,6 +198,7 @@ describe("D1 runner", () => {
       execution: execution({ dryRun: false, apply: true }),
       wranglerConfigText: wrangler,
       wranglerConfigPath: "wrangler.jsonc",
+      wranglerExecutablePath,
       commandRunner,
       privateFiles: files,
       planOptions: { maxChunkStatements: 3, maxChunkBytes: 1024 },
@@ -206,5 +214,132 @@ describe("D1 runner", () => {
     expect((await stat(path)).mode & 0o777).toBe(0o600);
     await files.cleanup(directory);
     await expect(stat(directory)).rejects.toThrow();
+  });
+
+  it("fails closed instead of invoking npx or an arbitrary executable", async () => {
+    const commandRunner: CommandRunner = { run: vi.fn() };
+    await expect(runD1Import({
+      input: input(), execution: execution(), wranglerConfigText: wrangler,
+      wranglerConfigPath: "wrangler.jsonc", wranglerExecutablePath: "npx", commandRunner,
+    })).rejects.toThrow(/Local Wrangler executable path/);
+    await expect(runD1Import({
+      input: input(), execution: execution(), wranglerConfigText: wrangler,
+      wranglerConfigPath: "wrangler.jsonc",
+      wranglerExecutablePath: "/tmp/unrelated/node_modules/.bin/wrangler",
+      commandRunner,
+    })).rejects.toThrow(/Local Wrangler executable path/);
+    expect(commandRunner.run).not.toHaveBeenCalled();
+  });
+
+  it("times out stalled processes with TERM, bounded KILL, and exactly-once settlement", async () => {
+    vi.useFakeTimers();
+    try {
+      const stdout = new EventEmitter();
+      const stderr = new EventEmitter();
+      const process = new EventEmitter() as EventEmitter & {
+        stdout: EventEmitter;
+        stderr: EventEmitter;
+        kill: ReturnType<typeof vi.fn>;
+      };
+      process.stdout = stdout;
+      process.stderr = stderr;
+      process.kill = vi.fn(() => true);
+      const spawnCommand = vi.fn(() => process) as unknown as SpawnCommand;
+      const runner = createNodeCommandRunner({ timeoutMs: 1_000, killGraceMs: 100, spawnCommand });
+      let settlements = 0;
+      const result = runner.run(wranglerExecutablePath, ["d1"]).then(
+        (value) => { settlements += 1; return value; },
+        (error: unknown) => { settlements += 1; throw error; },
+      );
+      const rejected = expect(result).rejects.toThrow(/^Wrangler command timed out$/);
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(process.kill).toHaveBeenCalledWith("SIGTERM");
+      await vi.advanceTimersByTimeAsync(100);
+      expect(process.kill).toHaveBeenCalledWith("SIGKILL");
+      await rejected;
+      process.emit("error", new Error("late private error"));
+      process.emit("close", 1);
+      expect(settlements).toBe(1);
+      expect(spawnCommand).toHaveBeenCalledWith(
+        wranglerExecutablePath,
+        ["d1"],
+        { shell: false, stdio: ["ignore", "pipe", "pipe"] },
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not hard-kill after a timeout-close race and bounds timeout options", async () => {
+    vi.useFakeTimers();
+    try {
+      const process = new EventEmitter() as EventEmitter & {
+        stdout: EventEmitter;
+        stderr: EventEmitter;
+        kill: ReturnType<typeof vi.fn>;
+      };
+      process.stdout = new EventEmitter();
+      process.stderr = new EventEmitter();
+      process.kill = vi.fn(() => true);
+      const runner = createNodeCommandRunner({
+        timeoutMs: 1_000,
+        killGraceMs: 100,
+        spawnCommand: (() => process) as unknown as SpawnCommand,
+      });
+      const result = runner.run(wranglerExecutablePath, ["d1"]);
+      const rejected = expect(result).rejects.toThrow(/^Wrangler command timed out$/);
+      await vi.advanceTimersByTimeAsync(1_000);
+      process.emit("close", null);
+      await rejected;
+      await vi.advanceTimersByTimeAsync(200);
+      expect(process.kill).toHaveBeenCalledTimes(1);
+      expect(process.kill).toHaveBeenCalledWith("SIGTERM");
+      expect(() => createNodeCommandRunner({ timeoutMs: 999 })).toThrow(/timeoutMs/);
+      expect(() => createNodeCommandRunner({ killGraceMs: 31_000 })).toThrow(/killGraceMs/);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("settles once when output overflow races process error and close", async () => {
+    const process = new EventEmitter() as EventEmitter & {
+      stdout: EventEmitter;
+      stderr: EventEmitter;
+      kill: ReturnType<typeof vi.fn>;
+    };
+    process.stdout = new EventEmitter();
+    process.stderr = new EventEmitter();
+    process.kill = vi.fn(() => true);
+    const runner = createNodeCommandRunner({
+      spawnCommand: (() => process) as unknown as SpawnCommand,
+    });
+    let settlements = 0;
+    const result = runner.run(wranglerExecutablePath, ["d1"]).then(
+      (value) => { settlements += 1; return value; },
+      (error: unknown) => { settlements += 1; throw error; },
+    );
+    const rejected = expect(result).rejects.toThrow(/^Wrangler output exceeded the safety limit$/);
+    process.stdout.emit("data", Buffer.alloc(1024 * 1024 + 1));
+    expect(process.kill).toHaveBeenCalledWith("SIGTERM");
+    process.emit("error", new Error("private overflow detail"));
+    process.emit("close", 1);
+    await rejected;
+    expect(settlements).toBe(1);
+  });
+
+  it("cleans private SQL after a command timeout", async () => {
+    let calls = 0;
+    const commandRunner: CommandRunner = { run: vi.fn(async (_file: string, args: readonly string[]) => {
+      calls += 1;
+      if (args.includes("--command")) return { exitCode: 0, stdout: preflight, stderr: "" };
+      throw new Error("Wrangler command timed out");
+    }) };
+    const { files } = memoryFiles();
+    await expect(runD1Import({
+      input: input(), execution: execution({ dryRun: false, apply: true }), wranglerConfigText: wrangler,
+      wranglerConfigPath: "wrangler.jsonc", wranglerExecutablePath, commandRunner, privateFiles: files,
+    })).rejects.toThrow(/^D1 chunk failed$/);
+    expect(calls).toBe(2);
+    expect(files.cleanup).toHaveBeenCalledOnce();
   });
 });

--- a/tests/unit/scripts/shopify-migration/adapters/d1/runner.test.ts
+++ b/tests/unit/scripts/shopify-migration/adapters/d1/runner.test.ts
@@ -1,0 +1,210 @@
+import { stat } from "node:fs/promises";
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  createPrivateSqlFiles,
+  runD1Import,
+  type CommandRunner,
+  type PrivateSqlFiles,
+} from "@/scripts/shopify-migration/adapters/d1/runner";
+import type { ExecutionPlan } from "@/scripts/shopify-migration/lib/config";
+
+const preflight = `${JSON.stringify([{ success: true, results: [{
+  migration_count: 20,
+  expected_migration_count: 20,
+  table_count: 12,
+  index_count: 12,
+  primary_key_count: 12,
+  unique_constraint_count: 5,
+  foreign_key_count: 6,
+  evolved_column_count: 1,
+  check_constraint_count: 11,
+}] }])}\n`;
+const validation = JSON.stringify([{ success: true, results: [{ expected_count: 1, actual_count: 1 }] }]);
+const wrangler = JSON.stringify({
+  d1_databases: [{ binding: "DB", database_name: "local-db", database_id: "prod-id", preview_database_id: "preview-id" }],
+});
+
+function execution(overrides: Partial<ExecutionPlan> = {}): ExecutionPlan {
+  return {
+    dryRun: true,
+    apply: false,
+    target: "local",
+    includeSensitive: false,
+    overwrite: false,
+    confirmedSensitiveData: false,
+    confirmedPreview: false,
+    confirmedProduction: false,
+    confirmedOverwrite: false,
+    ...overrides,
+  };
+}
+
+function input(path?: string) {
+  return {
+    categories: [{ category: {
+      id: "shopify_category_private",
+      name: "Private Name",
+      ...(path ? { primary_image: JSON.stringify({ file: { url: path } }) } : {}),
+    } }] as never,
+  };
+}
+
+function memoryFiles() {
+  const writes: Array<{ filename: string; contents: string }> = [];
+  const files: PrivateSqlFiles = {
+    createDirectory: vi.fn(async () => "/private/tmp/test-d1"),
+    write: vi.fn(async (_directory, filename, contents) => {
+      writes.push({ filename, contents });
+      return `/private/tmp/test-d1/${filename}`;
+    }),
+    cleanup: vi.fn(async () => undefined),
+  };
+  return { files, writes };
+}
+
+describe("D1 runner", () => {
+  it("returns a PII-free dry-run plan without subprocesses or temporary writes", async () => {
+    const commandRunner: CommandRunner = { run: vi.fn() };
+    const { files } = memoryFiles();
+    const result = await runD1Import({
+      input: input(), execution: execution(), wranglerConfigText: wrangler,
+      wranglerConfigPath: "wrangler.jsonc", commandRunner, privateFiles: files,
+    });
+    expect(result.dryRun).toBe(true);
+    expect(commandRunner.run).not.toHaveBeenCalled();
+    expect(files.createDirectory).not.toHaveBeenCalled();
+    expect(JSON.stringify(result)).not.toContain("Private Name");
+    expect(JSON.stringify(result)).not.toContain("shopify_category_private");
+  });
+
+  it("pins preview argv, preflights before files, and never auto-confirms", async () => {
+    const events: string[] = [];
+    const commandRunner: CommandRunner = { run: vi.fn(async (_file: string, args: readonly string[]) => {
+      events.push(args.includes("--command") ? "preflight" : args.some((value) => value.includes("chunk")) ? "chunk" : "validation");
+      return { exitCode: 0, stdout: args.includes("--command") ? preflight : args.some((value) => value.includes("validation")) ? validation : "", stderr: "" };
+    }) };
+    const { files } = memoryFiles();
+    (files.createDirectory as ReturnType<typeof vi.fn>).mockImplementation(async () => { events.push("temp"); return "/private/tmp/test-d1"; });
+    const result = await runD1Import({
+      input: input(),
+      execution: execution({ dryRun: false, apply: true, target: "preview", confirmedPreview: true }),
+      wranglerConfigText: wrangler,
+      wranglerConfigPath: "/repo/wrangler.jsonc",
+      commandRunner,
+      privateFiles: files,
+    });
+    expect(result.dryRun).toBe(false);
+    expect(events).toEqual(["preflight", "temp", "chunk", "validation"]);
+    const calls = (commandRunner.run as ReturnType<typeof vi.fn>).mock.calls as Array<[string, string[]]>;
+    expect(calls[0][0]).toBe("npx");
+    expect(calls[0][1]).toEqual(expect.arrayContaining(["wrangler", "d1", "execute", "local-db", "--remote", "--preview", "--config", "/repo/wrangler.jsonc", "--json", "--command"]));
+    expect(calls.flatMap((call) => call[1])).not.toContain("--yes");
+    expect(files.cleanup).toHaveBeenCalledOnce();
+  });
+
+  it("blocks schema mismatch before temp files and rejects ambiguous/prose JSON", async () => {
+    for (const stdout of [
+      JSON.stringify([{ success: true, results: [{ migration_count: 19 }] }]),
+      `${preflight}\nwarning`,
+      JSON.stringify([{ success: true, results: [{}] }, { success: true, results: [{}] }]),
+    ]) {
+      const commandRunner: CommandRunner = { run: vi.fn(async () => ({ exitCode: 0, stdout, stderr: "private row" })) };
+      const { files } = memoryFiles();
+      await expect(runD1Import({
+        input: input(), execution: execution({ dryRun: false, apply: true }), wranglerConfigText: wrangler,
+        wranglerConfigPath: "wrangler.jsonc", commandRunner, privateFiles: files,
+      })).rejects.toThrow(/^D1 preflight failed$/);
+      expect(files.createDirectory).not.toHaveBeenCalled();
+    }
+  });
+
+  it("accepts later additive migrations when the complete O05 baseline remains", async () => {
+    const future = preflight.replace('"migration_count":20', '"migration_count":21');
+    const commandRunner: CommandRunner = { run: vi.fn(async (_file: string, args: readonly string[]) => ({
+      exitCode: 0,
+      stdout: args.includes("--command") ? future : args.some((value) => value.includes("validation")) ? validation : "",
+      stderr: "",
+    })) };
+    const { files } = memoryFiles();
+    await expect(runD1Import({
+      input: input(), execution: execution({ dryRun: false, apply: true }), wranglerConfigText: wrangler,
+      wranglerConfigPath: "wrangler.jsonc", commandRunner, privateFiles: files,
+    })).resolves.toMatchObject({ dryRun: false });
+  });
+
+  it("requires both overwrite and sensitive confirmations", async () => {
+    const commandRunner: CommandRunner = { run: vi.fn() };
+    await expect(runD1Import({
+      input: input(), execution: execution({ dryRun: false, apply: true, overwrite: true }),
+      wranglerConfigText: wrangler, wranglerConfigPath: "wrangler.jsonc", commandRunner,
+    })).rejects.toThrow(/Overwrite apply/);
+    await expect(runD1Import({
+      input: { customers: [{ id: "user_12345678", type: "person" }] },
+      execution: execution(), wranglerConfigText: wrangler, wranglerConfigPath: "wrangler.jsonc", commandRunner,
+    })).rejects.toThrow(/Sensitive rows/);
+  });
+
+  it("rejects planned/plain-exists media and accepts only complete cryptographic evidence", async () => {
+    const path = "/media/categories/owner/1.jpg";
+    const commandRunner: CommandRunner = { run: vi.fn(async (_file: string, args: readonly string[]) => ({
+      exitCode: 0,
+      stdout: args.includes("--command") ? preflight : args.some((value) => value.includes("validation")) ? validation : "",
+      stderr: "",
+    })) };
+    const common = {
+      input: input(path), execution: execution({ dryRun: false, apply: true }), wranglerConfigText: wrangler,
+      wranglerConfigPath: "wrangler.jsonc", commandRunner,
+    };
+    await expect(runD1Import({ ...common, mediaEvidence: [{ objectKey: "categories/owner/1.jpg", publicPath: path, status: "planned" } as never] }))
+      .rejects.toThrow(/cryptographically verified/);
+    await expect(runD1Import({ ...common, mediaEvidence: [{ objectKey: "categories/owner/1.jpg", publicPath: path, status: "exists" } as never] }))
+      .rejects.toThrow(/cryptographically verified/);
+    const { files } = memoryFiles();
+    await expect(runD1Import({
+      ...common,
+      privateFiles: files,
+      mediaEvidence: [{
+        objectKey: "categories/owner/1.jpg", publicPath: path, status: "verified-existing",
+        sha256: "a".repeat(64), contentType: "image/jpeg", byteLength: 100,
+      }],
+    })).resolves.toMatchObject({ dryRun: false });
+  });
+
+  it("stops after a failed chunk, cleans up, and redacts command output", async () => {
+    let calls = 0;
+    const commandRunner: CommandRunner = { run: vi.fn(async (_file: string, args: readonly string[]) => {
+      calls += 1;
+      if (args.includes("--command")) return { exitCode: 0, stdout: preflight, stderr: "" };
+      return calls === 3
+        ? { exitCode: 1, stdout: "customer@example.invalid", stderr: "secret" }
+        : { exitCode: 0, stdout: "", stderr: "" };
+    }) };
+    const { files } = memoryFiles();
+    await expect(runD1Import({
+      input: { categories: [
+        { category: { id: "one", name: "One" } },
+        { category: { id: "two", name: "Two" } },
+        { category: { id: "three", name: "Three" } },
+      ] as never },
+      execution: execution({ dryRun: false, apply: true }),
+      wranglerConfigText: wrangler,
+      wranglerConfigPath: "wrangler.jsonc",
+      commandRunner,
+      privateFiles: files,
+      planOptions: { maxChunkStatements: 3, maxChunkBytes: 1024 },
+    })).rejects.toThrow(/^D1 chunk failed$/);
+    expect(commandRunner.run).toHaveBeenCalledTimes(3);
+    expect(files.cleanup).toHaveBeenCalledOnce();
+  });
+
+  it("creates private mode-0600 SQL files and removes their directory", async () => {
+    const files = createPrivateSqlFiles();
+    const directory = await files.createDirectory();
+    const path = await files.write(directory, "0001-chunk.sql", "SELECT 1;\n");
+    expect((await stat(path)).mode & 0o777).toBe(0o600);
+    await files.cleanup(directory);
+    await expect(stat(directory)).rejects.toThrow();
+  });
+});

--- a/tests/unit/scripts/shopify-migration/adapters/d1/runner.test.ts
+++ b/tests/unit/scripts/shopify-migration/adapters/d1/runner.test.ts
@@ -8,6 +8,7 @@ import {
   D1_TARGET_COLUMN_COUNT,
   createPrivateSqlFiles,
   createNodeCommandRunner,
+  preflightD1Target,
   runD1Import,
   type CommandRunner,
   type D1ProjectFiles,
@@ -118,6 +119,74 @@ function memoryFiles() {
 }
 
 describe("D1 runner", () => {
+  it("exports a read-only canonical preflight receipt without creating SQL files", async () => {
+    const commandRunner: CommandRunner = {
+      run: vi.fn(async () => ({ exitCode: 0, stdout: preflight, stderr: "" })),
+    };
+    const receipt = await preflightD1Target({
+      execution: execution({ dryRun: false, apply: true }),
+      ...project(),
+      commandRunner,
+    });
+    expect(receipt).toMatchObject({
+      version: 1,
+      target: "local",
+      databaseName: "local-db",
+      databaseId: null,
+      environment: null,
+    });
+    expect(receipt.projectDigest).toMatch(/^[a-f0-9]{64}$/u);
+    expect(commandRunner.run).toHaveBeenCalledOnce();
+    const args = (commandRunner.run as ReturnType<typeof vi.fn>).mock.calls[0][1] as string[];
+    expect(args).toContain("--command");
+    expect(args).not.toContain("--file");
+  });
+
+  it("fails read-only preflight for a missing migration without exposing command output", async () => {
+    const stale = preflight.replace('"migration_count":20', '"migration_count":19');
+    const commandRunner: CommandRunner = {
+      run: vi.fn(async () => ({ exitCode: 0, stdout: stale, stderr: "private database output" })),
+    };
+    await expect(preflightD1Target({
+      execution: execution({ dryRun: false, apply: true }),
+      ...project(),
+      commandRunner,
+    })).rejects.toThrow(/^D1 preflight failed$/);
+  });
+
+  it("rejects the wrong canonical database target before spawning a command", async () => {
+    const commandRunner: CommandRunner = { run: vi.fn() };
+    await expect(preflightD1Target({
+      execution: execution({ dryRun: false, apply: true }),
+      ...project(),
+      expectedDatabaseName: "another-database",
+      commandRunner,
+    })).rejects.toThrow("does not match expected");
+    expect(commandRunner.run).not.toHaveBeenCalled();
+  });
+
+  it("rejects a stale preflight receipt before media checks, subprocesses, or SQL files", async () => {
+    const commandRunner: CommandRunner = { run: vi.fn() };
+    const { files } = memoryFiles();
+    await expect(runD1Import({
+      input: input(),
+      execution: execution({ dryRun: false, apply: true }),
+      ...project(),
+      commandRunner,
+      privateFiles: files,
+      preflightReceipt: {
+        version: 1,
+        target: "local",
+        databaseName: "local-db",
+        databaseId: null,
+        environment: null,
+        projectDigest: "f".repeat(64),
+      },
+    })).rejects.toThrow("receipt does not match");
+    expect(commandRunner.run).not.toHaveBeenCalled();
+    expect(files.createDirectory).not.toHaveBeenCalled();
+  });
+
   it("binds a dry run to the real project's config and package-local Wrangler", async () => {
     const commandRunner: CommandRunner = { run: vi.fn() };
     await expect(runD1Import({

--- a/tests/unit/scripts/shopify-migration/adapters/d1/runner.test.ts
+++ b/tests/unit/scripts/shopify-migration/adapters/d1/runner.test.ts
@@ -5,10 +5,12 @@ import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  D1_TARGET_COLUMN_COUNT,
   createPrivateSqlFiles,
   createNodeCommandRunner,
   runD1Import,
   type CommandRunner,
+  type D1ProjectFiles,
   type PrivateSqlFiles,
   type SpawnCommand,
 } from "@/scripts/shopify-migration/adapters/d1/runner";
@@ -19,6 +21,9 @@ const preflight = `${JSON.stringify([{ success: true, results: [{
   expected_migration_count: 20,
   table_count: 12,
   index_count: 12,
+  target_column_count: D1_TARGET_COLUMN_COUNT,
+  compatible_target_column_count: D1_TARGET_COLUMN_COUNT,
+  incompatible_additive_column_count: 0,
   primary_key_count: 12,
   unique_constraint_count: 5,
   foreign_key_count: 6,
@@ -30,6 +35,49 @@ const wrangler = JSON.stringify({
   d1_databases: [{ binding: "DB", database_name: "local-db", database_id: "prod-id", preview_database_id: "preview-id" }],
 });
 const wranglerExecutablePath = join(process.cwd(), "node_modules", ".bin", "wrangler");
+const projectRoot = "/repo";
+const projectConfigPath = `${projectRoot}/wrangler.jsonc`;
+const projectPackageRoot = `${projectRoot}/node_modules/wrangler`;
+const projectPackageJsonPath = `${projectPackageRoot}/package.json`;
+const projectExecutablePath = `${projectPackageRoot}/bin/wrangler.js`;
+const projectShimPath = `${projectRoot}/node_modules/.bin/wrangler`;
+const packageJson = Buffer.from(JSON.stringify({
+  name: "wrangler",
+  version: "4.120.0",
+  bin: { wrangler: "bin/wrangler.js" },
+}));
+const executable = Buffer.from("#!/usr/bin/env node\n");
+
+function memoryProjectFiles(configReads: readonly string[] = [wrangler]): D1ProjectFiles {
+  let configIndex = 0;
+  return {
+    realpath: vi.fn(async (path: string) => path === projectShimPath ? projectExecutablePath : path),
+    readFile: vi.fn(async (path: string) => {
+      if (path === projectConfigPath) {
+        const value = configReads[Math.min(configIndex, configReads.length - 1)];
+        configIndex += 1;
+        return Buffer.from(value);
+      }
+      if (path === projectPackageJsonPath) return Buffer.from(packageJson);
+      if (path === projectExecutablePath) return Buffer.from(executable);
+      throw new Error("unexpected project read");
+    }),
+    stat: vi.fn(async (path: string) => {
+      if (path === projectRoot || path === projectPackageRoot) return { kind: "directory" as const, size: 0, mode: 0o755 };
+      if (path === projectConfigPath) {
+        const current = configReads[Math.min(configIndex, configReads.length - 1)];
+        return { kind: "file" as const, size: Buffer.byteLength(current), mode: 0o644 };
+      }
+      if (path === projectPackageJsonPath) return { kind: "file" as const, size: packageJson.byteLength, mode: 0o644 };
+      if (path === projectExecutablePath) return { kind: "file" as const, size: executable.byteLength, mode: 0o755 };
+      throw new Error("unexpected project stat");
+    }),
+  };
+}
+
+function project(configReads?: readonly string[]) {
+  return { projectRoot, projectFiles: memoryProjectFiles(configReads) };
+}
 
 function execution(overrides: Partial<ExecutionPlan> = {}): ExecutionPlan {
   return {
@@ -70,12 +118,19 @@ function memoryFiles() {
 }
 
 describe("D1 runner", () => {
+  it("binds a dry run to the real project's config and package-local Wrangler", async () => {
+    const commandRunner: CommandRunner = { run: vi.fn() };
+    await expect(runD1Import({
+      input: {}, execution: execution(), projectRoot: process.cwd(), commandRunner,
+    })).resolves.toMatchObject({ dryRun: true, totalRows: 0 });
+    expect(commandRunner.run).not.toHaveBeenCalled();
+  });
+
   it("returns a PII-free dry-run plan without subprocesses or temporary writes", async () => {
     const commandRunner: CommandRunner = { run: vi.fn() };
     const { files } = memoryFiles();
     const result = await runD1Import({
-      input: input(), execution: execution(), wranglerConfigText: wrangler,
-      wranglerConfigPath: "wrangler.jsonc", wranglerExecutablePath, commandRunner, privateFiles: files,
+      input: input(), execution: execution(), ...project(), commandRunner, privateFiles: files,
     });
     expect(result.dryRun).toBe(true);
     expect(commandRunner.run).not.toHaveBeenCalled();
@@ -95,17 +150,15 @@ describe("D1 runner", () => {
     const result = await runD1Import({
       input: input(),
       execution: execution({ dryRun: false, apply: true, target: "preview", confirmedPreview: true }),
-      wranglerConfigText: wrangler,
-      wranglerConfigPath: "wrangler.jsonc",
-      wranglerExecutablePath,
+      ...project(),
       commandRunner,
       privateFiles: files,
     });
     expect(result.dryRun).toBe(false);
     expect(events).toEqual(["preflight", "temp", "chunk", "validation"]);
     const calls = (commandRunner.run as ReturnType<typeof vi.fn>).mock.calls as Array<[string, string[]]>;
-    expect(calls[0][0]).toBe(wranglerExecutablePath);
-    expect(calls[0][1]).toEqual(expect.arrayContaining(["d1", "execute", "local-db", "--remote", "--preview", "--config", "wrangler.jsonc", "--json", "--command"]));
+    expect(calls[0][0]).toBe(projectExecutablePath);
+    expect(calls[0][1]).toEqual(expect.arrayContaining(["d1", "execute", "local-db", "--remote", "--preview", "--config", projectConfigPath, "--json", "--command"]));
     expect(calls.flatMap((call) => call[1])).not.toContain("wrangler");
     expect(calls.flatMap((call) => call[1])).not.toContain("--yes");
     expect(files.cleanup).toHaveBeenCalledOnce();
@@ -120,8 +173,7 @@ describe("D1 runner", () => {
       const commandRunner: CommandRunner = { run: vi.fn(async () => ({ exitCode: 0, stdout, stderr: "private row" })) };
       const { files } = memoryFiles();
       await expect(runD1Import({
-        input: input(), execution: execution({ dryRun: false, apply: true }), wranglerConfigText: wrangler,
-        wranglerConfigPath: "wrangler.jsonc", wranglerExecutablePath, commandRunner, privateFiles: files,
+        input: input(), execution: execution({ dryRun: false, apply: true }), ...project(), commandRunner, privateFiles: files,
       })).rejects.toThrow(/^D1 preflight failed$/);
       expect(files.createDirectory).not.toHaveBeenCalled();
     }
@@ -136,8 +188,7 @@ describe("D1 runner", () => {
     })) };
     const { files } = memoryFiles();
     await expect(runD1Import({
-      input: input(), execution: execution({ dryRun: false, apply: true }), wranglerConfigText: wrangler,
-      wranglerConfigPath: "wrangler.jsonc", wranglerExecutablePath, commandRunner, privateFiles: files,
+      input: input(), execution: execution({ dryRun: false, apply: true }), ...project(), commandRunner, privateFiles: files,
     })).resolves.toMatchObject({ dryRun: false });
   });
 
@@ -145,12 +196,41 @@ describe("D1 runner", () => {
     const commandRunner: CommandRunner = { run: vi.fn() };
     await expect(runD1Import({
       input: input(), execution: execution({ dryRun: false, apply: true, overwrite: true }),
-      wranglerConfigText: wrangler, wranglerConfigPath: "wrangler.jsonc", wranglerExecutablePath, commandRunner,
+      ...project(), commandRunner,
     })).rejects.toThrow(/Overwrite apply/);
     await expect(runD1Import({
       input: { customers: [{ id: "user_12345678", type: "person" }] },
-      execution: execution(), wranglerConfigText: wrangler, wranglerConfigPath: "wrangler.jsonc", wranglerExecutablePath, commandRunner,
+      execution: execution(), ...project(), commandRunner,
     })).rejects.toThrow(/Sensitive rows/);
+  });
+
+  it("rejects a divergent initial page version before project reads or command execution", async () => {
+    const commandRunner: CommandRunner = { run: vi.fn() };
+    const projectFiles = memoryProjectFiles();
+    await expect(runD1Import({
+      input: { pages: [{
+        sourceFingerprint: "page-fingerprint",
+        page: {
+          title: "Page", slug: "page", content: "<p>Page</p>", excerpt: null,
+          meta_title: "Page", meta_description: null, meta_keywords: null,
+          template: "default", parent_id: null, created_by: "actor", updated_by: "actor",
+          version: 1, custom_css: null, custom_js: null,
+        },
+        initialVersion: {
+          pageReference: { provider: "shopify", sourceFingerprint: "page-fingerprint", slug: "page" },
+          record: {
+            title: "Page", content: "<p>Different</p>", excerpt: null,
+            meta_title: "Page", meta_description: null, meta_keywords: null,
+            version: 1, created_by: "actor",
+          },
+        },
+        conflict: { strategy: "insert-only", key: "slug", onConflict: "skip" },
+        media: [],
+      }] as never },
+      execution: execution(), projectRoot, projectFiles, commandRunner,
+    })).rejects.toThrow(/page snapshot contract/);
+    expect(commandRunner.run).not.toHaveBeenCalled();
+    expect(projectFiles.readFile).not.toHaveBeenCalled();
   });
 
   it("rejects planned/plain-exists media and accepts only complete cryptographic evidence", async () => {
@@ -161,8 +241,7 @@ describe("D1 runner", () => {
       stderr: "",
     })) };
     const common = {
-      input: input(path), execution: execution({ dryRun: false, apply: true }), wranglerConfigText: wrangler,
-      wranglerConfigPath: "wrangler.jsonc", wranglerExecutablePath, commandRunner,
+      input: input(path), execution: execution({ dryRun: false, apply: true }), ...project(), commandRunner,
     };
     await expect(runD1Import({ ...common, mediaEvidence: [{ objectKey: "categories/owner/1.jpg", publicPath: path, status: "planned" } as never] }))
       .rejects.toThrow(/cryptographically verified/);
@@ -196,9 +275,7 @@ describe("D1 runner", () => {
         { category: { id: "three", name: "Three" } },
       ] as never },
       execution: execution({ dryRun: false, apply: true }),
-      wranglerConfigText: wrangler,
-      wranglerConfigPath: "wrangler.jsonc",
-      wranglerExecutablePath,
+      ...project(),
       commandRunner,
       privateFiles: files,
       planOptions: { maxChunkStatements: 3, maxChunkBytes: 1024 },
@@ -216,18 +293,59 @@ describe("D1 runner", () => {
     await expect(stat(directory)).rejects.toThrow();
   });
 
-  it("fails closed instead of invoking npx or an arbitrary executable", async () => {
+  it("fails closed for a non-canonical or unrelated project root", async () => {
     const commandRunner: CommandRunner = { run: vi.fn() };
     await expect(runD1Import({
-      input: input(), execution: execution(), wranglerConfigText: wrangler,
-      wranglerConfigPath: "wrangler.jsonc", wranglerExecutablePath: "npx", commandRunner,
-    })).rejects.toThrow(/Local Wrangler executable path/);
+      input: input(), execution: execution(), projectRoot: "relative", projectFiles: memoryProjectFiles(), commandRunner,
+    })).rejects.toThrow(/project root/);
+    expect(commandRunner.run).not.toHaveBeenCalled();
+  });
+
+  it("rejects same-name config bytes with a different database ID before spawn", async () => {
+    const changed = JSON.stringify({
+      d1_databases: [{
+        binding: "DB",
+        database_name: "local-db",
+        database_id: "different-prod-id",
+        preview_database_id: "different-preview-id",
+      }],
+    });
+    const commandRunner: CommandRunner = { run: vi.fn() };
+    const { files } = memoryFiles();
     await expect(runD1Import({
-      input: input(), execution: execution(), wranglerConfigText: wrangler,
-      wranglerConfigPath: "wrangler.jsonc",
-      wranglerExecutablePath: "/tmp/unrelated/node_modules/.bin/wrangler",
-      commandRunner,
-    })).rejects.toThrow(/Local Wrangler executable path/);
+      input: input(), execution: execution({ dryRun: false, apply: true }),
+      ...project([wrangler, changed]), commandRunner, privateFiles: files,
+    })).rejects.toThrow(/^D1 preflight failed$/);
+    expect(commandRunner.run).not.toHaveBeenCalled();
+    expect(files.createDirectory).not.toHaveBeenCalled();
+  });
+
+  it("rechecks config bytes before a write and cleans up when they change after preflight", async () => {
+    const changed = JSON.stringify({
+      d1_databases: [{
+        binding: "DB", database_name: "local-db",
+        database_id: "later-prod-id", preview_database_id: "later-preview-id",
+      }],
+    });
+    const commandRunner: CommandRunner = { run: vi.fn(async () => ({ exitCode: 0, stdout: preflight, stderr: "" })) };
+    const { files } = memoryFiles();
+    await expect(runD1Import({
+      input: input(), execution: execution({ dryRun: false, apply: true }),
+      ...project([wrangler, wrangler, changed]), commandRunner, privateFiles: files,
+    })).rejects.toThrow(/^D1 chunk failed$/);
+    expect(commandRunner.run).toHaveBeenCalledOnce();
+    expect(files.createDirectory).toHaveBeenCalledOnce();
+    expect(files.cleanup).toHaveBeenCalledOnce();
+  });
+
+  it("rejects a Wrangler shim resolving into unrelated tmp node_modules", async () => {
+    const projectFiles = memoryProjectFiles();
+    projectFiles.realpath = vi.fn(async (path: string) =>
+      path === projectShimPath ? "/tmp/unrelated/node_modules/wrangler/bin/wrangler.js" : path);
+    const commandRunner: CommandRunner = { run: vi.fn() };
+    await expect(runD1Import({
+      input: input(), execution: execution(), projectRoot, projectFiles, commandRunner,
+    })).rejects.toThrow(/not owned by the local package/);
     expect(commandRunner.run).not.toHaveBeenCalled();
   });
 
@@ -336,8 +454,7 @@ describe("D1 runner", () => {
     }) };
     const { files } = memoryFiles();
     await expect(runD1Import({
-      input: input(), execution: execution({ dryRun: false, apply: true }), wranglerConfigText: wrangler,
-      wranglerConfigPath: "wrangler.jsonc", wranglerExecutablePath, commandRunner, privateFiles: files,
+      input: input(), execution: execution({ dryRun: false, apply: true }), ...project(), commandRunner, privateFiles: files,
     })).rejects.toThrow(/^D1 chunk failed$/);
     expect(calls).toBe(2);
     expect(files.cleanup).toHaveBeenCalledOnce();

--- a/tests/unit/scripts/shopify-migration/adapters/d1/schema.test.ts
+++ b/tests/unit/scripts/shopify-migration/adapters/d1/schema.test.ts
@@ -1,0 +1,68 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  D1_PREFLIGHT_SQL,
+  D1_TARGET_COLUMN_COUNT,
+} from "@/scripts/shopify-migration/adapters/d1/runner";
+
+function migratedDatabase(): DatabaseSync {
+  const database = new DatabaseSync(":memory:");
+  const migrationRoot = join(process.cwd(), "migrations");
+  const migrations = readdirSync(migrationRoot).filter((name) => /^\d{4}_.+\.sql$/.test(name)).sort();
+  migrations.forEach((name) => database.exec(readFileSync(join(migrationRoot, name), "utf8")));
+  database.exec(`
+    CREATE TABLE d1_migrations (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL,
+      applied_at TEXT NOT NULL
+    );
+  `);
+  const insert = database.prepare("INSERT INTO d1_migrations (name, applied_at) VALUES (?, 'test')");
+  migrations.forEach((name) => insert.run(name));
+  return database;
+}
+
+function preflight(database: DatabaseSync): Record<string, unknown> {
+  return database.prepare(D1_PREFLIGHT_SQL).get() as Record<string, unknown>;
+}
+
+describe("D1 schema preflight contract", () => {
+  it("matches the real migrated schema's emitted column contracts", () => {
+    const database = migratedDatabase();
+    expect(preflight(database)).toMatchObject({
+      target_column_count: D1_TARGET_COLUMN_COUNT,
+      compatible_target_column_count: D1_TARGET_COLUMN_COUNT,
+      incompatible_additive_column_count: 0,
+    });
+    database.close();
+  });
+
+  it("permits compatible additive columns and detects incompatible additions or changed targets", () => {
+    const database = migratedDatabase();
+    database.exec(`
+      ALTER TABLE categories ADD COLUMN optional_extra TEXT;
+      ALTER TABLE products ADD COLUMN defaulted_extra TEXT NOT NULL DEFAULT 'safe';
+    `);
+    expect(preflight(database)).toMatchObject({
+      compatible_target_column_count: D1_TARGET_COLUMN_COUNT,
+      incompatible_additive_column_count: 0,
+    });
+
+    database.exec("ALTER TABLE inventory ADD COLUMN required_extra TEXT NOT NULL");
+    expect(preflight(database)).toMatchObject({ incompatible_additive_column_count: 1 });
+
+    database.exec("ALTER TABLE orders ADD COLUMN null_default_extra TEXT NOT NULL DEFAULT NULL");
+    expect(preflight(database)).toMatchObject({ incompatible_additive_column_count: 2 });
+
+    database.exec("ALTER TABLE categories RENAME COLUMN name TO incompatible_name");
+    expect(preflight(database)).toMatchObject({
+      compatible_target_column_count: D1_TARGET_COLUMN_COUNT - 1,
+      incompatible_additive_column_count: 3,
+    });
+    database.close();
+  });
+});

--- a/tests/unit/scripts/shopify-migration/adapters/media.test.ts
+++ b/tests/unit/scripts/shopify-migration/adapters/media.test.ts
@@ -128,14 +128,33 @@ describe("safe media downloader", () => {
     expect(evilRedirect).toHaveBeenCalledTimes(1);
 
     const privateRedirect = vi.fn<typeof fetch>()
-      .mockResolvedValueOnce(new Response(null, { status: 302, headers: { location: "https://media.example.test/image.jpg" } }))
+      .mockResolvedValueOnce(new Response(null, { status: 302, headers: { location: "https://example-store.myshopify.com/cdn/image.jpg" } }))
       .mockResolvedValueOnce(imageResponse());
     await expect(downloadVerifiedMedia(plan(), {
-      allowedHosts: ["cdn.shopify.com", "media.example.test"],
+      allowedHosts: ["cdn.shopify.com", "example-store.myshopify.com"],
       fetcher: privateRedirect,
-      resolveHost: async (host) => host === "media.example.test" ? ["127.0.0.1"] : PUBLIC_IP,
+      resolveHost: async (host) => host === "example-store.myshopify.com" ? ["127.0.0.1"] : PUBLIC_IP,
     })).rejects.toThrow(/non-public address/);
     expect(privateRedirect).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects arbitrary exact hosts and non-CDN myshopify paths before fetching", async () => {
+    const fetcher = vi.fn<typeof fetch>();
+    await expect(downloadVerifiedMedia(plan({
+      sourceUrl: "https://merchant-assets.example.test/image.jpg",
+      sourceHost: "merchant-assets.example.test",
+    }), {
+      allowedHosts: ["merchant-assets.example.test"], fetcher, resolveHost: async () => PUBLIC_IP,
+    })).rejects.toThrow(/non-Shopify/);
+
+    const myshopify = plan({
+      sourceUrl: "https://example-store.myshopify.com/files/image.jpg",
+      sourceHost: "example-store.myshopify.com",
+    });
+    await expect(downloadVerifiedMedia(myshopify, {
+      allowedHosts: ["example-store.myshopify.com"], fetcher, resolveHost: async () => PUBLIC_IP,
+    })).rejects.toThrow(/allowed exact HTTPS origin/);
+    expect(fetcher).not.toHaveBeenCalled();
   });
 
   it("rejects oversized declared and chunked bodies", async () => {

--- a/tests/unit/scripts/shopify-migration/adapters/media.test.ts
+++ b/tests/unit/scripts/shopify-migration/adapters/media.test.ts
@@ -1,0 +1,281 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ExecutionPlan } from "@/scripts/shopify-migration/lib/config";
+import type { MediaRewrite } from "@/scripts/shopify-migration/transformers/_shared";
+import {
+  downloadVerifiedMedia,
+  importMediaPlans,
+  R2BindingMediaStore,
+  wranglerR2GetArguments,
+  wranglerR2PutArguments,
+} from "@/scripts/shopify-migration/adapters/media";
+import type { MediaObjectStore } from "@/scripts/shopify-migration/adapters/media/r2";
+
+const JPEG = new Uint8Array([
+  0xff, 0xd8, 0xff, 0xc0, 0x00, 0x08, 0x08, 0x00, 0x01, 0x00, 0x01, 0x01, 0xff, 0xd9,
+]);
+const PUBLIC_IP = ["93.184.216.34"];
+const WRANGLER_CONFIG = `{
+  "r2_buckets": [{
+    "binding": "MEDIA",
+    "bucket_name": "store-media",
+    "preview_bucket_name": "store-media-preview"
+  }]
+}`;
+
+function plan(overrides: Partial<MediaRewrite> = {}): MediaRewrite {
+  return {
+    sourceUrl: "https://cdn.shopify.com/files/image.jpg",
+    sourceHost: "cdn.shopify.com",
+    objectKey: "products/shopify_product_abc/1.jpg",
+    publicPath: "/media/products/shopify_product_abc/1.jpg",
+    contentType: "image/jpeg",
+    role: "product",
+    ownerId: "shopify_product_abc",
+    requiredBeforePersistence: true,
+    ...overrides,
+  };
+}
+
+function execution(overrides: Partial<ExecutionPlan> = {}): ExecutionPlan {
+  return {
+    dryRun: true,
+    apply: false,
+    target: "local",
+    includeSensitive: false,
+    overwrite: false,
+    confirmedSensitiveData: false,
+    confirmedPreview: false,
+    confirmedProduction: false,
+    confirmedOverwrite: false,
+    ...overrides,
+  };
+}
+
+function store(overrides: Partial<MediaObjectStore> = {}): MediaObjectStore {
+  return {
+    head: vi.fn(async () => false),
+    put: vi.fn(async () => "written" as const),
+    ...overrides,
+  };
+}
+
+function imageResponse(bytes = JPEG, headers: Record<string, string> = {}): Response {
+  return new Response(bytes, { status: 200, headers: { "content-type": "image/jpeg", ...headers } });
+}
+
+describe("safe media downloader", () => {
+  it("downloads an allowlisted HTTPS image without forwarding credentials", async () => {
+    const fetcher = vi.fn<typeof fetch>(async (_url, init) => {
+      const headers = new Headers(init?.headers);
+      expect(headers.get("authorization")).toBeNull();
+      expect(headers.get("cookie")).toBeNull();
+      expect(init?.redirect).toBe("manual");
+      return imageResponse(JPEG, { "content-length": String(JPEG.byteLength) });
+    });
+    const media = await downloadVerifiedMedia(plan(), {
+      allowedHosts: ["cdn.shopify.com"],
+      fetcher,
+      resolveHost: async () => PUBLIC_IP,
+    });
+    expect(media.bytes).toEqual(JPEG);
+    expect(media.contentType).toBe("image/jpeg");
+  });
+
+  it("revalidates every redirect host and resolved address", async () => {
+    const evilRedirect = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(null, { status: 302, headers: { location: "https://evil.test/image.jpg" } }),
+    );
+    await expect(downloadVerifiedMedia(plan(), {
+      allowedHosts: ["cdn.shopify.com"], fetcher: evilRedirect, resolveHost: async () => PUBLIC_IP,
+    })).rejects.toThrow(/allowed exact HTTPS origin/);
+    expect(evilRedirect).toHaveBeenCalledTimes(1);
+
+    const privateRedirect = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(null, { status: 302, headers: { location: "https://media.example.test/image.jpg" } }))
+      .mockResolvedValueOnce(imageResponse());
+    await expect(downloadVerifiedMedia(plan(), {
+      allowedHosts: ["cdn.shopify.com", "media.example.test"],
+      fetcher: privateRedirect,
+      resolveHost: async (host) => host === "media.example.test" ? ["127.0.0.1"] : PUBLIC_IP,
+    })).rejects.toThrow(/non-public address/);
+    expect(privateRedirect).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects oversized declared and chunked bodies", async () => {
+    const declared = vi.fn<typeof fetch>().mockResolvedValue(imageResponse(JPEG, { "content-length": "999" }));
+    await expect(downloadVerifiedMedia(plan(), {
+      allowedHosts: ["cdn.shopify.com"], fetcher: declared, resolveHost: async () => PUBLIC_IP, maxBytes: 20,
+    })).rejects.toThrow(/Content-Length/);
+
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array(12));
+        controller.enqueue(new Uint8Array(12));
+        controller.close();
+      },
+    });
+    const chunked = vi.fn<typeof fetch>().mockResolvedValue(new Response(stream, {
+      status: 200, headers: { "content-type": "image/jpeg" },
+    }));
+    await expect(downloadVerifiedMedia(plan(), {
+      allowedHosts: ["cdn.shopify.com"], fetcher: chunked, resolveHost: async () => PUBLIC_IP, maxBytes: 20,
+    })).rejects.toThrow(/exceeds 20 bytes/);
+  });
+
+  it("keeps the deadline active while streaming and cancels a stalled body", async () => {
+    const cancelled = vi.fn();
+    const stalled = new ReadableStream<Uint8Array>({
+      pull: () => new Promise<void>(() => undefined),
+      cancel: cancelled,
+    });
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(new Response(stalled, {
+      status: 200, headers: { "content-type": "image/jpeg" },
+    }));
+    await expect(downloadVerifiedMedia(plan(), {
+      allowedHosts: ["cdn.shopify.com"], fetcher, resolveHost: async () => PUBLIC_IP, timeoutMs: 5,
+    })).rejects.toThrow(/timed out/);
+    expect(cancelled).toHaveBeenCalled();
+  });
+
+  it("bounds DNS resolution before making a request", async () => {
+    const fetcher = vi.fn<typeof fetch>();
+    await expect(downloadVerifiedMedia(plan(), {
+      allowedHosts: ["cdn.shopify.com"],
+      fetcher,
+      resolveHost: () => new Promise<readonly string[]>(() => undefined),
+      timeoutMs: 5,
+    })).rejects.toThrow(/DNS resolution timed out/);
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it("rejects MIME, extension, and magic-byte spoofing", async () => {
+    const pngClaim = vi.fn<typeof fetch>().mockResolvedValue(new Response(JPEG, {
+      status: 200, headers: { "content-type": "image/png" },
+    }));
+    await expect(downloadVerifiedMedia(plan(), {
+      allowedHosts: ["cdn.shopify.com"], fetcher: pngClaim, resolveHost: async () => PUBLIC_IP,
+    })).rejects.toThrow(/Content-Type/);
+
+    const fakeJpeg = vi.fn<typeof fetch>().mockResolvedValue(imageResponse(new Uint8Array([0xff, 0xd8, 0xff, 0xd9])));
+    await expect(downloadVerifiedMedia(plan(), {
+      allowedHosts: ["cdn.shopify.com"], fetcher: fakeJpeg, resolveHost: async () => PUBLIC_IP,
+    })).rejects.toThrow(/signature/);
+
+    const unsupported = {
+      ...plan(),
+      objectKey: "products/shopify_product_abc/1.gif",
+      publicPath: "/media/products/shopify_product_abc/1.gif",
+      contentType: "image/gif",
+      sourceUrl: "https://cdn.shopify.com/files/image.gif",
+    } as unknown as MediaRewrite;
+    await expect(downloadVerifiedMedia(unsupported, {
+      allowedHosts: ["cdn.shopify.com"], fetcher: fakeJpeg, resolveHost: async () => PUBLIC_IP,
+    }))
+      .rejects.toThrow(/unsupported/);
+  });
+});
+
+describe("media import execution", () => {
+  it("performs zero network, head, or writes in dry-run mode", async () => {
+    const targetStore = store();
+    const fetcher = vi.fn<typeof fetch>();
+    const resolver = vi.fn(async () => PUBLIC_IP);
+    await expect(importMediaPlans([plan()], {
+      execution: execution(),
+      wranglerConfigText: WRANGLER_CONFIG,
+      allowedHosts: ["cdn.shopify.com"],
+      store: targetStore,
+      download: { fetcher, resolveHost: resolver },
+    })).resolves.toEqual([{ objectKey: plan().objectKey, status: "planned", bytes: 0 }]);
+    expect(fetcher).not.toHaveBeenCalled();
+    expect(resolver).not.toHaveBeenCalled();
+    expect(targetStore.head).not.toHaveBeenCalled();
+    expect(targetStore.put).not.toHaveBeenCalled();
+  });
+
+  it("skips an existing object without downloading or overwriting", async () => {
+    const targetStore = store({ head: vi.fn(async () => true) });
+    const fetcher = vi.fn<typeof fetch>();
+    const result = await importMediaPlans([plan()], {
+      execution: execution({ dryRun: false, apply: true }),
+      wranglerConfigText: WRANGLER_CONFIG,
+      allowedHosts: ["cdn.shopify.com"],
+      store: targetStore,
+      download: { fetcher, resolveHost: async () => PUBLIC_IP },
+    });
+    expect(result[0].status).toBe("exists");
+    expect(fetcher).not.toHaveBeenCalled();
+    expect(targetStore.put).not.toHaveBeenCalled();
+  });
+
+  it("requires target and overwrite confirmations independently", async () => {
+    const options = { wranglerConfigText: WRANGLER_CONFIG, allowedHosts: ["cdn.shopify.com"], store: store() };
+    await expect(importMediaPlans([plan()], {
+      ...options, execution: execution({ target: "preview", dryRun: false, apply: true }),
+    })).rejects.toThrow(/preview confirmation/);
+    await expect(importMediaPlans([plan()], {
+      ...options,
+      execution: execution({ dryRun: false, apply: true, overwrite: true, confirmedOverwrite: false }),
+    })).rejects.toThrow(/overwrite confirmation/);
+  });
+
+  it("uses the canonical preview bucket and preserves conditional create results", async () => {
+    const put = vi.fn(async () => "exists" as const);
+    const targetStore = store({ put });
+    const result = await importMediaPlans([plan()], {
+      execution: execution({ target: "preview", dryRun: false, apply: true, confirmedPreview: true }),
+      wranglerConfigText: WRANGLER_CONFIG,
+      allowedHosts: ["cdn.shopify.com"],
+      store: targetStore,
+      download: {
+        fetcher: vi.fn<typeof fetch>().mockResolvedValue(imageResponse()),
+        resolveHost: async () => PUBLIC_IP,
+      },
+    });
+    expect(put).toHaveBeenCalledWith("store-media-preview", plan().objectKey, JPEG, expect.objectContaining({ overwrite: false }));
+    expect(result[0]).toMatchObject({ status: "exists", bytes: 0 });
+  });
+});
+
+describe("R2 adapters and command construction", () => {
+  it("constructs explicit local/remote argv arrays without shell or secrets", () => {
+    const get = wranglerR2GetArguments({
+      bucketName: "store-media-preview", objectKey: plan().objectKey, target: "preview",
+      environment: "staging", configPath: "wrangler.jsonc",
+    });
+    expect(get).toEqual([
+      "r2", "object", "get", `store-media-preview/${plan().objectKey}`, "--pipe", "--remote",
+      "--config", "wrangler.jsonc", "--env", "staging",
+    ]);
+    const put = wranglerR2PutArguments({
+      bucketName: "store-media", objectKey: plan().objectKey, target: "local", configPath: "wrangler.jsonc",
+      contentType: "image/jpeg", overwriteConfirmed: true,
+    });
+    expect(put).toContain("--local");
+    expect(put).toContain("--content-type");
+    expect(put).toContain("--cache-control");
+    expect(JSON.stringify(put)).not.toMatch(/token|secret|authorization/i);
+    expect(() => wranglerR2PutArguments({
+      bucketName: "store-media", objectKey: plan().objectKey, target: "local", configPath: "wrangler.jsonc",
+      contentType: "image/jpeg", overwriteConfirmed: false,
+    })).toThrow(/create-only/);
+    expect(() => wranglerR2GetArguments({
+      bucketName: "store-media", objectKey: plan().objectKey, target: "local", configPath: "--remote",
+    })).toThrow(/config path is invalid/);
+  });
+
+  it("uses an atomic R2 conditional when overwrite is not confirmed", async () => {
+    const bucket = {
+      head: vi.fn(async () => null),
+      put: vi.fn(async () => null),
+    } as unknown as R2Bucket;
+    const adapter = new R2BindingMediaStore("store-media", bucket);
+    await expect(adapter.put("store-media", plan().objectKey, JPEG, {
+      contentType: "image/jpeg", cacheControl: "public, max-age=1", overwrite: false,
+    })).resolves.toBe("exists");
+    expect(bucket.put).toHaveBeenCalledWith(plan().objectKey, JPEG, expect.objectContaining({
+      onlyIf: { etagDoesNotMatch: "*" },
+      httpMetadata: { contentType: "image/jpeg", cacheControl: "public, max-age=1" },
+    }));
+  });
+});

--- a/tests/unit/scripts/shopify-migration/adapters/media.test.ts
+++ b/tests/unit/scripts/shopify-migration/adapters/media.test.ts
@@ -13,7 +13,7 @@ import {
   wranglerR2PutArguments,
 } from "@/scripts/shopify-migration/adapters/media";
 import {
-  IMMUTABLE_MEDIA_CACHE_CONTROL,
+  REVALIDATING_MEDIA_CACHE_CONTROL,
   MEDIA_IMPORTER_VERSION,
   type ExpectedMediaObject,
   type MediaObjectStore,
@@ -73,7 +73,7 @@ function store(overrides: Partial<MediaObjectStore> = {}): MediaObjectStore {
 function expectedMedia(source = plan(), bytes = JPEG): ExpectedMediaObject {
   return {
     contentType: source.contentType,
-    cacheControl: IMMUTABLE_MEDIA_CACHE_CONTROL,
+    cacheControl: REVALIDATING_MEDIA_CACHE_CONTROL,
     byteLength: bytes.byteLength,
     sha256: createHash("sha256").update(bytes).digest("hex"),
     sha256Base64: createHash("sha256").update(bytes).digest("base64"),
@@ -461,7 +461,7 @@ describe("R2 adapters and command construction", () => {
       Key: plan().objectKey,
       ContentLength: JPEG.byteLength,
       ContentType: "image/jpeg",
-      CacheControl: IMMUTABLE_MEDIA_CACHE_CONTROL,
+      CacheControl: REVALIDATING_MEDIA_CACHE_CONTROL,
       ChecksumSHA256: expectedMedia().sha256Base64,
       IfNoneMatch: "*",
       Metadata: expect.objectContaining({

--- a/tests/unit/scripts/shopify-migration/adapters/media.test.ts
+++ b/tests/unit/scripts/shopify-migration/adapters/media.test.ts
@@ -1,14 +1,25 @@
+import { createHash } from "node:crypto";
+import { HeadObjectCommand, PutObjectCommand, type HeadObjectCommandOutput, type PutObjectCommandOutput } from "@aws-sdk/client-s3";
 import { describe, expect, it, vi } from "vitest";
 import type { ExecutionPlan } from "@/scripts/shopify-migration/lib/config";
 import type { MediaRewrite } from "@/scripts/shopify-migration/transformers/_shared";
 import {
   downloadVerifiedMedia,
+  fingerprintMediaSource,
   importMediaPlans,
   R2BindingMediaStore,
+  R2S3MediaStore,
   wranglerR2GetArguments,
   wranglerR2PutArguments,
 } from "@/scripts/shopify-migration/adapters/media";
-import type { MediaObjectStore } from "@/scripts/shopify-migration/adapters/media/r2";
+import {
+  IMMUTABLE_MEDIA_CACHE_CONTROL,
+  MEDIA_IMPORTER_VERSION,
+  type ExpectedMediaObject,
+  type MediaObjectStore,
+  type S3CommandSender,
+  type StoredMediaObject,
+} from "@/scripts/shopify-migration/adapters/media/r2";
 
 const JPEG = new Uint8Array([
   0xff, 0xd8, 0xff, 0xc0, 0x00, 0x08, 0x08, 0x00, 0x01, 0x00, 0x01, 0x01, 0xff, 0xd9,
@@ -53,8 +64,34 @@ function execution(overrides: Partial<ExecutionPlan> = {}): ExecutionPlan {
 
 function store(overrides: Partial<MediaObjectStore> = {}): MediaObjectStore {
   return {
-    head: vi.fn(async () => false),
+    inspect: vi.fn(async () => null),
     put: vi.fn(async () => "written" as const),
+    ...overrides,
+  };
+}
+
+function expectedMedia(source = plan(), bytes = JPEG): ExpectedMediaObject {
+  return {
+    contentType: source.contentType,
+    cacheControl: IMMUTABLE_MEDIA_CACHE_CONTROL,
+    byteLength: bytes.byteLength,
+    sha256: createHash("sha256").update(bytes).digest("hex"),
+    sha256Base64: createHash("sha256").update(bytes).digest("base64"),
+    sourceFingerprint: fingerprintMediaSource(source.sourceUrl),
+  };
+}
+
+function storedMedia(overrides: Partial<StoredMediaObject> = {}): StoredMediaObject {
+  const expected = expectedMedia();
+  return {
+    contentType: expected.contentType,
+    cacheControl: expected.cacheControl,
+    byteLength: expected.byteLength,
+    sha256: expected.sha256,
+    importer: MEDIA_IMPORTER_VERSION,
+    sourceFingerprint: expected.sourceFingerprint,
+    importerContentSha256: expected.sha256,
+    importerByteLength: String(expected.byteLength),
     ...overrides,
   };
 }
@@ -176,7 +213,7 @@ describe("safe media downloader", () => {
 });
 
 describe("media import execution", () => {
-  it("performs zero network, head, or writes in dry-run mode", async () => {
+  it("performs zero network, inspection, or writes in dry-run mode", async () => {
     const targetStore = store();
     const fetcher = vi.fn<typeof fetch>();
     const resolver = vi.fn(async () => PUBLIC_IP);
@@ -186,26 +223,83 @@ describe("media import execution", () => {
       allowedHosts: ["cdn.shopify.com"],
       store: targetStore,
       download: { fetcher, resolveHost: resolver },
-    })).resolves.toEqual([{ objectKey: plan().objectKey, status: "planned", bytes: 0 }]);
+    })).resolves.toEqual([{
+      objectKey: plan().objectKey,
+      publicPath: plan().publicPath,
+      contentType: "image/jpeg",
+      status: "planned",
+      byteLength: null,
+      sha256: null,
+    }]);
     expect(fetcher).not.toHaveBeenCalled();
     expect(resolver).not.toHaveBeenCalled();
-    expect(targetStore.head).not.toHaveBeenCalled();
+    expect(targetStore.inspect).not.toHaveBeenCalled();
     expect(targetStore.put).not.toHaveBeenCalled();
   });
 
-  it("skips an existing object without downloading or overwriting", async () => {
-    const targetStore = store({ head: vi.fn(async () => true) });
-    const fetcher = vi.fn<typeof fetch>();
+  it("downloads first and accepts a conditional-write race only after exact verification", async () => {
+    const inspect = vi.fn(async () => storedMedia());
+    const put = vi.fn(async () => "exists" as const);
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(imageResponse());
     const result = await importMediaPlans([plan()], {
       execution: execution({ dryRun: false, apply: true }),
       wranglerConfigText: WRANGLER_CONFIG,
       allowedHosts: ["cdn.shopify.com"],
-      store: targetStore,
+      store: store({ inspect, put }),
       download: { fetcher, resolveHost: async () => PUBLIC_IP },
     });
-    expect(result[0].status).toBe("exists");
-    expect(fetcher).not.toHaveBeenCalled();
-    expect(targetStore.put).not.toHaveBeenCalled();
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(put).toHaveBeenCalledTimes(1);
+    expect(inspect).toHaveBeenCalledTimes(1);
+    expect(result[0]).toEqual({
+      objectKey: plan().objectKey,
+      publicPath: plan().publicPath,
+      contentType: "image/jpeg",
+      status: "verified-existing",
+      byteLength: JPEG.byteLength,
+      sha256: expectedMedia().sha256,
+    });
+  });
+
+  it("rejects changed-source collisions and wrong importer metadata without overwriting", async () => {
+    const changedSource = plan({ sourceUrl: "https://cdn.shopify.com/files/replaced-image.jpg" });
+    const put = vi.fn(async () => "exists" as const);
+    await expect(importMediaPlans([changedSource], {
+      execution: execution({ dryRun: false, apply: true }),
+      wranglerConfigText: WRANGLER_CONFIG,
+      allowedHosts: ["cdn.shopify.com"],
+      store: store({ put, inspect: vi.fn(async () => storedMedia()) }),
+      download: { fetcher: vi.fn<typeof fetch>().mockResolvedValue(imageResponse()), resolveHost: async () => PUBLIC_IP },
+    })).rejects.toThrow(/explicit overwrite review/);
+    expect(put).toHaveBeenCalledWith("store-media", changedSource.objectKey, JPEG, expect.objectContaining({ overwrite: false }));
+
+    await expect(importMediaPlans([plan()], {
+      execution: execution({ dryRun: false, apply: true }),
+      wranglerConfigText: WRANGLER_CONFIG,
+      allowedHosts: ["cdn.shopify.com"],
+      store: store({
+        put: vi.fn(async () => "exists" as const),
+        inspect: vi.fn(async () => storedMedia({ importer: "untrusted-importer" })),
+      }),
+      download: { fetcher: vi.fn<typeof fetch>().mockResolvedValue(imageResponse()), resolveHost: async () => PUBLIC_IP },
+    })).rejects.toThrow(/explicit overwrite review/);
+  });
+
+  it("rejects corrupt, partial, or content-type-mismatched existing objects", async () => {
+    for (const existing of [
+      storedMedia({ sha256: "0".repeat(64) }),
+      storedMedia({ byteLength: JPEG.byteLength - 1 }),
+      storedMedia({ contentType: "image/png" }),
+      storedMedia({ importerContentSha256: undefined }),
+    ]) {
+      await expect(importMediaPlans([plan()], {
+        execution: execution({ dryRun: false, apply: true }),
+        wranglerConfigText: WRANGLER_CONFIG,
+        allowedHosts: ["cdn.shopify.com"],
+        store: store({ put: vi.fn(async () => "exists" as const), inspect: vi.fn(async () => existing) }),
+        download: { fetcher: vi.fn<typeof fetch>().mockResolvedValue(imageResponse()), resolveHost: async () => PUBLIC_IP },
+      })).rejects.toThrow(/explicit overwrite review/);
+    }
   });
 
   it("requires target and overwrite confirmations independently", async () => {
@@ -219,8 +313,8 @@ describe("media import execution", () => {
     })).rejects.toThrow(/overwrite confirmation/);
   });
 
-  it("uses the canonical preview bucket and preserves conditional create results", async () => {
-    const put = vi.fn(async () => "exists" as const);
+  it("uses the canonical preview bucket and returns verified persistence details", async () => {
+    const put = vi.fn(async () => "written" as const);
     const targetStore = store({ put });
     const result = await importMediaPlans([plan()], {
       execution: execution({ target: "preview", dryRun: false, apply: true, confirmedPreview: true }),
@@ -232,8 +326,37 @@ describe("media import execution", () => {
         resolveHost: async () => PUBLIC_IP,
       },
     });
-    expect(put).toHaveBeenCalledWith("store-media-preview", plan().objectKey, JPEG, expect.objectContaining({ overwrite: false }));
-    expect(result[0]).toMatchObject({ status: "exists", bytes: 0 });
+    expect(put).toHaveBeenCalledWith("store-media-preview", plan().objectKey, JPEG, expect.objectContaining({
+      overwrite: false,
+      byteLength: JPEG.byteLength,
+      sha256: expectedMedia().sha256,
+      sourceFingerprint: expectedMedia().sourceFingerprint,
+    }));
+    expect(result[0]).toMatchObject({
+      status: "written",
+      byteLength: JPEG.byteLength,
+      sha256: expectedMedia().sha256,
+      publicPath: plan().publicPath,
+    });
+  });
+
+  it("overwrites only after both overwrite flags are explicit", async () => {
+    const put = vi.fn(async () => "written" as const);
+    const inspect = vi.fn(async () => storedMedia({ sha256: "0".repeat(64) }));
+    await importMediaPlans([plan()], {
+      execution: execution({
+        dryRun: false,
+        apply: true,
+        overwrite: true,
+        confirmedOverwrite: true,
+      }),
+      wranglerConfigText: WRANGLER_CONFIG,
+      allowedHosts: ["cdn.shopify.com"],
+      store: store({ put, inspect }),
+      download: { fetcher: vi.fn<typeof fetch>().mockResolvedValue(imageResponse()), resolveHost: async () => PUBLIC_IP },
+    });
+    expect(put).toHaveBeenCalledWith("store-media", plan().objectKey, JPEG, expect.objectContaining({ overwrite: true }));
+    expect(inspect).not.toHaveBeenCalled();
   });
 });
 
@@ -271,11 +394,111 @@ describe("R2 adapters and command construction", () => {
     } as unknown as R2Bucket;
     const adapter = new R2BindingMediaStore("store-media", bucket);
     await expect(adapter.put("store-media", plan().objectKey, JPEG, {
-      contentType: "image/jpeg", cacheControl: "public, max-age=1", overwrite: false,
+      ...expectedMedia(), cacheControl: "public, max-age=1", overwrite: false,
     })).resolves.toBe("exists");
     expect(bucket.put).toHaveBeenCalledWith(plan().objectKey, JPEG, expect.objectContaining({
       onlyIf: { etagDoesNotMatch: "*" },
       httpMetadata: { contentType: "image/jpeg", cacheControl: "public, max-age=1" },
+      customMetadata: expect.objectContaining({
+        "mercora-importer": MEDIA_IMPORTER_VERSION,
+        "mercora-content-sha256": expectedMedia().sha256,
+      }),
+      sha256: expect.any(Uint8Array),
     }));
+  });
+
+  it("inspects binding objects using actual R2 checksum and importer-owned metadata", async () => {
+    const expected = expectedMedia();
+    const bucket = {
+      head: vi.fn(async () => ({
+        size: expected.byteLength,
+        checksums: { sha256: Uint8Array.from(Buffer.from(expected.sha256, "hex")).buffer },
+        httpMetadata: { contentType: expected.contentType, cacheControl: expected.cacheControl },
+        customMetadata: {
+          "mercora-importer": MEDIA_IMPORTER_VERSION,
+          "mercora-source-sha256": expected.sourceFingerprint,
+          "mercora-content-sha256": expected.sha256,
+          "mercora-byte-length": String(expected.byteLength),
+        },
+      })),
+    } as unknown as R2Bucket;
+    const adapter = new R2BindingMediaStore("store-media", bucket);
+    await expect(adapter.inspect("store-media", plan().objectKey)).resolves.toEqual(storedMedia());
+  });
+
+  it("uses S3 conditional PutObject with checksum and importer metadata", async () => {
+    const send = vi.fn(async (command: HeadObjectCommand | PutObjectCommand) => {
+      if (command instanceof PutObjectCommand) return {} as PutObjectCommandOutput;
+      return {} as HeadObjectCommandOutput;
+    });
+    const adapter = new R2S3MediaStore("store-media", { send } as S3CommandSender);
+    await expect(adapter.put("store-media", plan().objectKey, JPEG, {
+      ...expectedMedia(), overwrite: false,
+    })).resolves.toBe("written");
+    const command = send.mock.calls[0][0];
+    expect(command).toBeInstanceOf(PutObjectCommand);
+    expect((command as PutObjectCommand).input).toMatchObject({
+      Bucket: "store-media",
+      Key: plan().objectKey,
+      ContentLength: JPEG.byteLength,
+      ContentType: "image/jpeg",
+      CacheControl: IMMUTABLE_MEDIA_CACHE_CONTROL,
+      ChecksumSHA256: expectedMedia().sha256Base64,
+      IfNoneMatch: "*",
+      Metadata: expect.objectContaining({
+        "mercora-importer": MEDIA_IMPORTER_VERSION,
+        "mercora-source-sha256": expectedMedia().sourceFingerprint,
+      }),
+    });
+  });
+
+  it.each([
+    [409, "ConditionalRequestConflict"],
+    [412, "PreconditionFailed"],
+  ])("maps an S3 conditional race (%s) to exists and re-heads verifiable metadata", async (status, name) => {
+    const expected = expectedMedia();
+    const send = vi.fn(async (command: HeadObjectCommand | PutObjectCommand) => {
+      if (command instanceof PutObjectCommand) {
+        throw Object.assign(new Error("redacted"), { name, $metadata: { httpStatusCode: status } });
+      }
+      return {
+        ContentLength: expected.byteLength,
+        ContentType: expected.contentType,
+        CacheControl: expected.cacheControl,
+        ChecksumSHA256: expected.sha256Base64,
+        Metadata: {
+          "mercora-importer": MEDIA_IMPORTER_VERSION,
+          "mercora-source-sha256": expected.sourceFingerprint,
+          "mercora-content-sha256": expected.sha256,
+          "mercora-byte-length": String(expected.byteLength),
+        },
+      } as unknown as HeadObjectCommandOutput;
+    });
+    const adapter = new R2S3MediaStore("store-media", { send } as S3CommandSender);
+    await expect(adapter.put("store-media", plan().objectKey, JPEG, {
+      ...expected, overwrite: false,
+    })).resolves.toBe("exists");
+    await expect(adapter.inspect("store-media", plan().objectKey)).resolves.toEqual(storedMedia());
+    const head = send.mock.calls[1][0];
+    expect(head).toBeInstanceOf(HeadObjectCommand);
+    expect((head as HeadObjectCommand).input.ChecksumMode).toBe("ENABLED");
+  });
+
+  it("never silently overwrites through either object adapter", async () => {
+    const binding = {
+      put: vi.fn(async () => null),
+    } as unknown as R2Bucket;
+    await new R2BindingMediaStore("store-media", binding).put("store-media", plan().objectKey, JPEG, {
+      ...expectedMedia(), overwrite: false,
+    });
+    expect(binding.put).toHaveBeenCalledWith(expect.any(String), expect.any(Uint8Array), expect.objectContaining({
+      onlyIf: { etagDoesNotMatch: "*" },
+    }));
+
+    const send = vi.fn(async (_command: HeadObjectCommand | PutObjectCommand) => ({} as PutObjectCommandOutput));
+    await new R2S3MediaStore("store-media", { send } as S3CommandSender).put(
+      "store-media", plan().objectKey, JPEG, { ...expectedMedia(), overwrite: false },
+    );
+    expect((send.mock.calls[0][0] as PutObjectCommand).input.IfNoneMatch).toBe("*");
   });
 });

--- a/tests/unit/scripts/shopify-migration/adapters/media.test.ts
+++ b/tests/unit/scripts/shopify-migration/adapters/media.test.ts
@@ -18,6 +18,7 @@ import {
   MEDIA_IMPORTER_VERSION,
   type ExpectedMediaObject,
   type MediaObjectStore,
+  resolveR2S3Timeouts,
   type S3CommandSender,
   type StoredMediaObject,
 } from "@/scripts/shopify-migration/adapters/media/r2";
@@ -591,5 +592,40 @@ describe("R2 adapters and command construction", () => {
       "store-media", plan().objectKey, JPEG, { ...expectedMedia(), overwrite: false },
     );
     expect((send.mock.calls[0][0] as PutObjectCommand).input.IfNoneMatch).toBe("*");
+  });
+
+  it("bounds S3 operations with an abort signal and redacts provider errors", async () => {
+    const providerSecret = "secret-access-key-and-customer-object-name";
+    const signals: AbortSignal[] = [];
+    const send = vi.fn((_command: HeadObjectCommand | PutObjectCommand, options?: { abortSignal?: AbortSignal }) =>
+      new Promise<never>((_resolve, reject) => {
+        const signal = options?.abortSignal;
+        expect(signal).toBeDefined();
+        signals.push(signal!);
+        signal!.addEventListener("abort", () => reject(new Error(providerSecret)), { once: true });
+      }));
+    const adapter = new R2S3MediaStore("store-media", { send } as S3CommandSender, { operationTimeoutMs: 5 });
+
+    await expect(adapter.inspect("store-media", plan().objectKey)).rejects.toThrow("R2 object inspection failed");
+    await expect(adapter.put("store-media", plan().objectKey, JPEG, {
+      ...expectedMedia(), overwrite: false,
+    })).rejects.toThrow("R2 object write failed");
+    expect(signals).toHaveLength(2);
+    expect(signals.every((signal) => signal.aborted)).toBe(true);
+    for (const operation of [
+      adapter.inspect("wrong-bucket", providerSecret),
+      adapter.put("wrong-bucket", providerSecret, JPEG, { ...expectedMedia(), overwrite: false }),
+    ]) await expect(operation).rejects.not.toThrow(providerSecret);
+  });
+
+  it("uses finite bounded operation, connection, request, and socket timeouts", () => {
+    expect(resolveR2S3Timeouts()).toEqual({
+      operationTimeoutMs: 60_000,
+      connectionTimeoutMs: 10_000,
+      requestTimeoutMs: 30_000,
+      socketTimeoutMs: 30_000,
+    });
+    expect(() => resolveR2S3Timeouts({ requestTimeoutMs: 0 })).toThrow(/requestTimeoutMs/);
+    expect(() => resolveR2S3Timeouts({ socketTimeoutMs: 120_001 })).toThrow(/socketTimeoutMs/);
   });
 });

--- a/tests/unit/scripts/shopify-migration/adapters/media.test.ts
+++ b/tests/unit/scripts/shopify-migration/adapters/media.test.ts
@@ -107,6 +107,21 @@ function imageResponse(bytes = JPEG, headers: Record<string, string> = {}): Resp
   return new Response(bytes, { status: 200, headers: { "content-type": "image/jpeg", ...headers } });
 }
 
+function extendedWebp(includePayload: boolean): Uint8Array {
+  const extendedHeader = Buffer.alloc(18);
+  extendedHeader.write("VP8X", 0, "ascii");
+  extendedHeader.writeUInt32LE(10, 4);
+  const chunks = includePayload
+    ? Buffer.concat([extendedHeader, Buffer.from(WEBP).subarray(12)])
+    : extendedHeader;
+  const result = Buffer.alloc(12 + chunks.byteLength);
+  result.write("RIFF", 0, "ascii");
+  result.writeUInt32LE(result.byteLength - 8, 4);
+  result.write("WEBP", 8, "ascii");
+  chunks.copy(result, 12);
+  return Uint8Array.from(result);
+}
+
 describe("safe media downloader", () => {
   it("downloads an allowlisted HTTPS image without forwarding credentials", async () => {
     const fetcher = vi.fn<typeof fetch>(async (_url, init) => {
@@ -282,6 +297,9 @@ describe("safe media downloader", () => {
     excessiveWebpPixels[28] = 0xff;
     excessiveWebpPixels[29] = 0x3f;
     expect(() => verifyImageSignature(excessiveWebpPixels, "image/webp")).toThrow(/signature/);
+
+    expect(() => verifyImageSignature(extendedWebp(false), "image/webp")).toThrow(/signature/);
+    expect(() => verifyImageSignature(extendedWebp(true), "image/webp")).not.toThrow();
   });
 });
 

--- a/tests/unit/scripts/shopify-migration/adapters/media.test.ts
+++ b/tests/unit/scripts/shopify-migration/adapters/media.test.ts
@@ -9,6 +9,7 @@ import {
   importMediaPlans,
   R2BindingMediaStore,
   R2S3MediaStore,
+  verifyImageSignature,
   wranglerR2GetArguments,
   wranglerR2PutArguments,
 } from "@/scripts/shopify-migration/adapters/media";
@@ -21,9 +22,15 @@ import {
   type StoredMediaObject,
 } from "@/scripts/shopify-migration/adapters/media/r2";
 
-const JPEG = new Uint8Array([
-  0xff, 0xd8, 0xff, 0xc0, 0x00, 0x08, 0x08, 0x00, 0x01, 0x00, 0x01, 0x01, 0xff, 0xd9,
-]);
+const JPEG = Uint8Array.from(Buffer.from(
+  "/9j/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAj/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFAEBAAAAAAAAAAAAAAAAAAAAAf/EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAMAwEAAhEDEQA/AJXAIf/Z",
+  "base64",
+));
+const PNG = Uint8Array.from(Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAACXBIWXMAAAPoAAAD6AG1e1JrAAAADElEQVQImWNgZGIGAAAOAAeCcsnOAAAAAElFTkSuQmCC",
+  "base64",
+));
+const WEBP = Uint8Array.from(Buffer.from("UklGRiQAAABXRUJQVlA4IBgAAAAwAQCdASoBAAEAAUAmJaQAA3AA/v0gUAA=", "base64"));
 const PUBLIC_IP = ["93.184.216.34"];
 const WRANGLER_CONFIG = `{
   "r2_buckets": [{
@@ -228,6 +235,53 @@ describe("safe media downloader", () => {
       allowedHosts: ["cdn.shopify.com"], fetcher: fakeJpeg, resolveHost: async () => PUBLIC_IP,
     }))
       .rejects.toThrow(/unsupported/);
+  });
+
+  it("accepts structurally complete JPEG, PNG, and WebP images", async () => {
+    for (const [bytes, extension, contentType] of [
+      [JPEG, "jpg", "image/jpeg"],
+      [PNG, "png", "image/png"],
+      [WEBP, "webp", "image/webp"],
+    ] as const) {
+      const mediaPlan = plan({
+        sourceUrl: `https://cdn.shopify.com/files/image.${extension}`,
+        objectKey: `products/shopify_product_abc/1.${extension}`,
+        publicPath: `/media/products/shopify_product_abc/1.${extension}`,
+        contentType,
+      });
+      await expect(downloadVerifiedMedia(mediaPlan, {
+        allowedHosts: ["cdn.shopify.com"],
+        fetcher: vi.fn<typeof fetch>().mockResolvedValue(imageResponse(bytes, { "content-type": contentType })),
+        resolveHost: async () => PUBLIC_IP,
+      })).resolves.toMatchObject({ bytes, contentType });
+    }
+  });
+
+  it("rejects truncated, trailing-polyglot, and structurally corrupt image containers", () => {
+    for (const [bytes, contentType] of [
+      [JPEG, "image/jpeg"], [PNG, "image/png"], [WEBP, "image/webp"],
+    ] as const) {
+      expect(() => verifyImageSignature(bytes.slice(0, -1), contentType)).toThrow(/signature/);
+      const polyglot = new Uint8Array(bytes.byteLength + 8);
+      polyglot.set(bytes);
+      polyglot.set(Buffer.from("<script>"), bytes.byteLength);
+      expect(() => verifyImageSignature(polyglot, contentType)).toThrow(/signature/);
+    }
+
+    const badPngCrc = PNG.slice();
+    badPngCrc[29] ^= 1;
+    expect(() => verifyImageSignature(badPngCrc, "image/png")).toThrow(/signature/);
+
+    const badWebpSync = WEBP.slice();
+    badWebpSync[23] ^= 1;
+    expect(() => verifyImageSignature(badWebpSync, "image/webp")).toThrow(/signature/);
+
+    const excessiveWebpPixels = WEBP.slice();
+    excessiveWebpPixels[26] = 0xff;
+    excessiveWebpPixels[27] = 0x3f;
+    excessiveWebpPixels[28] = 0xff;
+    excessiveWebpPixels[29] = 0x3f;
+    expect(() => verifyImageSignature(excessiveWebpPixels, "image/webp")).toThrow(/signature/);
   });
 });
 

--- a/tests/unit/scripts/shopify-migration/cli.test.ts
+++ b/tests/unit/scripts/shopify-migration/cli.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import { parseMigrationCli } from "@/scripts/shopify-migration/cli";
+
+const environment = {
+  MIGRATION_INPUT_ROOT: "input",
+  MIGRATION_CURRENCY: "USD",
+  MIGRATION_INVENTORY_LOCATION_ID: "main",
+  MIGRATION_FULFILLMENT_TYPE: "physical",
+  MIGRATION_ACTOR_ID: "user_operator",
+  MIGRATION_FALLBACK_AUTHOR: "Store team",
+  MIGRATION_MEDIA_HOSTS: "cdn.shopify.com,store.myshopify.com",
+  MIGRATION_UNRESOLVED_CUSTOMER: "reject",
+};
+
+describe("Shopify migration CLI", () => {
+  it("defaults to a local dry run with explicit domain inputs", () => {
+    const result = parseMigrationCli(environment, [], "/repo");
+    expect(result.config.execution).toMatchObject({ dryRun: true, apply: false, target: "local" });
+    expect(result.domain).toEqual({
+      currency: "USD",
+      inventoryLocationId: "main",
+      fulfillmentType: "physical",
+      actorId: "user_operator",
+      fallbackAuthor: "Store team",
+      allowedMediaHosts: ["cdn.shopify.com", "store.myshopify.com"],
+      unresolvedCustomer: "reject",
+    });
+    expect(result.projectRoot).toBe("/repo");
+  });
+
+  it("requires every migration-specific domain decision", () => {
+    for (const key of [
+      "MIGRATION_CURRENCY",
+      "MIGRATION_INVENTORY_LOCATION_ID",
+      "MIGRATION_FULFILLMENT_TYPE",
+      "MIGRATION_ACTOR_ID",
+      "MIGRATION_FALLBACK_AUTHOR",
+      "MIGRATION_MEDIA_HOSTS",
+      "MIGRATION_UNRESOLVED_CUSTOMER",
+    ]) {
+      expect(() => parseMigrationCli({ ...environment, [key]: undefined }, [], "/repo")).toThrow();
+    }
+  });
+
+  it("gates Judge.me and attribution inputs behind sensitive confirmation", () => {
+    expect(() => parseMigrationCli(environment, ["--judge-me-file=reviews.csv"], "/repo"))
+      .toThrow("require --include-sensitive");
+    const result = parseMigrationCli(environment, [
+      "--include-sensitive",
+      "--confirm-sensitive-data",
+      "--judge-me-file=reviews.csv",
+      "--review-attributions=attributions.json",
+    ], "/repo");
+    expect(result).toMatchObject({
+      judgeMeFile: "reviews.csv",
+      reviewAttributionsFile: "attributions.json",
+    });
+  });
+
+  it("rejects traversal, duplicate scalar decisions, and implicit remote apply", () => {
+    expect(() => parseMigrationCli(environment, ["--judge-me-file=../reviews.csv"], "/repo")).toThrow();
+    expect(() => parseMigrationCli(environment, ["--currency=USD", "--currency=CAD"], "/repo")).toThrow("once");
+    expect(() => parseMigrationCli(
+      { ...environment, MIGRATION_TARGET: "preview" },
+      ["--apply", "--confirm-preview"],
+      "/repo",
+    )).toThrow("explicit --target");
+  });
+});

--- a/tests/unit/scripts/shopify-migration/cli.test.ts
+++ b/tests/unit/scripts/shopify-migration/cli.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -9,6 +9,7 @@ import {
   createClerkRestMigrationClient,
   createFileMigrationSource,
   createShopifyApiMigrationSource,
+  assertPrivateMigrationRoots,
   parseMigrationCli,
 } from "@/scripts/shopify-migration/cli";
 
@@ -149,6 +150,101 @@ describe("Shopify migration CLI", () => {
     expect(requested.some((path) => path.endsWith("customers.json") || path.endsWith("orders.json"))).toBe(false);
   });
 
+  it("extracts blog articles sequentially with a bounded per-blog pipeline", async () => {
+    let activeArticles = 0;
+    let maximumActiveArticles = 0;
+    const responseRows: Record<string, unknown[]> = {
+      custom_collections: [], smart_collections: [], collects: [], products: [], pages: [], redirects: [],
+      blogs: [{ id: 7, title: "One", handle: "one" }, { id: 8, title: "Two", handle: "two" }],
+      articles: [],
+    };
+    vi.stubGlobal("fetch", vi.fn(async (input: string | URL | Request) => {
+      const url = new URL(input instanceof Request ? input.url : String(input));
+      const isArticle = url.pathname.endsWith("articles.json");
+      if (isArticle) {
+        activeArticles += 1;
+        maximumActiveArticles = Math.max(maximumActiveArticles, activeArticles);
+        await Promise.resolve();
+        activeArticles -= 1;
+      }
+      const key = url.pathname.split("/").at(-1)!.replace(".json", "");
+      return new Response(JSON.stringify({ [key]: responseRows[key] ?? [] }), {
+        headers: { "content-type": "application/json" },
+      });
+    }));
+    const parsed = parseMigrationCli({
+      ...environment,
+      MIGRATION_SOURCE_MODE: "api",
+      SHOPIFY_STORE_URL: "https://store.myshopify.com",
+      SHOPIFY_ACCESS_TOKEN: "private-token",
+      SHOPIFY_API_VERSION: "2026-07",
+    }, [], "/repo");
+    await createShopifyApiMigrationSource(parsed.config, parsed).extract(false);
+    expect(maximumActiveArticles).toBe(1);
+  });
+
+  it("requires read_all_orders confirmation and reconciles the historical source count", async () => {
+    const apiEnvironment = {
+      ...environment,
+      MIGRATION_SOURCE_MODE: "api",
+      SHOPIFY_STORE_URL: "https://store.myshopify.com",
+      SHOPIFY_ACCESS_TOKEN: "private-token",
+      SHOPIFY_API_VERSION: "2026-07",
+    };
+    const sensitive = ["--include-sensitive", "--confirm-sensitive-data"];
+    expect(() => parseMigrationCli(apiEnvironment, sensitive, "/repo")).toThrow("read-all-orders");
+    expect(() => parseMigrationCli(
+      apiEnvironment,
+      [...sensitive, "--confirm-shopify-read-all-orders"],
+      "/repo",
+    )).toThrow("expected Shopify order count");
+
+    const requestedOrders: URL[] = [];
+    vi.stubGlobal("fetch", vi.fn(async (input: string | URL | Request) => {
+      const url = new URL(input instanceof Request ? input.url : String(input));
+      const key = url.pathname.split("/").at(-1)!.replace(".json", "");
+      if (key === "orders") requestedOrders.push(url);
+      const rows = key === "orders" ? [{ id: 1 }] : [];
+      return new Response(JSON.stringify({ [key]: rows }), { headers: { "content-type": "application/json" } });
+    }));
+    const parsed = parseMigrationCli(
+      apiEnvironment,
+      [...sensitive, "--confirm-shopify-read-all-orders", "--expected-shopify-order-count=1"],
+      "/repo",
+    );
+    await expect(createShopifyApiMigrationSource(parsed.config, parsed).extract(true)).resolves.toMatchObject({
+      orders: [{ id: 1 }],
+    });
+    expect(requestedOrders[0].searchParams.get("status")).toBe("any");
+
+    const mismatch = { ...parsed, expectedShopifyOrderCount: 2 };
+    await expect(createShopifyApiMigrationSource(mismatch.config, mismatch).extract(true))
+      .rejects.toThrow("does not match the confirmed source count");
+  });
+
+  it("requires canonical migration roots outside the repository", async () => {
+    const createdProjectRoot = await mkdtemp(join(tmpdir(), "mercora-project-"));
+    const createdOutsideInput = await mkdtemp(join(tmpdir(), "mercora-private-input-"));
+    const createdOutsideOutput = await mkdtemp(join(tmpdir(), "mercora-private-output-"));
+    temporaryDirectories.push(createdProjectRoot, createdOutsideInput, createdOutsideOutput);
+    const projectRoot = await realpath(createdProjectRoot);
+    const outsideInput = await realpath(createdOutsideInput);
+    const outsideOutput = await realpath(createdOutsideOutput);
+    expect(() => assertPrivateMigrationRoots({
+      sourceMode: "file",
+      inputRoot: outsideInput,
+      outputRoot: outsideOutput,
+      execution: parseMigrationCli({ ...environment, MIGRATION_INPUT_ROOT: outsideInput }, [], projectRoot).config.execution,
+    }, projectRoot)).not.toThrow();
+    const inside = join(projectRoot, "input");
+    await mkdir(inside);
+    expect(() => assertPrivateMigrationRoots({
+      sourceMode: "file",
+      inputRoot: inside,
+      execution: parseMigrationCli({ ...environment, MIGRATION_INPUT_ROOT: inside }, [], projectRoot).config.execution,
+    }, projectRoot)).toThrow("outside the project repository");
+  });
+
   it("forwards Clerk abort signals and emits only the narrow migration user shape", async () => {
     const controller = new AbortController();
     const fetchRequest = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
@@ -205,5 +301,37 @@ describe("Shopify migration CLI", () => {
     expect(error).toBeInstanceOf(ClerkRetryableRequestError);
     expect((error as ClerkRetryableRequestError).retryAfterMs).toBe(2_000);
     expect(String(error)).not.toContain("private provider message");
+  });
+
+  it("binds the Clerk secret to the expected instance and environment", async () => {
+    const fetchRequest = vi.fn(async (_input: string | URL | Request, _init?: RequestInit) => new Response(JSON.stringify({
+      id: "ins_preview_store",
+      environment_type: "development",
+    }), { headers: { "content-type": "application/json" } }));
+    const client = createClerkRestMigrationClient("sk_test_private", fetchRequest);
+    await expect(client.verifyTarget("ins_preview_store", "development")).resolves.toBeUndefined();
+    await expect(client.verifyTarget("ins_other_store", "development"))
+      .rejects.toThrow("does not match the confirmed migration target");
+    expect(String(fetchRequest.mock.calls[0][0])).toBe("https://api.clerk.com/v1/instance");
+  });
+
+  it("aborts a stalled Clerk instance preflight at its fixed bound", async () => {
+    vi.useFakeTimers();
+    try {
+      let observedSignal: AbortSignal | undefined;
+      const client = createClerkRestMigrationClient("sk_test_private", vi.fn((_input, init) => {
+        observedSignal = init?.signal as AbortSignal;
+        return new Promise<Response>((_resolve, reject) => {
+          observedSignal!.addEventListener("abort", () => reject(new DOMException("aborted", "AbortError")), { once: true });
+        });
+      }));
+      const pending = client.verifyTarget("ins_preview_store", "development");
+      const rejected = expect(pending).rejects.toBeInstanceOf(ClerkRetryableRequestError);
+      await vi.advanceTimersByTimeAsync(30_000);
+      await rejected;
+      expect(observedSignal?.aborted).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/tests/unit/scripts/shopify-migration/cli.test.ts
+++ b/tests/unit/scripts/shopify-migration/cli.test.ts
@@ -1,6 +1,16 @@
-import { describe, expect, it } from "vitest";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
-import { parseMigrationCli } from "@/scripts/shopify-migration/cli";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ClerkRetryableRequestError } from "@/scripts/shopify-migration/adapters/clerk";
+import {
+  createClerkRestMigrationClient,
+  createFileMigrationSource,
+  createShopifyApiMigrationSource,
+  parseMigrationCli,
+} from "@/scripts/shopify-migration/cli";
 
 const environment = {
   MIGRATION_INPUT_ROOT: "input",
@@ -14,6 +24,12 @@ const environment = {
 };
 
 describe("Shopify migration CLI", () => {
+  const temporaryDirectories: string[] = [];
+  afterEach(async () => {
+    await Promise.all(temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })));
+    vi.unstubAllGlobals();
+  });
+
   it("defaults to a local dry run with explicit domain inputs", () => {
     const result = parseMigrationCli(environment, [], "/repo");
     expect(result.config.execution).toMatchObject({ dryRun: true, apply: false, target: "local" });
@@ -66,5 +82,128 @@ describe("Shopify migration CLI", () => {
       ["--apply", "--confirm-preview"],
       "/repo",
     )).toThrow("explicit --target");
+  });
+
+  it("extracts every public file collection and keeps sensitive files gated", async () => {
+    const root = await mkdtemp(join(tmpdir(), "mercora-shopify-cli-"));
+    temporaryDirectories.push(root);
+    const records: Record<string, unknown[]> = {
+      custom_collections: [{ id: 1, title: "Custom", handle: "custom" }],
+      smart_collections: [{ id: 2, title: "Smart", handle: "smart" }],
+      collects: [],
+      products: [],
+      pages: [],
+      blogs: [],
+      articles: [],
+      redirects: [],
+    };
+    await Promise.all(Object.entries(records).map(([name, rows]) =>
+      writeFile(join(root, `${name}.json`), JSON.stringify(rows), { mode: 0o600 })));
+    const parsed = parseMigrationCli({ ...environment, MIGRATION_INPUT_ROOT: root }, [], "/repo");
+    const result = await createFileMigrationSource(parsed.config, parsed).extract(false);
+    expect(result.collections.map((collection) => collection.collection_type)).toEqual(["custom", "smart"]);
+    expect(result).toMatchObject({ customers: [], orders: [], judgeMeRows: [] });
+  });
+
+  it("extracts the complete public Shopify API graph without sensitive endpoints", async () => {
+    const requested: string[] = [];
+    const responseRows: Record<string, unknown[]> = {
+      custom_collections: [],
+      smart_collections: [],
+      collects: [],
+      products: [],
+      pages: [],
+      blogs: [{ id: 7, title: "Journal", handle: "journal" }],
+      articles: [{ id: 8, blog_id: 7, title: "Post", handle: "post" }],
+      redirects: [],
+    };
+    vi.stubGlobal("fetch", vi.fn(async (input: string | URL | Request) => {
+      const url = new URL(input instanceof Request ? input.url : String(input));
+      requested.push(url.pathname);
+      const filename = url.pathname.split("/").at(-1)!;
+      const key = filename.slice(0, -".json".length);
+      return new Response(JSON.stringify({ [key]: responseRows[key] ?? [] }), {
+        headers: { "content-type": "application/json" },
+      });
+    }));
+    const parsed = parseMigrationCli({
+      ...environment,
+      MIGRATION_SOURCE_MODE: "api",
+      SHOPIFY_STORE_URL: "https://store.myshopify.com",
+      SHOPIFY_ACCESS_TOKEN: "private-token",
+      SHOPIFY_API_VERSION: "2026-07",
+    }, [], "/repo");
+    const result = await createShopifyApiMigrationSource(parsed.config, parsed).extract(false);
+    expect(result.blogs).toHaveLength(1);
+    expect(result.articles).toHaveLength(1);
+    expect(requested).toEqual(expect.arrayContaining([
+      "/admin/api/2026-07/custom_collections.json",
+      "/admin/api/2026-07/smart_collections.json",
+      "/admin/api/2026-07/collects.json",
+      "/admin/api/2026-07/products.json",
+      "/admin/api/2026-07/pages.json",
+      "/admin/api/2026-07/blogs.json",
+      "/admin/api/2026-07/blogs/7/articles.json",
+      "/admin/api/2026-07/redirects.json",
+    ]));
+    expect(requested.some((path) => path.endsWith("customers.json") || path.endsWith("orders.json"))).toBe(false);
+  });
+
+  it("forwards Clerk abort signals and emits only the narrow migration user shape", async () => {
+    const controller = new AbortController();
+    const fetchRequest = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+      expect(init?.signal).toBe(controller.signal);
+      return new Response(JSON.stringify([{ id: "user_existing", external_id: "a".repeat(64), email_addresses: [] }]), {
+        headers: { "content-type": "application/json" },
+      });
+    });
+    const client = createClerkRestMigrationClient("sk_test_private", fetchRequest);
+    const result = await client.users.getUserList(
+      { externalId: ["a".repeat(64)], limit: 2 },
+      { signal: controller.signal },
+    );
+    expect(result).toEqual({ data: [{ id: "user_existing", externalId: "a".repeat(64) }] });
+    const [url, init] = fetchRequest.mock.calls[0];
+    expect(String(url)).toContain(`external_id=${"a".repeat(64)}`);
+    expect(new Headers(init?.headers).get("authorization")).toBe("Bearer sk_test_private");
+  });
+
+  it("actually cancels a stalled Clerk request through the supplied signal", async () => {
+    const controller = new AbortController();
+    let observedSignal: AbortSignal | null = null;
+    const stalledFetch = vi.fn((_input: string | URL | Request, init?: RequestInit) => {
+      observedSignal = init?.signal as AbortSignal;
+      return new Promise<Response>((_resolve, reject) => {
+        observedSignal!.addEventListener("abort", () => reject(new DOMException("aborted", "AbortError")), { once: true });
+      });
+    });
+    const pending = createClerkRestMigrationClient("sk_test_private", stalledFetch).users.getUserList(
+      { emailAddress: ["customer@example.test"], limit: 2 },
+      { signal: controller.signal },
+    );
+    await vi.waitFor(() => expect(observedSignal).toBe(controller.signal));
+    controller.abort();
+    await expect(pending).rejects.toBeInstanceOf(ClerkRetryableRequestError);
+    expect(observedSignal!.aborted).toBe(true);
+  });
+
+  it("maps SDK-shaped Clerk throttling without exposing its response", async () => {
+    const sdkError = Object.assign(new Error("provider payload must remain private"), {
+      clerkError: true,
+      status: 429,
+      retryAfter: 2,
+      errors: [{ message: "private provider message" }],
+    });
+    const client = createClerkRestMigrationClient(
+      "sk_test_private",
+      vi.fn(async () => { throw sdkError; }),
+    );
+    const error = await client.users.getUserList(
+      { externalId: ["a".repeat(64)], limit: 2 },
+      { signal: new AbortController().signal },
+    ).catch((value: unknown) => value);
+    expect(error).toBeInstanceOf(ClerkRetryableRequestError);
+    expect((error as ClerkRetryableRequestError).retryAfterMs).toBe(2_000);
+    expect(String(error)).not.toContain("private provider message");
   });
 });

--- a/tests/unit/scripts/shopify-migration/config.test.ts
+++ b/tests/unit/scripts/shopify-migration/config.test.ts
@@ -14,6 +14,8 @@ describe("Shopify migration config", () => {
       confirmedPreview: false,
       confirmedProduction: false,
       confirmedOverwrite: false,
+      createClerkUsers: false,
+      confirmedClerkAutoVerification: false,
     });
     expect(config).not.toHaveProperty("wranglerEnvironment");
     expect(config.inputRoot).toBe("/operator/imports");
@@ -91,6 +93,49 @@ describe("Shopify migration config", () => {
       { MIGRATION_INPUT_ROOT: "input" },
       ["--apply", "--overwrite", "--confirm-overwrite"],
     ).execution).toMatchObject({ apply: true, overwrite: true, confirmedOverwrite: true });
+  });
+
+  it("requires independent Clerk creation and auto-verification confirmations", () => {
+    const base = ["--apply", "--include-sensitive", "--confirm-sensitive-data"];
+    expect(() => parseMigrationConfig(
+      { MIGRATION_INPUT_ROOT: "input" },
+      [...base, "--create-clerk-users"],
+    )).toThrow("--confirm-clerk-auto-verification");
+    expect(() => parseMigrationConfig(
+      { MIGRATION_INPUT_ROOT: "input" },
+      ["--apply", "--confirm-clerk-auto-verification"],
+    )).toThrow("requires --create-clerk-users");
+    expect(() => parseMigrationConfig(
+      { MIGRATION_INPUT_ROOT: "input" },
+      ["--create-clerk-users", "--confirm-clerk-auto-verification", "--include-sensitive", "--confirm-sensitive-data"],
+    )).toThrow("may only be used with --apply");
+    expect(() => parseMigrationConfig(
+      { MIGRATION_INPUT_ROOT: "input" },
+      ["--apply", "--create-clerk-users", "--confirm-clerk-auto-verification"],
+    )).toThrow("requires --include-sensitive");
+
+    const config = parseMigrationConfig(
+      { MIGRATION_INPUT_ROOT: "input" },
+      [...base, "--create-clerk-users", "--confirm-clerk-auto-verification"],
+    );
+    expect(config.execution).toMatchObject({
+      apply: true,
+      includeSensitive: true,
+      confirmedSensitiveData: true,
+      createClerkUsers: true,
+      confirmedClerkAutoVerification: true,
+    });
+  });
+
+  it("rejects duplicate Clerk provisioning flags", () => {
+    expect(() => parseMigrationConfig(
+      { MIGRATION_INPUT_ROOT: "input" },
+      ["--create-clerk-users", "--create-clerk-users"],
+    )).toThrow("may only be provided once");
+    expect(() => parseMigrationConfig(
+      { MIGRATION_INPUT_ROOT: "input" },
+      ["--confirm-clerk-auto-verification", "--confirm-clerk-auto-verification"],
+    )).toThrow("may only be provided once");
   });
 
   it("accepts a bounded Wrangler environment without resource-name overrides", () => {

--- a/tests/unit/scripts/shopify-migration/config.test.ts
+++ b/tests/unit/scripts/shopify-migration/config.test.ts
@@ -63,6 +63,10 @@ describe("Shopify migration config", () => {
       { MIGRATION_INPUT_ROOT: "input" },
       ["--apply", "--target=preview"],
     )).toThrow("--confirm-preview");
+    expect(() => parseMigrationConfig(
+      { MIGRATION_INPUT_ROOT: "input", MIGRATION_TARGET: "production", MERCORA_ALLOW_PRODUCTION_IMPORTS: "1" },
+      ["--apply", "--confirm-production"],
+    )).toThrow("explicit --target=preview or --target=production");
 
     const config = parseMigrationConfig(
       { MIGRATION_INPUT_ROOT: "input", MERCORA_ALLOW_PRODUCTION_IMPORTS: "1" },
@@ -103,6 +107,8 @@ describe("Shopify migration config", () => {
     expect(config).not.toHaveProperty("r2BucketName");
     expect(() => parseMigrationConfig({ MIGRATION_INPUT_ROOT: "input" }, ["--env=../../prod"]))
       .toThrow("environment name");
+    expect(() => parseMigrationConfig({ MIGRATION_INPUT_ROOT: "input" }, ["--env="]))
+      .toThrow("non-empty Wrangler environment");
   });
 
   it("rejects unknown options and contradictory execution modes", () => {

--- a/tests/unit/scripts/shopify-migration/config.test.ts
+++ b/tests/unit/scripts/shopify-migration/config.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { parseMigrationConfig, validateShopifyOrigin } from "@/scripts/shopify-migration/lib/config";
+
+describe("Shopify migration config", () => {
+  it("defaults to a zero-write local dry run without target resource defaults", () => {
+    const config = parseMigrationConfig({ MIGRATION_INPUT_ROOT: "imports" }, [], "/operator");
+    expect(config.execution).toEqual({
+      dryRun: true,
+      apply: false,
+      target: "local",
+      includeSensitive: false,
+      overwrite: false,
+      confirmedSensitiveData: false,
+      confirmedProduction: false,
+    });
+    expect(config).not.toHaveProperty("d1DatabaseName");
+    expect(config).not.toHaveProperty("r2BucketName");
+    expect(config.inputRoot).toBe("/operator/imports");
+  });
+
+  it.each([
+    "http://shop.myshopify.com",
+    "https://myshopify.com",
+    "https://shop.myshopify.com.evil.test",
+    "https://user:pass@shop.myshopify.com",
+    "https://shop.myshopify.com:8443",
+    "https://shop.myshopify.com/admin",
+    "https://shop.myshopify.com?token=x",
+    "https://shop.myshopify.com/#fragment",
+  ])("rejects hostile or non-origin store URL %s", (origin) => {
+    expect(() => validateShopifyOrigin(origin)).toThrow(/exact HTTPS|valid HTTPS/);
+  });
+
+  it("requires an explicit token, store, and API version in API mode", () => {
+    expect(() => parseMigrationConfig({}, ["--source=api"])).toThrow("SHOPIFY_STORE_URL");
+    expect(() => parseMigrationConfig({ SHOPIFY_STORE_URL: "https://shop.myshopify.com" }, ["--source=api"]))
+      .toThrow("SHOPIFY_ACCESS_TOKEN");
+    expect(() => parseMigrationConfig({
+      SHOPIFY_STORE_URL: "https://shop.myshopify.com",
+      SHOPIFY_ACCESS_TOKEN: "secret",
+    }, ["--source=api"])).toThrow("SHOPIFY_API_VERSION");
+  });
+
+  it("accepts only explicit quarterly API versions", () => {
+    expect(() => parseMigrationConfig({
+      SHOPIFY_STORE_URL: "https://shop.myshopify.com",
+      SHOPIFY_ACCESS_TOKEN: "secret",
+      SHOPIFY_API_VERSION: "latest",
+    }, ["--source=api"])).toThrow(/quarterly version/);
+  });
+
+  it("requires explicit confirmations for sensitive data and production writes", () => {
+    expect(() => parseMigrationConfig({ MIGRATION_INPUT_ROOT: "input" }, ["--include-sensitive"]))
+      .toThrow("--confirm-sensitive-data");
+    expect(() => parseMigrationConfig({ MIGRATION_INPUT_ROOT: "input" }, ["--apply", "--target=production"]))
+      .toThrow("--confirm-production");
+
+    const config = parseMigrationConfig(
+      { MIGRATION_INPUT_ROOT: "input" },
+      ["--apply", "--target=production", "--confirm-production", "--include-sensitive", "--confirm-sensitive-data"],
+    );
+    expect(config.execution).toMatchObject({
+      apply: true,
+      dryRun: false,
+      target: "production",
+      includeSensitive: true,
+      confirmedProduction: true,
+      confirmedSensitiveData: true,
+    });
+  });
+
+  it("rejects unknown options and contradictory execution modes", () => {
+    expect(() => parseMigrationConfig({ MIGRATION_INPUT_ROOT: "input" }, ["--delete-all"])).toThrow("Unknown");
+    expect(() => parseMigrationConfig({ MIGRATION_INPUT_ROOT: "input" }, ["--apply", "--dry-run"]))
+      .toThrow("mutually exclusive");
+  });
+});

--- a/tests/unit/scripts/shopify-migration/config.test.ts
+++ b/tests/unit/scripts/shopify-migration/config.test.ts
@@ -11,10 +11,11 @@ describe("Shopify migration config", () => {
       includeSensitive: false,
       overwrite: false,
       confirmedSensitiveData: false,
+      confirmedPreview: false,
       confirmedProduction: false,
+      confirmedOverwrite: false,
     });
-    expect(config).not.toHaveProperty("d1DatabaseName");
-    expect(config).not.toHaveProperty("r2BucketName");
+    expect(config).not.toHaveProperty("wranglerEnvironment");
     expect(config.inputRoot).toBe("/operator/imports");
   });
 
@@ -49,14 +50,22 @@ describe("Shopify migration config", () => {
     }, ["--source=api"])).toThrow(/quarterly version/);
   });
 
-  it("requires explicit confirmations for sensitive data and production writes", () => {
+  it("requires explicit confirmations for sensitive data and remote writes", () => {
     expect(() => parseMigrationConfig({ MIGRATION_INPUT_ROOT: "input" }, ["--include-sensitive"]))
       .toThrow("--confirm-sensitive-data");
     expect(() => parseMigrationConfig({ MIGRATION_INPUT_ROOT: "input" }, ["--apply", "--target=production"]))
       .toThrow("--confirm-production");
+    expect(() => parseMigrationConfig(
+      { MIGRATION_INPUT_ROOT: "input" },
+      ["--apply", "--target=production", "--confirm-production"],
+    )).toThrow("MERCORA_ALLOW_PRODUCTION_IMPORTS=1");
+    expect(() => parseMigrationConfig(
+      { MIGRATION_INPUT_ROOT: "input" },
+      ["--apply", "--target=preview"],
+    )).toThrow("--confirm-preview");
 
     const config = parseMigrationConfig(
-      { MIGRATION_INPUT_ROOT: "input" },
+      { MIGRATION_INPUT_ROOT: "input", MERCORA_ALLOW_PRODUCTION_IMPORTS: "1" },
       ["--apply", "--target=production", "--confirm-production", "--include-sensitive", "--confirm-sensitive-data"],
     );
     expect(config.execution).toMatchObject({
@@ -69,9 +78,40 @@ describe("Shopify migration config", () => {
     });
   });
 
+  it("requires an independent overwrite confirmation for writes", () => {
+    expect(() => parseMigrationConfig(
+      { MIGRATION_INPUT_ROOT: "input" },
+      ["--apply", "--overwrite"],
+    )).toThrow("--confirm-overwrite");
+    expect(parseMigrationConfig(
+      { MIGRATION_INPUT_ROOT: "input" },
+      ["--apply", "--overwrite", "--confirm-overwrite"],
+    ).execution).toMatchObject({ apply: true, overwrite: true, confirmedOverwrite: true });
+  });
+
+  it("accepts a bounded Wrangler environment without resource-name overrides", () => {
+    const config = parseMigrationConfig(
+      {
+        MIGRATION_INPUT_ROOT: "input",
+        MIGRATION_D1_DATABASE: "typo-database",
+        MIGRATION_R2_BUCKET: "typo-bucket",
+      },
+      ["--env=staging"],
+    );
+    expect(config.wranglerEnvironment).toBe("staging");
+    expect(config).not.toHaveProperty("d1DatabaseName");
+    expect(config).not.toHaveProperty("r2BucketName");
+    expect(() => parseMigrationConfig({ MIGRATION_INPUT_ROOT: "input" }, ["--env=../../prod"]))
+      .toThrow("environment name");
+  });
+
   it("rejects unknown options and contradictory execution modes", () => {
     expect(() => parseMigrationConfig({ MIGRATION_INPUT_ROOT: "input" }, ["--delete-all"])).toThrow("Unknown");
     expect(() => parseMigrationConfig({ MIGRATION_INPUT_ROOT: "input" }, ["--apply", "--dry-run"]))
       .toThrow("mutually exclusive");
+    expect(() => parseMigrationConfig(
+      { MIGRATION_INPUT_ROOT: "input" },
+      ["--confirm-sensitive-data"],
+    )).toThrow("requires --include-sensitive");
   });
 });

--- a/tests/unit/scripts/shopify-migration/d1-sql.test.ts
+++ b/tests/unit/scripts/shopify-migration/d1-sql.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  MAX_D1_STATEMENT_BYTES,
+  buildInsertStatement,
+  chunkSqlStatements,
+  sqlLiteral,
+} from "@/scripts/shopify-migration/adapters/d1/sql";
+
+describe("D1 migration SQL", () => {
+  it("quotes values without accepting executable identifiers or unsafe numbers", () => {
+    expect(sqlLiteral("Merchant's title\nnext line")).toBe("'Merchant''s title\nnext line'");
+    expect(sqlLiteral(true)).toBe("1");
+    expect(sqlLiteral(null)).toBe("NULL");
+    expect(() => sqlLiteral(Number.NaN)).toThrow(/safe integers/);
+    expect(() => buildInsertStatement({ table: "orders; DROP TABLE orders", row: { id: "one" } }))
+      .toThrow(/identifier/);
+  });
+
+  it("builds insert-only and explicit overwrite statements", () => {
+    expect(buildInsertStatement({
+      table: "pages",
+      row: { slug: "about", title: "About" },
+      conflictColumns: ["slug"],
+      mode: "insert-only",
+    })).toContain('ON CONFLICT ("slug") DO NOTHING');
+    expect(buildInsertStatement({
+      table: "products",
+      row: { id: "product_one", name: "One", status: "active" },
+      conflictColumns: ["id"],
+      mode: "overwrite",
+    })).toContain('DO UPDATE SET "name" = excluded."name", "status" = excluded."status"');
+  });
+
+  it("makes an idempotent compare mismatch fail through a NOT NULL guard", () => {
+    const statement = buildInsertStatement({
+      table: "products",
+      row: { id: "product_one", name: "One", status: "active" },
+      conflictColumns: ["id"],
+      mode: "compare",
+      guardColumn: "name",
+    });
+    expect(statement).toContain('"products"."status" IS excluded."status"');
+    expect(statement).toContain('ELSE NULL END');
+    expect(() => buildInsertStatement({
+      table: "products",
+      row: { id: "product_one", name: null },
+      conflictColumns: ["id"],
+      mode: "compare",
+      guardColumn: "name",
+    })).toThrow(/non-null/);
+  });
+
+  it("rejects statements that could exceed D1's per-statement limit", () => {
+    const hostile = "'".repeat(MAX_D1_STATEMENT_BYTES);
+    expect(() => buildInsertStatement({ table: "pages", row: { slug: "one", content: hostile } }))
+      .toThrow(/safety limit/);
+  });
+
+  it("chunks complete statements by count and UTF-8 bytes", () => {
+    const statements = [
+      buildInsertStatement({ table: "pages", row: { slug: "one" } }),
+      buildInsertStatement({ table: "pages", row: { slug: "two" } }),
+      buildInsertStatement({ table: "pages", row: { slug: "three" } }),
+    ];
+    const chunks = chunkSqlStatements(statements, { maxStatements: 2, maxBytes: 512 });
+    expect(chunks).toHaveLength(2);
+    expect(chunks[0].match(/INSERT/g)).toHaveLength(2);
+    expect(chunks[1].match(/INSERT/g)).toHaveLength(1);
+    expect(chunks.every((chunk) => chunk.endsWith(";\n"))).toBe(true);
+  });
+});

--- a/tests/unit/scripts/shopify-migration/file-reader.test.ts
+++ b/tests/unit/scripts/shopify-migration/file-reader.test.ts
@@ -1,0 +1,52 @@
+import { mkdtempSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { rmSync } from "node:fs";
+import { readCsvFile, readJsonFile, resolveInputFile } from "@/scripts/shopify-migration/lib/file-reader";
+
+const roots: string[] = [];
+function root(): string {
+  const value = mkdtempSync(join(tmpdir(), "mercora-shopify-reader-"));
+  roots.push(value);
+  return value;
+}
+
+afterEach(() => {
+  for (const path of roots.splice(0)) rmSync(path, { recursive: true, force: true });
+});
+
+describe("bounded migration file readers", () => {
+  it("reads bounded CSV and JSON array wrappers", () => {
+    const input = root();
+    writeFileSync(join(input, "rows.csv"), "id,title\n1,Example Product\n", "utf8");
+    writeFileSync(join(input, "rows.json"), JSON.stringify({ products: [{ id: 1 }] }), "utf8");
+    expect(readCsvFile(input, "rows.csv")).toEqual([{ id: "1", title: "Example Product" }]);
+    expect(readJsonFile(input, "rows.json")).toEqual([{ id: 1 }]);
+  });
+
+  it("rejects traversal, absolute paths, and symlink escapes", () => {
+    const input = root();
+    const outside = root();
+    writeFileSync(join(outside, "secret.csv"), "email\ncustomer@example.test\n", "utf8");
+    symlinkSync(join(outside, "secret.csv"), join(input, "link.csv"));
+    expect(() => resolveInputFile(input, "../secret.csv")).toThrow(/escapes/);
+    expect(() => resolveInputFile(input, join(outside, "secret.csv"))).toThrow(/relative/);
+    expect(() => resolveInputFile(input, "link.csv")).toThrow(/symlink escapes/);
+  });
+
+  it("rejects oversized files and excessive record counts", () => {
+    const input = root();
+    writeFileSync(join(input, "large.json"), JSON.stringify([{ id: 1 }, { id: 2 }]), "utf8");
+    expect(() => readJsonFile(input, "large.json", { maxBytes: 5 })).toThrow(/byte limit/);
+    expect(() => readJsonFile(input, "large.json", { maxRecords: 1 })).toThrow(/more than 1 records/);
+  });
+
+  it("rejects duplicate CSV headings and oversized records", () => {
+    const input = root();
+    writeFileSync(join(input, "duplicate.csv"), "id,id\n1,2\n", "utf8");
+    writeFileSync(join(input, "record.csv"), `id\n${"x".repeat(20)}\n`, "utf8");
+    expect(() => readCsvFile(input, "duplicate.csv")).toThrow(/duplicate/);
+    expect(() => readCsvFile(input, "record.csv", { maxRecordBytes: 10 })).toThrow();
+  });
+});

--- a/tests/unit/scripts/shopify-migration/orchestrator.test.ts
+++ b/tests/unit/scripts/shopify-migration/orchestrator.test.ts
@@ -1,21 +1,37 @@
 import { describe, expect, it, vi } from "vitest";
 
-import type { ClerkMigrationClient } from "@/scripts/shopify-migration/adapters/clerk";
 import type { CommandRunner } from "@/scripts/shopify-migration/adapters/d1";
 import type { MediaObjectStore } from "@/scripts/shopify-migration/adapters/media";
 import type { ExecutionPlan, MigrationConfig } from "@/scripts/shopify-migration/lib/config";
+import type { MediaRewrite } from "@/scripts/shopify-migration/transformers/_shared";
 import {
   orchestrateMigration,
   type MigrationAdapterRunners,
   type MigrationApplyFactories,
   type MigrationSource,
   type MigrationSourceBundle,
+  type TargetBoundClerkMigrationClient,
 } from "@/scripts/shopify-migration/orchestrator";
 
+const accountId = "a".repeat(32);
+const clerkInstanceId = "ins_preview_store";
 const wranglerConfig = JSON.stringify({
-  d1_databases: [{ binding: "DB", database_name: "migration-db", database_id: "db-id" }],
-  r2_buckets: [{ binding: "MEDIA", bucket_name: "migration-media" }],
+  account_id: accountId,
+  vars: { CLERK_INSTANCE_ID: clerkInstanceId },
+  d1_databases: [{
+    binding: "DB", database_name: "migration-db", database_id: "db-id", preview_database_id: "preview-db-id",
+  }],
+  r2_buckets: [{ binding: "MEDIA", bucket_name: "migration-media", preview_bucket_name: "migration-media-preview" }],
 });
+
+const preflightReceipt = {
+  version: 1 as const,
+  target: "preview" as const,
+  databaseName: "migration-db",
+  databaseId: "preview-db-id",
+  environment: null,
+  projectDigest: "b".repeat(64),
+};
 
 function execution(overrides: Partial<ExecutionPlan> = {}): ExecutionPlan {
   return {
@@ -125,15 +141,25 @@ describe("Shopify migration orchestrator", () => {
   it("applies strictly in media, Clerk, then D1 order", async () => {
     const events: string[] = [];
     const mediaStore = {} as MediaObjectStore;
-    const clerkClient = {} as ClerkMigrationClient;
+    const clerkClient = {
+      verifyTarget: vi.fn(async () => { events.push("clerk-preflight"); }),
+    } as unknown as TargetBoundClerkMigrationClient;
     const commandRunner = {} as CommandRunner;
     const plan = execution({
       dryRun: false,
       apply: true,
+      target: "preview",
       includeSensitive: true,
       confirmedSensitiveData: true,
+      confirmedPreview: true,
     });
     const records = bundle({
+      collections: [{
+        id: 1,
+        title: "Tea",
+        handle: "tea",
+        image: { src: "https://cdn.shopify.com/tea.jpg", width: 100, height: 100 },
+      }],
       customers: [{
         id: 42,
         email: "customer@example.test",
@@ -147,7 +173,18 @@ describe("Shopify migration orchestrator", () => {
       createCommandRunner: vi.fn(() => { events.push("d1-factory"); return commandRunner; }),
     };
     const runners: MigrationAdapterRunners = {
-      importMedia: vi.fn(async () => { events.push("media-run"); return []; }),
+      preflightD1: vi.fn(async () => { events.push("d1-preflight"); return preflightReceipt; }),
+      importMedia: vi.fn(async (plans: readonly MediaRewrite[]) => {
+        events.push("media-run");
+        return plans.map((media) => ({
+          objectKey: media.objectKey,
+          publicPath: media.publicPath,
+          contentType: media.contentType,
+          status: "written" as const,
+          byteLength: 10,
+          sha256: "c".repeat(64),
+        }));
+      }),
       provisionClerk: vi.fn(async (plans) => {
         events.push("clerk-run");
         return {
@@ -169,21 +206,170 @@ describe("Shopify migration orchestrator", () => {
       source: source(records),
       projectRoot: "/repo",
       wranglerConfigText: wranglerConfig,
+      remoteTargetBinding: { cloudflareAccountId: accountId, clerkInstanceId },
       applyFactories: factories,
       runners,
       now: () => new Date("2026-08-14T12:00:00.000Z"),
     });
 
     expect(events).toEqual([
+      "d1-factory",
+      "d1-preflight",
+      "clerk-factory",
+      "clerk-preflight",
       "media-factory",
       "media-run",
-      "clerk-factory",
       "clerk-run",
-      "d1-factory",
       "d1-run",
     ]);
-    expect(result).toMatchObject({ dryRun: false, clerk: { created: 1 }, media: { persisted: 0 } });
+    expect(result).toMatchObject({ dryRun: false, clerk: { created: 1 }, media: { persisted: 1 } });
     expect(JSON.stringify(result)).not.toContain("customer@example.test");
     expect(JSON.stringify(result)).not.toContain("Private");
+  });
+
+  it("rejects local external-write plans before constructing any adapter", async () => {
+    const factories: MigrationApplyFactories = {
+      createMediaStore: vi.fn(),
+      createClerkClient: vi.fn(),
+      createCommandRunner: vi.fn(),
+    };
+    await expect(orchestrateMigration({
+      config: config(execution({
+        dryRun: false,
+        apply: true,
+        includeSensitive: true,
+        confirmedSensitiveData: true,
+      })),
+      domain,
+      source: source(bundle({
+        collections: [{ id: 1, title: "Tea", handle: "tea", image: { src: "https://cdn.shopify.com/tea.jpg" } }],
+        customers: [{ id: 42, email: "customer@example.test", verified_email: true }],
+      })),
+      projectRoot: "/repo",
+      wranglerConfigText: wranglerConfig,
+      applyFactories: factories,
+      runners: {} as MigrationAdapterRunners,
+    })).rejects.toThrow("Local apply cannot use remote R2 or Clerk");
+    expect(factories.createCommandRunner).not.toHaveBeenCalled();
+    expect(factories.createMediaStore).not.toHaveBeenCalled();
+    expect(factories.createClerkClient).not.toHaveBeenCalled();
+  });
+
+  it("rejects remote target identity mismatches before preflight or client construction", async () => {
+    const factories: MigrationApplyFactories = {
+      createMediaStore: vi.fn(),
+      createClerkClient: vi.fn(),
+      createCommandRunner: vi.fn(),
+    };
+    const preflightD1 = vi.fn();
+    const preview = execution({ dryRun: false, apply: true, target: "preview", confirmedPreview: true });
+    await expect(orchestrateMigration({
+      config: config(preview),
+      domain,
+      source: source(bundle()),
+      projectRoot: "/repo",
+      wranglerConfigText: wranglerConfig,
+      remoteTargetBinding: { cloudflareAccountId: "f".repeat(32) },
+      applyFactories: factories,
+      runners: { preflightD1 } as unknown as MigrationAdapterRunners,
+    })).rejects.toThrow("Cloudflare credential account does not match");
+    expect(preflightD1).not.toHaveBeenCalled();
+    expect(factories.createCommandRunner).not.toHaveBeenCalled();
+    expect(factories.createMediaStore).not.toHaveBeenCalled();
+    expect(factories.createClerkClient).not.toHaveBeenCalled();
+  });
+
+  it("rejects a Clerk instance mismatch before D1 preflight or client construction", async () => {
+    const factories: MigrationApplyFactories = {
+      createMediaStore: vi.fn(),
+      createClerkClient: vi.fn(),
+      createCommandRunner: vi.fn(),
+    };
+    const preflightD1 = vi.fn();
+    const preview = execution({
+      dryRun: false,
+      apply: true,
+      target: "preview",
+      confirmedPreview: true,
+      includeSensitive: true,
+      confirmedSensitiveData: true,
+    });
+    await expect(orchestrateMigration({
+      config: config(preview),
+      domain,
+      source: source(bundle({ customers: [{ id: 42, email: "customer@example.test", verified_email: true }] })),
+      projectRoot: "/repo",
+      wranglerConfigText: wranglerConfig,
+      remoteTargetBinding: { cloudflareAccountId: accountId, clerkInstanceId: "ins_wrong_store" },
+      applyFactories: factories,
+      runners: { preflightD1 } as unknown as MigrationAdapterRunners,
+    })).rejects.toThrow("Clerk instance does not match");
+    expect(preflightD1).not.toHaveBeenCalled();
+    expect(factories.createCommandRunner).not.toHaveBeenCalled();
+    expect(factories.createClerkClient).not.toHaveBeenCalled();
+  });
+
+  it("runs D1 preflight before constructing mutating media or Clerk adapters", async () => {
+    const factories: MigrationApplyFactories = {
+      createMediaStore: vi.fn(),
+      createClerkClient: vi.fn(),
+      createCommandRunner: vi.fn(() => ({} as CommandRunner)),
+    };
+    const preflightD1 = vi.fn(async () => { throw new Error("D1 preflight failed"); });
+    await expect(orchestrateMigration({
+      config: config(execution({ dryRun: false, apply: true, target: "preview", confirmedPreview: true })),
+      domain,
+      source: source(bundle({
+        collections: [{ id: 1, title: "Tea", handle: "tea", image: { src: "https://cdn.shopify.com/tea.jpg" } }],
+      })),
+      projectRoot: "/repo",
+      wranglerConfigText: wranglerConfig,
+      remoteTargetBinding: { cloudflareAccountId: accountId },
+      applyFactories: factories,
+      runners: { preflightD1 } as unknown as MigrationAdapterRunners,
+    })).rejects.toThrow("D1 preflight failed");
+    expect(preflightD1).toHaveBeenCalledOnce();
+    expect(factories.createMediaStore).not.toHaveBeenCalled();
+    expect(factories.createClerkClient).not.toHaveBeenCalled();
+  });
+
+  it("stops after a Clerk credential-instance mismatch without constructing media or running writes", async () => {
+    const verifyTarget = vi.fn(async () => { throw new Error("Clerk credential instance does not match"); });
+    const factories: MigrationApplyFactories = {
+      createMediaStore: vi.fn(),
+      createClerkClient: vi.fn(async () => ({ verifyTarget } as unknown as TargetBoundClerkMigrationClient)),
+      createCommandRunner: vi.fn(() => ({} as CommandRunner)),
+    };
+    const provisionClerk = vi.fn();
+    const runD1 = vi.fn();
+    await expect(orchestrateMigration({
+      config: config(execution({
+        dryRun: false,
+        apply: true,
+        target: "preview",
+        confirmedPreview: true,
+        includeSensitive: true,
+        confirmedSensitiveData: true,
+      })),
+      domain,
+      source: source(bundle({
+        collections: [{ id: 1, title: "Tea", handle: "tea", image: { src: "https://cdn.shopify.com/tea.jpg" } }],
+        customers: [{ id: 42, email: "customer@example.test", verified_email: true }],
+      })),
+      projectRoot: "/repo",
+      wranglerConfigText: wranglerConfig,
+      remoteTargetBinding: { cloudflareAccountId: accountId, clerkInstanceId },
+      applyFactories: factories,
+      runners: {
+        preflightD1: vi.fn(async () => preflightReceipt),
+        importMedia: vi.fn(),
+        provisionClerk,
+        runD1,
+      } as unknown as MigrationAdapterRunners,
+    })).rejects.toThrow("Clerk credential instance does not match");
+    expect(verifyTarget).toHaveBeenCalledWith(clerkInstanceId, "development");
+    expect(factories.createMediaStore).not.toHaveBeenCalled();
+    expect(provisionClerk).not.toHaveBeenCalled();
+    expect(runD1).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/scripts/shopify-migration/orchestrator.test.ts
+++ b/tests/unit/scripts/shopify-migration/orchestrator.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { ClerkMigrationClient } from "@/scripts/shopify-migration/adapters/clerk";
+import type { CommandRunner } from "@/scripts/shopify-migration/adapters/d1";
+import type { MediaObjectStore } from "@/scripts/shopify-migration/adapters/media";
+import type { ExecutionPlan, MigrationConfig } from "@/scripts/shopify-migration/lib/config";
+import {
+  orchestrateMigration,
+  type MigrationAdapterRunners,
+  type MigrationApplyFactories,
+  type MigrationSource,
+  type MigrationSourceBundle,
+} from "@/scripts/shopify-migration/orchestrator";
+
+const wranglerConfig = JSON.stringify({
+  d1_databases: [{ binding: "DB", database_name: "migration-db", database_id: "db-id" }],
+  r2_buckets: [{ binding: "MEDIA", bucket_name: "migration-media" }],
+});
+
+function execution(overrides: Partial<ExecutionPlan> = {}): ExecutionPlan {
+  return {
+    dryRun: true,
+    apply: false,
+    target: "local",
+    includeSensitive: false,
+    overwrite: false,
+    confirmedSensitiveData: false,
+    confirmedPreview: false,
+    confirmedProduction: false,
+    confirmedOverwrite: false,
+    createClerkUsers: false,
+    confirmedClerkAutoVerification: false,
+    ...overrides,
+  };
+}
+
+function config(plan = execution()): MigrationConfig {
+  return { sourceMode: "file", inputRoot: "/input", execution: plan };
+}
+
+function bundle(overrides: Partial<MigrationSourceBundle> = {}): MigrationSourceBundle {
+  return {
+    collections: [],
+    collects: [],
+    products: [],
+    pages: [],
+    blogs: [],
+    articles: [],
+    redirects: [],
+    customers: [],
+    orders: [],
+    judgeMeRows: [],
+    ...overrides,
+  };
+}
+
+function source(records: MigrationSourceBundle): MigrationSource {
+  return { extract: vi.fn(async () => records) };
+}
+
+const domain = {
+  currency: "USD",
+  inventoryLocationId: "main",
+  fulfillmentType: "physical" as const,
+  actorId: "user_operator",
+  fallbackAuthor: "Store team",
+  allowedMediaHosts: ["cdn.shopify.com"],
+  unresolvedCustomer: "reject" as const,
+  reviewAttributions: new Map(),
+};
+
+describe("Shopify migration orchestrator", () => {
+  it("keeps dry runs free of write adapter construction and sensitive payloads", async () => {
+    const factories: MigrationApplyFactories = {
+      createMediaStore: vi.fn(),
+      createClerkClient: vi.fn(),
+      createCommandRunner: vi.fn(),
+    };
+    const records = bundle({
+      collections: [{ id: 1, title: "Private catalog title", handle: "tea", variants: undefined } as never],
+    });
+    const result = await orchestrateMigration({
+      config: config(),
+      domain,
+      source: source(records),
+      projectRoot: "/repo",
+      wranglerConfigText: wranglerConfig,
+      expectedDatabaseName: "migration-db",
+      applyFactories: factories,
+      now: () => new Date("2026-08-14T12:00:00.000Z"),
+    });
+
+    expect(result).toMatchObject({ dryRun: true, target: "local", authoritative: false });
+    expect(result.entities.categories).toMatchObject({ source: 1, transformed: 1, written: 0 });
+    expect(factories.createMediaStore).not.toHaveBeenCalled();
+    expect(factories.createClerkClient).not.toHaveBeenCalled();
+    expect(factories.createCommandRunner).not.toHaveBeenCalled();
+    expect(JSON.stringify(result)).not.toContain("Private catalog title");
+  });
+
+  it("validates deterministic transforms before constructing apply adapters", async () => {
+    const createMediaStore = vi.fn();
+    const records = bundle({
+      collects: [
+        { id: 1, collection_id: 10, product_id: 20 },
+        { id: 1, collection_id: 11, product_id: 21 },
+      ],
+    });
+    await expect(orchestrateMigration({
+      config: config(execution({ dryRun: false, apply: true })),
+      domain,
+      source: source(records),
+      projectRoot: "/repo",
+      wranglerConfigText: wranglerConfig,
+      applyFactories: {
+        createMediaStore,
+        createClerkClient: vi.fn(),
+        createCommandRunner: vi.fn(),
+      },
+      runners: {} as MigrationAdapterRunners,
+    })).rejects.toThrow("ambiguous duplicate");
+    expect(createMediaStore).not.toHaveBeenCalled();
+  });
+
+  it("applies strictly in media, Clerk, then D1 order", async () => {
+    const events: string[] = [];
+    const mediaStore = {} as MediaObjectStore;
+    const clerkClient = {} as ClerkMigrationClient;
+    const commandRunner = {} as CommandRunner;
+    const plan = execution({
+      dryRun: false,
+      apply: true,
+      includeSensitive: true,
+      confirmedSensitiveData: true,
+    });
+    const records = bundle({
+      customers: [{
+        id: 42,
+        email: "customer@example.test",
+        first_name: "Private",
+        verified_email: true,
+      }],
+    });
+    const factories: MigrationApplyFactories = {
+      createMediaStore: vi.fn(() => { events.push("media-factory"); return mediaStore; }),
+      createClerkClient: vi.fn(async () => { events.push("clerk-factory"); return clerkClient; }),
+      createCommandRunner: vi.fn(() => { events.push("d1-factory"); return commandRunner; }),
+    };
+    const runners: MigrationAdapterRunners = {
+      importMedia: vi.fn(async () => { events.push("media-run"); return []; }),
+      provisionClerk: vi.fn(async (plans) => {
+        events.push("clerk-run");
+        return {
+          idMap: new Map([[plans[0].sourceFingerprint, "user_imported_customer"]]),
+          created: 1,
+          existing: 0,
+          reconciliation: [],
+        };
+      }),
+      runD1: vi.fn(async () => {
+        events.push("d1-run");
+        return { dryRun: false as const, dependencies: [], totalRows: 1, chunksApplied: 1, validationsPassed: 1 };
+      }),
+    };
+
+    const result = await orchestrateMigration({
+      config: config(plan),
+      domain,
+      source: source(records),
+      projectRoot: "/repo",
+      wranglerConfigText: wranglerConfig,
+      applyFactories: factories,
+      runners,
+      now: () => new Date("2026-08-14T12:00:00.000Z"),
+    });
+
+    expect(events).toEqual([
+      "media-factory",
+      "media-run",
+      "clerk-factory",
+      "clerk-run",
+      "d1-factory",
+      "d1-run",
+    ]);
+    expect(result).toMatchObject({ dryRun: false, clerk: { created: 1 }, media: { persisted: 0 } });
+    expect(JSON.stringify(result)).not.toContain("customer@example.test");
+    expect(JSON.stringify(result)).not.toContain("Private");
+  });
+});

--- a/tests/unit/scripts/shopify-migration/safety-artifacts.test.ts
+++ b/tests/unit/scripts/shopify-migration/safety-artifacts.test.ts
@@ -41,25 +41,85 @@ describe("migration identity and artifacts", () => {
 });
 
 describe("redacted structured migration logging", () => {
-  it("redacts sensitive keys, email-shaped values, and configured secrets", () => {
+  it("admits operational metadata while redacting sensitive and unknown fields", () => {
     const records: StructuredLogRecord[] = [];
     const logger = new MigrationLogger((record) => records.push(record), ["shpat_supersecret"], () => new Date("2026-08-14T00:00:00Z"));
     logger.info("shopify.page", {
       accessToken: "shpat_supersecret",
       note: "customer@example.test used shpat_supersecret",
       nested: { shippingAddress: "123 Main St" },
+      entity: "products",
+      metrics: { sourceCount: 4, written: 3, durationMs: 20 },
+      execution: { dryRun: true, target: "local" },
       count: 3,
     });
     const serialized = JSON.stringify(records);
     expect(serialized).not.toContain("shpat_supersecret");
     expect(serialized).not.toContain("customer@example.test");
     expect(serialized).not.toContain("123 Main St");
-    expect(records[0]).toMatchObject({ level: "info", event: "shopify.page" });
+    expect(records[0]).toMatchObject({
+      level: "info",
+      event: "shopify.page",
+      context: {
+        entity: "products",
+        metrics: { sourceCount: 4, written: 3, durationMs: 20 },
+        execution: { dryRun: true, target: "local" },
+        count: 3,
+        redacted: "[REDACTED]",
+      },
+    });
   });
 
-  it("redacts arbitrary nested values without mutating the input", () => {
+  it("redacts arbitrary values and keys without mutating the input", () => {
     const input = { reviewer_email: "person@example.test", ok: "public" };
-    expect(redactForLog(input)).toEqual({ reviewer_email: "[REDACTED]", ok: "public" });
+    expect(redactForLog(input)).toEqual({ redacted: "[REDACTED]" });
     expect(input.reviewer_email).toBe("person@example.test");
+  });
+
+  it("keeps identifiers, names, phones, addresses, and nested records out of the sink", () => {
+    const records: StructuredLogRecord[] = [];
+    const logger = new MigrationLogger((record) => records.push(record));
+    logger.warn("migration.record-rejected", {
+      customerId: "gid://shopify/Customer/123456",
+      orderId: 987654,
+      sourceId: "provider-4455",
+      providerSourceId: "4455",
+      name: "Example Customer",
+      phone: "+1 555 0100",
+      address: "123 Example Street",
+      record: {
+        id: "gid://shopify/Order/987654",
+        email: "customer@example.test",
+        first_name: "Example",
+        shipping_address: { address1: "123 Example Street" },
+      },
+      error: new TypeError("customer@example.test failed at 123 Example Street"),
+      entity: "orders",
+      skipped: 1,
+    });
+    const serialized = JSON.stringify(records);
+    for (const forbidden of [
+      "gid://shopify/Customer/123456",
+      "987654",
+      "provider-4455",
+      "4455",
+      "Example Customer",
+      "+1 555 0100",
+      "123 Example Street",
+      "customer@example.test",
+    ]) {
+      expect(serialized).not.toContain(forbidden);
+    }
+    expect(records[0]).toMatchObject({
+      context: { entity: "orders", skipped: 1, error: { errorClass: "TypeError" }, redacted: "[REDACTED]" },
+    });
+  });
+
+  it("redacts raw arrays, circular structures, and secret-shaped operational labels", () => {
+    const circular: Record<string, unknown> = { count: 1 };
+    circular.summary = circular;
+    expect(redactForLog({ result: [{ customerId: "123" }] })).toEqual({ result: "[REDACTED]" });
+    expect(redactForLog(circular)).toEqual({ count: 1, summary: "[REDACTED]" });
+    expect(redactForLog({ entity: "shpat_secret" }, ["shpat_secret"])).toEqual({ entity: "[REDACTED]" });
   });
 });

--- a/tests/unit/scripts/shopify-migration/safety-artifacts.test.ts
+++ b/tests/unit/scripts/shopify-migration/safety-artifacts.test.ts
@@ -1,7 +1,7 @@
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, renameSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { deterministicProviderId, providerFingerprint } from "@/scripts/shopify-migration/lib/ids";
 import { IdMap } from "@/scripts/shopify-migration/lib/id-map";
 import { MigrationLogger, redactForLog, type StructuredLogRecord } from "@/scripts/shopify-migration/lib/logger";
@@ -70,6 +70,39 @@ describe("migration identity and artifacts", () => {
 
     expect(readFileSync(path, "utf8")).toBe("prior-valid\n");
     expect(readdirSync(output)).toEqual(["manifest.json"]);
+  });
+
+  it("fsyncs the parent directory after the atomic rename", () => {
+    const output = mkdtempSync(join(tmpdir(), "mercora-shopify-map-"));
+    roots.push(output);
+    const path = join(output, "manifest.json");
+    const events: string[] = [];
+    const directorySync = vi.fn((directory: string) => {
+      events.push("directory-sync");
+      expect(directory).toBe(output);
+    });
+    atomicWritePrivateFile(path, "complete\n", {
+      operations: {
+        rename: (from, to) => { events.push("rename"); renameSync(from, to); },
+        fsyncDirectory: directorySync,
+      },
+    });
+    expect(events).toEqual(["rename", "directory-sync"]);
+    expect(readFileSync(path, "utf8")).toBe("complete\n");
+  });
+
+  it("rejects non-regular, symlinked, and oversized ID-map inputs before parsing", () => {
+    const output = mkdtempSync(join(tmpdir(), "mercora-shopify-map-"));
+    roots.push(output);
+    mkdirSync(join(output, "directory-map"));
+    expect(() => IdMap.load(output, "directory-map")).toThrow(/regular non-symlink/);
+
+    writeFileSync(join(output, "target.json"), "{}", { mode: 0o600 });
+    symlinkSync(join(output, "target.json"), join(output, "linked.json"));
+    expect(() => IdMap.load(output, "linked.json")).toThrow(/symbolic link/);
+
+    writeFileSync(join(output, "oversized.json"), Buffer.alloc(10 * 1024 * 1024 + 1), { mode: 0o600 });
+    expect(() => IdMap.load(output, "oversized.json")).toThrow(/too large/);
   });
 });
 

--- a/tests/unit/scripts/shopify-migration/safety-artifacts.test.ts
+++ b/tests/unit/scripts/shopify-migration/safety-artifacts.test.ts
@@ -1,10 +1,11 @@
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { deterministicProviderId, providerFingerprint } from "@/scripts/shopify-migration/lib/ids";
 import { IdMap } from "@/scripts/shopify-migration/lib/id-map";
 import { MigrationLogger, redactForLog, type StructuredLogRecord } from "@/scripts/shopify-migration/lib/logger";
+import { atomicWritePrivateFile } from "@/scripts/shopify-migration/lib/private-atomic-file";
 
 const roots: string[] = [];
 afterEach(() => {
@@ -37,6 +38,38 @@ describe("migration identity and artifacts", () => {
     const output = mkdtempSync(join(tmpdir(), "mercora-shopify-map-"));
     roots.push(output);
     expect(() => new IdMap("shopify").save(output, "../map.json")).toThrow(/escapes/);
+  });
+
+  it("atomically replaces permissive artifacts with mode 0600", () => {
+    const output = mkdtempSync(join(tmpdir(), "mercora-shopify-map-"));
+    roots.push(output);
+    mkdirSync(join(output, "state"));
+    const path = join(output, "state/id-map.json");
+    writeFileSync(path, "old", { mode: 0o644 });
+    chmodSync(path, 0o644);
+
+    const map = new IdMap("shopify");
+    map.register("product", "1", "product_1");
+    map.save(output, "state/id-map.json");
+
+    expect(statSync(path).mode & 0o777).toBe(0o600);
+    expect(readFileSync(path, "utf8")).toContain('"authoritative": false');
+  });
+
+  it.each(["write", "rename"] as const)("preserves the prior artifact when atomic %s fails", (failure) => {
+    const output = mkdtempSync(join(tmpdir(), "mercora-shopify-map-"));
+    roots.push(output);
+    const path = join(output, "manifest.json");
+    writeFileSync(path, "prior-valid\n", { mode: 0o600 });
+
+    expect(() => atomicWritePrivateFile(path, "replacement\n", {
+      operations: failure === "write"
+        ? { write: () => { throw new Error("simulated write failure"); } }
+        : { rename: () => { throw new Error("simulated rename failure"); } },
+    })).toThrow(`simulated ${failure} failure`);
+
+    expect(readFileSync(path, "utf8")).toBe("prior-valid\n");
+    expect(readdirSync(output)).toEqual(["manifest.json"]);
   });
 });
 

--- a/tests/unit/scripts/shopify-migration/safety-artifacts.test.ts
+++ b/tests/unit/scripts/shopify-migration/safety-artifacts.test.ts
@@ -1,0 +1,65 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { deterministicProviderId, providerFingerprint } from "@/scripts/shopify-migration/lib/ids";
+import { IdMap } from "@/scripts/shopify-migration/lib/id-map";
+import { MigrationLogger, redactForLog, type StructuredLogRecord } from "@/scripts/shopify-migration/lib/logger";
+
+const roots: string[] = [];
+afterEach(() => {
+  for (const path of roots.splice(0)) rmSync(path, { recursive: true, force: true });
+});
+
+describe("migration identity and artifacts", () => {
+  it("creates deterministic provider IDs without exposing the source", () => {
+    const one = deterministicProviderId("shopify", "customer", "customer@example.test");
+    const two = deterministicProviderId("shopify", "customer", "customer@example.test");
+    expect(one).toBe(two);
+    expect(one).not.toContain("customer@example.test");
+    expect(providerFingerprint("shopify", "customer", "1")).not.toBe(providerFingerprint("shopify", "order", "1"));
+  });
+
+  it("persists only non-authoritative fingerprints and safe target IDs", () => {
+    const output = mkdtempSync(join(tmpdir(), "mercora-shopify-map-"));
+    roots.push(output);
+    const map = new IdMap("shopify");
+    map.register("customer", "customer@example.test", "customer_123");
+    map.save(output, "state/id-map.json");
+    const serialized = readFileSync(join(output, "state/id-map.json"), "utf8");
+    expect(serialized).toContain('"authoritative": false');
+    expect(serialized).not.toContain("customer@example.test");
+    expect(IdMap.load(output, "state/id-map.json").resolve("customer", "customer@example.test")).toBe("customer_123");
+    expect(() => map.register("customer", "2", "not an email@example.test")).toThrow(/invalid|sensitive/);
+  });
+
+  it("rejects output traversal", () => {
+    const output = mkdtempSync(join(tmpdir(), "mercora-shopify-map-"));
+    roots.push(output);
+    expect(() => new IdMap("shopify").save(output, "../map.json")).toThrow(/escapes/);
+  });
+});
+
+describe("redacted structured migration logging", () => {
+  it("redacts sensitive keys, email-shaped values, and configured secrets", () => {
+    const records: StructuredLogRecord[] = [];
+    const logger = new MigrationLogger((record) => records.push(record), ["shpat_supersecret"], () => new Date("2026-08-14T00:00:00Z"));
+    logger.info("shopify.page", {
+      accessToken: "shpat_supersecret",
+      note: "customer@example.test used shpat_supersecret",
+      nested: { shippingAddress: "123 Main St" },
+      count: 3,
+    });
+    const serialized = JSON.stringify(records);
+    expect(serialized).not.toContain("shpat_supersecret");
+    expect(serialized).not.toContain("customer@example.test");
+    expect(serialized).not.toContain("123 Main St");
+    expect(records[0]).toMatchObject({ level: "info", event: "shopify.page" });
+  });
+
+  it("redacts arbitrary nested values without mutating the input", () => {
+    const input = { reviewer_email: "person@example.test", ok: "public" };
+    expect(redactForLog(input)).toEqual({ reviewer_email: "[REDACTED]", ok: "public" });
+    expect(input.reviewer_email).toBe("person@example.test");
+  });
+});

--- a/tests/unit/scripts/shopify-migration/shopify-api.test.ts
+++ b/tests/unit/scripts/shopify-migration/shopify-api.test.ts
@@ -92,6 +92,15 @@ describe("Shopify REST transport", () => {
     expect(fetcher).not.toHaveBeenCalled();
   });
 
+  it("cannot bypass sensitive transport through the generic paginator", async () => {
+    const fetcher = vi.fn<typeof fetch>();
+    const transport = client(fetcher);
+    await expect(transport.fetchPaginated("customers.json", "customers")).rejects.toThrow(/sensitive-data/);
+    await expect(transport.fetchPaginated("orders.json", "orders")).rejects.toThrow(/sensitive-data/);
+    await expect(transport.fetchPaginated("metafields.json", "metafields")).rejects.toThrow(/not supported/);
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
   it("never includes the access token in transport errors", async () => {
     const fetcher = vi.fn<typeof fetch>().mockResolvedValue(new Response(null, { status: 500 }));
     let message = "";

--- a/tests/unit/scripts/shopify-migration/shopify-api.test.ts
+++ b/tests/unit/scripts/shopify-migration/shopify-api.test.ts
@@ -19,6 +19,15 @@ function json(body: unknown, init: ResponseInit = {}): Response {
   });
 }
 
+function streamedResponse(chunks: readonly Uint8Array[], headers: Record<string, string> = {}): Response {
+  return new Response(new ReadableStream<Uint8Array>({
+    start(controller) {
+      chunks.forEach((chunk) => controller.enqueue(chunk));
+      controller.close();
+    },
+  }), { status: 200, headers: { "content-type": "application/json", ...headers } });
+}
+
 describe("Shopify REST transport", () => {
   it("traverses RFC Link rel=next and preserves all records", async () => {
     const fetcher = vi.fn<typeof fetch>()
@@ -76,6 +85,72 @@ describe("Shopify REST transport", () => {
     expect(exhausted).toHaveBeenCalledTimes(2);
   });
 
+  it("aborts a request that stalls before response headers", async () => {
+    let signal: AbortSignal | undefined;
+    const fetcher = vi.fn<typeof fetch>(async (_url, init) => {
+      signal = init?.signal ?? undefined;
+      return await new Promise<Response>(() => undefined);
+    });
+
+    await expect(client(fetcher, { timeoutMs: 5 }).fetchProducts()).rejects.toThrow(/timed out/);
+    expect(signal?.aborted).toBe(true);
+  });
+
+  it("keeps the timeout active through the response body and cancels a stalled stream", async () => {
+    const cancel = vi.fn();
+    const body = new ReadableStream<Uint8Array>({
+      pull: () => new Promise<void>(() => undefined),
+      cancel,
+    });
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(new Response(body, {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }));
+
+    await expect(client(fetcher, { timeoutMs: 5 }).fetchProducts()).rejects.toThrow(/timed out/);
+    expect(cancel).toHaveBeenCalled();
+  });
+
+  it("rejects oversized declared and streamed response bodies", async () => {
+    const declared = vi.fn<typeof fetch>().mockResolvedValue(json({ products: [] }, {
+      headers: { "content-length": "999" },
+    }));
+    await expect(client(declared, { maxResponseBytes: 32 }).fetchProducts()).rejects.toThrow(/exceeds 32 bytes/);
+
+    const streamed = vi.fn<typeof fetch>().mockResolvedValue(streamedResponse([
+      new TextEncoder().encode('{"products":["'),
+      new TextEncoder().encode("x".repeat(32)),
+      new TextEncoder().encode('"]}'),
+    ]));
+    await expect(client(streamed, { maxResponseBytes: 32 }).fetchProducts()).rejects.toThrow(/exceeds 32 bytes/);
+  });
+
+  it("rejects a declared Content-Length that does not match the streamed body", async () => {
+    const bytes = new TextEncoder().encode('{"products":[]}');
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(streamedResponse(
+      [bytes],
+      { "content-length": String(bytes.byteLength + 1) },
+    ));
+    await expect(client(fetcher).fetchProducts()).rejects.toThrow(/does not match its body/);
+  });
+
+  it("reports malformed JSON without echoing response data or credentials", async () => {
+    const privatePayload = "private-customer@example.test shpat_never-log-this";
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(new Response(`{${privatePayload}`, {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }));
+    let message = "";
+    try {
+      await client(fetcher).fetchProducts();
+    } catch (error) {
+      message = String(error);
+    }
+    expect(message).toContain("not valid JSON");
+    expect(message).not.toContain(privatePayload);
+    expect(message).not.toContain("shpat_never-log-this");
+  });
+
   it("requests all order statuses on the first request", async () => {
     const fetcher = vi.fn<typeof fetch>().mockResolvedValue(json({ orders: [] }));
     await client(fetcher, { includeSensitive: true }).fetchOrders({ query: { fields: "id", status: "open" } });
@@ -106,5 +181,13 @@ describe("Shopify REST transport", () => {
     let message = "";
     try { await client(fetcher).fetchProducts(); } catch (error) { message = String(error); }
     expect(message).not.toContain("shpat_never-log-this");
+
+    const thrown = vi.fn<typeof fetch>().mockRejectedValue(
+      new Error("network failed with shpat_never-log-this and private response text"),
+    );
+    message = "";
+    try { await client(thrown).fetchProducts(); } catch (error) { message = String(error); }
+    expect(message).toBe("Error: Shopify API request failed");
+    expect(message).not.toContain("private response text");
   });
 });

--- a/tests/unit/scripts/shopify-migration/shopify-api.test.ts
+++ b/tests/unit/scripts/shopify-migration/shopify-api.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from "vitest";
+import { ShopifyClient } from "@/scripts/shopify-migration/lib/shopify-api";
+
+function client(fetcher: typeof fetch, overrides: Partial<ConstructorParameters<typeof ShopifyClient>[0]> = {}) {
+  return new ShopifyClient({
+    origin: "https://merchant.myshopify.com",
+    accessToken: "shpat_never-log-this",
+    apiVersion: "2026-07",
+    fetch: fetcher,
+    ...overrides,
+  });
+}
+
+function json(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json", ...init.headers },
+    ...init,
+  });
+}
+
+describe("Shopify REST transport", () => {
+  it("traverses RFC Link rel=next and preserves all records", async () => {
+    const fetcher = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(json({ products: [{ id: 1 }] }, {
+        headers: { link: '<https://merchant.myshopify.com/admin/api/2026-07/products.json?page_info=a%2Cb>; rel="previous next"' },
+      }))
+      .mockResolvedValueOnce(json({ products: [{ id: 2 }] }));
+    await expect(client(fetcher).fetchProducts()).resolves.toEqual([{ id: 1 }, { id: 2 }]);
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    "https://evil.test/admin/api/2026-07/products.json?page_info=x",
+    "https://merchant.myshopify.com/admin/api/2025-10/products.json?page_info=x",
+    "https://merchant.myshopify.com/products.json?page_info=x",
+    "https://merchant.myshopify.com/admin/api/2026-07/%2e%2e/orders.json?page_info=x",
+  ])("rejects hostile next target %s before sending credentials", async (next) => {
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(json({ products: [] }, {
+      headers: { link: `<${next}>; rel="next"` },
+    }));
+    await expect(client(fetcher).fetchProducts()).rejects.toThrow(/escaped/);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("detects pagination cycles", async () => {
+    const first = "https://merchant.myshopify.com/admin/api/2026-07/products.json?limit=250";
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(json({ products: [] }, {
+      headers: { link: `<${first}>; rel=next` },
+    }));
+    await expect(client(fetcher).fetchProducts()).rejects.toThrow(/cycle/);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("enforces page and record bounds", async () => {
+    const next = "https://merchant.myshopify.com/admin/api/2026-07/products.json?page_info=two";
+    const pageFetcher = vi.fn<typeof fetch>().mockResolvedValue(json({ products: [{ id: 1 }] }, {
+      headers: { link: `<${next}>; rel=next` },
+    }));
+    await expect(client(pageFetcher, { maxPages: 1 }).fetchProducts()).rejects.toThrow(/exceeded 1 pages/);
+
+    const recordFetcher = vi.fn<typeof fetch>().mockResolvedValue(json({ products: [{ id: 1 }, { id: 2 }] }));
+    await expect(client(recordFetcher, { maxRecords: 1 }).fetchProducts()).rejects.toThrow(/exceeded 1 records/);
+  });
+
+  it("honors Retry-After with a bounded retry budget", async () => {
+    const sleep = vi.fn(async () => undefined);
+    const fetcher = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(null, { status: 429, headers: { "retry-after": "2" } }))
+      .mockResolvedValueOnce(json({ products: [] }));
+    await expect(client(fetcher, { sleep, maxRetries: 1, maxRetryAfterMs: 1_500 }).fetchProducts()).resolves.toEqual([]);
+    expect(sleep).toHaveBeenCalledWith(1_500);
+
+    const exhausted = vi.fn<typeof fetch>().mockResolvedValue(new Response(null, { status: 429 }));
+    await expect(client(exhausted, { sleep, maxRetries: 1 }).fetchProducts()).rejects.toThrow(/retry budget/);
+    expect(exhausted).toHaveBeenCalledTimes(2);
+  });
+
+  it("requests all order statuses on the first request", async () => {
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(json({ orders: [] }));
+    await client(fetcher, { includeSensitive: true }).fetchOrders({ query: { fields: "id", status: "open" } });
+    const url = fetcher.mock.calls[0][0] as URL;
+    expect(url.searchParams.get("status")).toBe("any");
+    expect(url.searchParams.get("fields")).toBe("id");
+  });
+
+  it("blocks customer and order transport unless sensitive-data access was confirmed", () => {
+    const fetcher = vi.fn<typeof fetch>();
+    const transport = client(fetcher);
+    expect(() => transport.fetchCustomers()).toThrow(/sensitive-data/);
+    expect(() => transport.fetchOrders()).toThrow(/sensitive-data/);
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it("never includes the access token in transport errors", async () => {
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(new Response(null, { status: 500 }));
+    let message = "";
+    try { await client(fetcher).fetchProducts(); } catch (error) { message = String(error); }
+    expect(message).not.toContain("shpat_never-log-this");
+  });
+});

--- a/tests/unit/scripts/shopify-migration/transformers/blog.test.ts
+++ b/tests/unit/scripts/shopify-migration/transformers/blog.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import { transformBlogContent } from "@/scripts/shopify-migration/transformers/blog";
+
+const options = {
+  generatedAt: "2026-08-14T12:00:00.000Z",
+  actorId: "migration-operator",
+  fallbackAuthor: "Store Team",
+};
+
+describe("blog transform", () => {
+  it("plans categories, posts, sanitized media, metadata, and exact legacy redirects", () => {
+    const result = transformBlogContent([{
+      id: 10,
+      title: "Guides",
+      handle: "guides",
+      created_at: "2024-01-01T00:00:00Z",
+    }], [{
+      id: 20,
+      blog_id: 10,
+      title: "A Useful Guide",
+      handle: "a-useful-guide",
+      author: "Alex",
+      tags: "How To, Featured, how to",
+      summary_html: "<p>A useful summary.</p>",
+      body_html: '<p>Useful words.</p><img src="https://cdn.example.test/inside.gif"><iframe src="https://evil.test"></iframe>',
+      image: { src: "https://cdn.example.test/cover.avif", alt: "Cover" },
+      published: true,
+      published_at: "2024-01-02T00:00:00Z",
+      created_at: "2024-01-01T00:00:00Z",
+      updated_at: "2024-01-03T00:00:00Z",
+    }], options);
+
+    expect(result.categories[0]).toMatchObject({
+      record: { name: "Guides", slug: "guides" },
+      conflict: { strategy: "insert-only", onConflict: "reuse" },
+    });
+    const post = result.records[0];
+    expect(post.record).toMatchObject({
+      slug: "a-useful-guide",
+      author: "Alex",
+      tags: JSON.stringify(["how to", "featured"]),
+      status: "published",
+      reading_time: 1,
+      published_at: 1_704_153_600,
+    });
+    expect(post.record.html).toContain("/media/blog/");
+    expect(post.record.html).not.toContain("iframe");
+    expect(post.record.cover_image_url).toContain("/media/blog/");
+    expect(post.media.map(({ contentType }) => contentType)).toEqual(["image/avif", "image/gif"]);
+    expect(post.redirect).toEqual({
+      sourcePath: "/blogs/guides/a-useful-guide",
+      targetPath: "/blog/a-useful-guide",
+      statusCode: 301,
+      entityType: "blog",
+    });
+    expect(post.sourceFingerprint).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("uses the configured author, keeps drafts unpublished, and skips orphan articles", () => {
+    const result = transformBlogContent(
+      [{ id: 1, title: "News", handle: "news" }],
+      [
+        { id: 2, blog_id: 1, title: "Draft", handle: "draft", published: false, published_at: "2024-01-01T00:00:00Z" },
+        { id: 3, blog_id: 999, title: "Orphan", handle: "orphan" },
+      ],
+      options,
+    );
+    expect(result.records[0].record).toMatchObject({ author: "Store Team", status: "draft", published_at: null });
+    expect(result.skipped[0].reason).toBe("Article references a blog that was not imported");
+  });
+});

--- a/tests/unit/scripts/shopify-migration/transformers/blog.test.ts
+++ b/tests/unit/scripts/shopify-migration/transformers/blog.test.ts
@@ -6,7 +6,7 @@ const options = {
   generatedAt: "2026-08-14T12:00:00.000Z",
   actorId: "migration-operator",
   fallbackAuthor: "Store Team",
-  allowedMediaHosts: ["cdn.example.test"],
+  allowedMediaHosts: ["cdn.shopify.com"],
 };
 
 describe("blog transform", () => {
@@ -24,8 +24,8 @@ describe("blog transform", () => {
       author: "Alex",
       tags: "How To, Featured, how to",
       summary_html: "<p>A useful summary.</p>",
-      body_html: '<p>Useful words.</p><img src="https://cdn.example.test/inside.webp"><iframe src="https://evil.test"></iframe>',
-      image: { src: "https://cdn.example.test/cover.jpg", alt: "Cover" },
+      body_html: '<p>Useful words.</p><img src="https://cdn.shopify.com/inside.webp"><iframe src="https://evil.test"></iframe>',
+      image: { src: "https://cdn.shopify.com/cover.jpg", alt: "Cover" },
       published: true,
       published_at: "2024-01-02T00:00:00Z",
       created_at: "2024-01-01T00:00:00Z",
@@ -96,8 +96,8 @@ describe("blog transform", () => {
         blog_id: 1,
         title: "No remote media",
         handle: "no-remote-media",
-        body_html: '<p>Text</p><img src="https://cdn.example.test/inline.png">',
-        image: { src: "https://cdn.example.test/cover.png" },
+        body_html: '<p>Text</p><img src="https://cdn.shopify.com/inline.png">',
+        image: { src: "https://cdn.shopify.com/cover.png" },
       }],
       { ...options, allowedMediaHosts: [] },
     );
@@ -125,8 +125,8 @@ describe("blog transform", () => {
         blog_id: 1,
         title: "Unsupported media",
         handle: "unsupported-media",
-        body_html: '<p>Text remains.</p><img src="https://cdn.example.test/inline.gif">',
-        image: { src: "https://cdn.example.test/cover.avif" },
+        body_html: '<p>Text remains.</p><img src="https://cdn.shopify.com/inline.gif">',
+        image: { src: "https://cdn.shopify.com/cover.avif" },
       }],
       options,
     );

--- a/tests/unit/scripts/shopify-migration/transformers/blog.test.ts
+++ b/tests/unit/scripts/shopify-migration/transformers/blog.test.ts
@@ -6,6 +6,7 @@ const options = {
   generatedAt: "2026-08-14T12:00:00.000Z",
   actorId: "migration-operator",
   fallbackAuthor: "Store Team",
+  allowedMediaHosts: ["cdn.example.test"],
 };
 
 describe("blog transform", () => {
@@ -23,8 +24,8 @@ describe("blog transform", () => {
       author: "Alex",
       tags: "How To, Featured, how to",
       summary_html: "<p>A useful summary.</p>",
-      body_html: '<p>Useful words.</p><img src="https://cdn.example.test/inside.gif"><iframe src="https://evil.test"></iframe>',
-      image: { src: "https://cdn.example.test/cover.avif", alt: "Cover" },
+      body_html: '<p>Useful words.</p><img src="https://cdn.example.test/inside.webp"><iframe src="https://evil.test"></iframe>',
+      image: { src: "https://cdn.example.test/cover.jpg", alt: "Cover" },
       published: true,
       published_at: "2024-01-02T00:00:00Z",
       created_at: "2024-01-01T00:00:00Z",
@@ -47,7 +48,7 @@ describe("blog transform", () => {
     expect(post.record.html).toContain("/media/blog/");
     expect(post.record.html).not.toContain("iframe");
     expect(post.record.cover_image_url).toContain("/media/blog/");
-    expect(post.media.map(({ contentType }) => contentType)).toEqual(["image/avif", "image/gif"]);
+    expect(post.media.map(({ contentType }) => contentType)).toEqual(["image/jpeg", "image/webp"]);
     expect(post.redirect).toEqual({
       sourcePath: "/blogs/guides/a-useful-guide",
       targetPath: "/blog/a-useful-guide",
@@ -68,5 +69,52 @@ describe("blog transform", () => {
     );
     expect(result.records[0].record).toMatchObject({ author: "Store Team", status: "draft", published_at: null });
     expect(result.skipped[0].reason).toBe("Article references a blog that was not imported");
+  });
+
+  it("strips unapproved blog media instead of persisting remote sources", () => {
+    const result = transformBlogContent(
+      [{ id: 1, title: "News", handle: "news" }],
+      [{
+        id: 2,
+        blog_id: 1,
+        title: "No remote media",
+        handle: "no-remote-media",
+        body_html: '<p>Text</p><img src="https://cdn.example.test/inline.png">',
+        image: { src: "https://cdn.example.test/cover.png" },
+      }],
+      { ...options, allowedMediaHosts: [] },
+    );
+    expect(result.records[0].media).toEqual([]);
+    expect(result.records[0].record.cover_image_url).toBeNull();
+    expect(result.records[0].record.html).not.toContain("https://");
+    expect(result.records[0].record.html).not.toContain("src=");
+  });
+
+  it("rejects blog fields beyond current persistence limits", () => {
+    const result = transformBlogContent(
+      [{ id: 1, title: "News", handle: "news" }],
+      [{ id: 2, blog_id: 1, title: "Post", handle: "post", tags: "x".repeat(51) }],
+      options,
+    );
+    expect(result.records).toEqual([]);
+    expect(result.skipped[0].reason).toContain("tags exceed");
+  });
+
+  it("omits GIF and AVIF because the upload adapter cannot verify their signatures", () => {
+    const result = transformBlogContent(
+      [{ id: 1, title: "News", handle: "news" }],
+      [{
+        id: 2,
+        blog_id: 1,
+        title: "Unsupported media",
+        handle: "unsupported-media",
+        body_html: '<p>Text remains.</p><img src="https://cdn.example.test/inline.gif">',
+        image: { src: "https://cdn.example.test/cover.avif" },
+      }],
+      options,
+    );
+    expect(result.records[0].media).toEqual([]);
+    expect(result.records[0].record.html).toBe("<p>Text remains.</p>");
+    expect(result.records[0].record.cover_image_url).toBeNull();
   });
 });

--- a/tests/unit/scripts/shopify-migration/transformers/blog.test.ts
+++ b/tests/unit/scripts/shopify-migration/transformers/blog.test.ts
@@ -71,6 +71,23 @@ describe("blog transform", () => {
     expect(result.skipped[0].reason).toBe("Article references a blog that was not imported");
   });
 
+  it("keeps persisted rows identical across run clocks when source timestamps are unavailable", () => {
+    const blogs = [{ id: 1, title: "News", handle: "news" }];
+    const articles = [{
+      id: 2,
+      blog_id: 1,
+      title: "Stable",
+      handle: "stable",
+      body_html: "<p>Stable</p>",
+    }];
+    const first = transformBlogContent(blogs, articles, { ...options, generatedAt: "2026-01-01T00:00:00Z" });
+    const second = transformBlogContent(blogs, articles, { ...options, generatedAt: "2027-01-01T00:00:00Z" });
+    expect(first.categories).toEqual(second.categories);
+    expect(first.records).toEqual(second.records);
+    expect(first.categories[0].record).toMatchObject({ created_at: 0, updated_at: 0 });
+    expect(first.records[0].record).toMatchObject({ created_at: 0, updated_at: 0 });
+  });
+
   it("strips unapproved blog media instead of persisting remote sources", () => {
     const result = transformBlogContent(
       [{ id: 1, title: "News", handle: "news" }],

--- a/tests/unit/scripts/shopify-migration/transformers/blog.test.ts
+++ b/tests/unit/scripts/shopify-migration/transformers/blog.test.ts
@@ -134,4 +134,26 @@ describe("blog transform", () => {
     expect(result.records[0].record.html).toBe("<p>Text remains.</p>");
     expect(result.records[0].record.cover_image_url).toBeNull();
   });
+
+  it("resolves category and post slug conflicts identically for permuted provider input", () => {
+    const blogs = [
+      { id: 30, title: "Thirty", handle: "shared" },
+      { id: 10, title: "Ten", handle: "shared" },
+      { id: 20, title: "Twenty", handle: "other" },
+    ];
+    const articles = [
+      { id: 300, blog_id: 20, title: "Three", handle: "same-post", body_html: "<p>Three</p>" },
+      { id: 100, blog_id: 20, title: "One", handle: "same-post", body_html: "<p>One</p>" },
+      { id: 200, blog_id: 20, title: "Two", handle: "other-post", body_html: "<p>Two</p>" },
+    ];
+    const first = transformBlogContent(blogs, articles, options);
+    const second = transformBlogContent([...blogs].reverse(), [...articles].reverse(), options);
+    expect(first.categories).toEqual(second.categories);
+    expect(first.records).toEqual(second.records);
+    expect(first.categories.map(({ record }) => record.slug)).toEqual(["other"]);
+    expect(first.records.map(({ record }) => record.slug)).toEqual(["other-post"]);
+    expect(first.skipped.map(({ record, reason }) => [record.id, reason])).toEqual(
+      second.skipped.map(({ record, reason }) => [record.id, reason]),
+    );
+  });
 });

--- a/tests/unit/scripts/shopify-migration/transformers/pages.test.ts
+++ b/tests/unit/scripts/shopify-migration/transformers/pages.test.ts
@@ -46,11 +46,12 @@ describe("page transform", () => {
       duplicate,
     ], options);
 
-    expect(result.records).toHaveLength(1);
-    expect(result.skipped.map(({ reason }) => reason)).toEqual([
+    expect(result.records).toEqual([]);
+    expect(result.skipped.map(({ reason }) => reason)).toEqual(expect.arrayContaining([
       "Page slug is reserved by the storefront: checkout",
-      "Duplicate page slug: safe-page",
-    ]);
+      "Ambiguous duplicate page slug: safe-page",
+      "Ambiguous duplicate page slug: safe-page",
+    ]));
   });
 
   it("fails closed to draft when publication time is absent or invalid", () => {
@@ -158,5 +159,21 @@ describe("page transform", () => {
       expect(result.records).toEqual([]);
       expect(result.skipped[0].reason).toContain("SQL-safe");
     }
+  });
+
+  it("resolves duplicate slugs identically for permuted provider input", () => {
+    const sources = [
+      { id: 300, title: "Three", handle: "same-page", body_html: "<p>Three</p>" },
+      { id: 100, title: "One", handle: "same-page", body_html: "<p>One</p>" },
+      { id: 200, title: "Two", handle: "other-page", body_html: "<p>Two</p>" },
+    ];
+    const first = transformPages(sources, options);
+    const second = transformPages([...sources].reverse(), options);
+    expect(first.records).toEqual(second.records);
+    expect(first.records.map(({ page }) => page.slug)).toEqual(["other-page"]);
+    expect(first.skipped).toHaveLength(2);
+    expect(first.skipped.map(({ record, reason }) => [record.id, reason])).toEqual(
+      second.skipped.map(({ record, reason }) => [record.id, reason]),
+    );
   });
 });

--- a/tests/unit/scripts/shopify-migration/transformers/pages.test.ts
+++ b/tests/unit/scripts/shopify-migration/transformers/pages.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, it } from "vitest";
 
+import {
+  MAX_SQL_TEXT_BYTES,
+  escapedSqlUtf8Bytes,
+} from "@/scripts/shopify-migration/transformers/_shared";
 import { transformPages } from "@/scripts/shopify-migration/transformers/pages";
 
 const options = {
   generatedAt: "2026-08-14T12:00:00.000Z",
   actorId: "migration-operator",
+  allowedMediaHosts: ["cdn.example.test"],
 };
 
 describe("page transform", () => {
@@ -33,11 +38,11 @@ describe("page transform", () => {
   });
 
   it("rejects current reserved storefront slugs and duplicates", () => {
-    const source = { id: 1, title: "Reserved", handle: "checkout", body_html: "" };
-    const duplicate = { id: 3, title: "Duplicate", handle: "safe-page", body_html: "" };
+    const source = { id: 1, title: "Reserved", handle: "checkout", body_html: "<p>Reserved</p>" };
+    const duplicate = { id: 3, title: "Duplicate", handle: "safe-page", body_html: "<p>Duplicate</p>" };
     const result = transformPages([
       source,
-      { id: 2, title: "Safe", handle: "safe-page", body_html: "" },
+      { id: 2, title: "Safe", handle: "safe-page", body_html: "<p>Safe</p>" },
       duplicate,
     ], options);
 
@@ -58,5 +63,76 @@ describe("page transform", () => {
     }], options);
     expect(result.records[0].page).toMatchObject({ status: "draft", published_at: null });
     expect(result.warnings[0]).toContain("imported as draft");
+  });
+
+  it("rewrites only exact allowlisted media hosts and strips every unsafe inline source", () => {
+    const result = transformPages([{
+      id: 20,
+      title: "Media",
+      handle: "media",
+      body_html: [
+        '<img alt="allowed" src="https://CDN.Example.Test/ok.webp">',
+        '<img alt="suffix" src="https://cdn.example.test.evil/bad.png">',
+        '<img alt="credentials" src="https://user@cdn.example.test/bad.png">',
+        '<img alt="port" src="https://cdn.example.test:8443/bad.png">',
+        '<img alt="ip" src="https://127.0.0.1/bad.png">',
+        '<img alt="localhost" src="https://localhost/bad.png">',
+        '<img alt="javascript" src="javascript:alert(1)">',
+      ].join(""),
+    }], { ...options, allowedMediaHosts: ["CDN.Example.Test"] });
+
+    expect(result.records[0].media).toHaveLength(1);
+    expect(result.records[0].media[0]).toMatchObject({
+      sourceHost: "cdn.example.test",
+      sourceUrl: "https://cdn.example.test/ok.webp",
+    });
+    expect(result.records[0].page.content.match(/\bsrc=/gu)).toHaveLength(1);
+    expect(result.records[0].page.content).not.toContain('src="https://');
+    expect(result.records[0].page.content).not.toContain("javascript:");
+    expect(result.records[0].page.content).not.toContain("cdn.example.test.evil");
+    expect(result.records[0].page.content).not.toContain("https://user@cdn.example.test/bad.png");
+  });
+
+  it.each([
+    "localhost",
+    "sub.localhost",
+    "127.0.0.1",
+    "[::1]",
+    "cdn.example.test:443",
+    "user@cdn.example.test",
+  ])("rejects unsafe media allowlist entry %s", (host) => {
+    expect(() => transformPages([], { ...options, allowedMediaHosts: [host] })).toThrow(
+      "Invalid allowed media hostname",
+    );
+  });
+
+  it("rejects content beyond the current page persistence limits", () => {
+    const result = transformPages([{
+      id: 30,
+      title: "x".repeat(501),
+      handle: "too-large",
+      body_html: "y".repeat(100_001),
+    }], options);
+    expect(result.records).toEqual([]);
+    expect(result.skipped).toHaveLength(1);
+  });
+
+  it("bounds Wrangler SQL literals by escaped UTF-8 bytes", () => {
+    expect(escapedSqlUtf8Bytes("'".repeat(MAX_SQL_TEXT_BYTES / 2))).toBe(MAX_SQL_TEXT_BYTES);
+    expect(escapedSqlUtf8Bytes("😀".repeat(MAX_SQL_TEXT_BYTES / 4))).toBe(MAX_SQL_TEXT_BYTES);
+
+    for (const content of [
+      "'".repeat(MAX_SQL_TEXT_BYTES / 2 + 1),
+      "😀".repeat(MAX_SQL_TEXT_BYTES / 4 + 1),
+    ]) {
+      const result = transformPages([{
+        id: `oversized-${content.codePointAt(0)}`,
+        title: "SQL bound",
+        handle: `sql-bound-${content.codePointAt(0)}`,
+        body_html: `<p>${content}</p>`,
+      }], options);
+      expect(result.records).toEqual([]);
+      expect(result.skipped[0].reason).toContain("SQL-safe");
+    }
   });
 });

--- a/tests/unit/scripts/shopify-migration/transformers/pages.test.ts
+++ b/tests/unit/scripts/shopify-migration/transformers/pages.test.ts
@@ -65,6 +65,15 @@ describe("page transform", () => {
     expect(result.warnings[0]).toContain("imported as draft");
   });
 
+  it("keeps persisted rows identical across run clocks when source timestamps are unavailable", () => {
+    const source = { id: 11, title: "Stable", handle: "stable", body_html: "<p>Stable</p>" };
+    const first = transformPages([source], { ...options, generatedAt: "2026-01-01T00:00:00Z" });
+    const second = transformPages([source], { ...options, generatedAt: "2027-01-01T00:00:00Z" });
+    expect(first.records).toEqual(second.records);
+    expect(first.records[0].page).toMatchObject({ created_at: 0, updated_at: 0 });
+    expect(first.records[0].initialVersion.record.created_at).toBe(0);
+  });
+
   it("rewrites only exact allowlisted media hosts and strips every unsafe inline source", () => {
     const result = transformPages([{
       id: 20,

--- a/tests/unit/scripts/shopify-migration/transformers/pages.test.ts
+++ b/tests/unit/scripts/shopify-migration/transformers/pages.test.ts
@@ -9,7 +9,7 @@ import { transformPages } from "@/scripts/shopify-migration/transformers/pages";
 const options = {
   generatedAt: "2026-08-14T12:00:00.000Z",
   actorId: "migration-operator",
-  allowedMediaHosts: ["cdn.example.test"],
+  allowedMediaHosts: ["cdn.shopify.com"],
 };
 
 describe("page transform", () => {
@@ -18,7 +18,7 @@ describe("page transform", () => {
       id: 100,
       title: "Care Guide",
       handle: "care-guide",
-      body_html: '<h2>Care</h2><img src="https://cdn.example.test/care.png"><script>alert(1)</script><a href="javascript:bad()">bad</a>',
+      body_html: '<h2>Care</h2><img src="https://cdn.shopify.com/care.png"><script>alert(1)</script><a href="javascript:bad()">bad</a>',
       published_at: "2024-04-03T02:01:00Z",
       created_at: "2024-04-01T00:00:00Z",
       updated_at: "2024-04-02T00:00:00Z",
@@ -80,26 +80,26 @@ describe("page transform", () => {
       title: "Media",
       handle: "media",
       body_html: [
-        '<img alt="allowed" src="https://CDN.Example.Test/ok.webp">',
-        '<img alt="suffix" src="https://cdn.example.test.evil/bad.png">',
-        '<img alt="credentials" src="https://user@cdn.example.test/bad.png">',
-        '<img alt="port" src="https://cdn.example.test:8443/bad.png">',
+        '<img alt="allowed" src="https://CDN.Shopify.Com/ok.webp">',
+        '<img alt="suffix" src="https://cdn.shopify.com.evil/bad.png">',
+        '<img alt="credentials" src="https://user@cdn.shopify.com/bad.png">',
+        '<img alt="port" src="https://cdn.shopify.com:8443/bad.png">',
         '<img alt="ip" src="https://127.0.0.1/bad.png">',
         '<img alt="localhost" src="https://localhost/bad.png">',
         '<img alt="javascript" src="javascript:alert(1)">',
       ].join(""),
-    }], { ...options, allowedMediaHosts: ["CDN.Example.Test"] });
+    }], { ...options, allowedMediaHosts: ["CDN.Shopify.Com"] });
 
     expect(result.records[0].media).toHaveLength(1);
     expect(result.records[0].media[0]).toMatchObject({
-      sourceHost: "cdn.example.test",
-      sourceUrl: "https://cdn.example.test/ok.webp",
+      sourceHost: "cdn.shopify.com",
+      sourceUrl: "https://cdn.shopify.com/ok.webp",
     });
     expect(result.records[0].page.content.match(/\bsrc=/gu)).toHaveLength(1);
     expect(result.records[0].page.content).not.toContain('src="https://');
     expect(result.records[0].page.content).not.toContain("javascript:");
-    expect(result.records[0].page.content).not.toContain("cdn.example.test.evil");
-    expect(result.records[0].page.content).not.toContain("https://user@cdn.example.test/bad.png");
+    expect(result.records[0].page.content).not.toContain("cdn.shopify.com.evil");
+    expect(result.records[0].page.content).not.toContain("https://user@cdn.shopify.com/bad.png");
   });
 
   it.each([
@@ -107,12 +107,27 @@ describe("page transform", () => {
     "sub.localhost",
     "127.0.0.1",
     "[::1]",
-    "cdn.example.test:443",
-    "user@cdn.example.test",
+    "cdn.shopify.com:443",
+    "user@cdn.shopify.com",
+    "merchant-assets.example.test",
   ])("rejects unsafe media allowlist entry %s", (host) => {
-    expect(() => transformPages([], { ...options, allowedMediaHosts: [host] })).toThrow(
-      "Invalid allowed media hostname",
-    );
+    expect(() => transformPages([], { ...options, allowedMediaHosts: [host] })).toThrow(/allowed media hostname/);
+  });
+
+  it("accepts only the /cdn/ asset boundary on an exact myshopify host", () => {
+    const result = transformPages([{
+      id: 21,
+      title: "Shop assets",
+      handle: "shop-assets",
+      body_html: [
+        '<img alt="good" src="https://example-store.myshopify.com/cdn/good.png">',
+        '<img alt="bad" src="https://example-store.myshopify.com/files/bad.png">',
+      ].join(""),
+    }], { ...options, allowedMediaHosts: ["example-store.myshopify.com"] });
+
+    expect(result.records[0].media).toHaveLength(1);
+    expect(result.records[0].media[0].sourceUrl).toBe("https://example-store.myshopify.com/cdn/good.png");
+    expect(result.records[0].page.content).not.toContain("/files/bad.png");
   });
 
   it("rejects content beyond the current page persistence limits", () => {

--- a/tests/unit/scripts/shopify-migration/transformers/pages.test.ts
+++ b/tests/unit/scripts/shopify-migration/transformers/pages.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import { transformPages } from "@/scripts/shopify-migration/transformers/pages";
+
+const options = {
+  generatedAt: "2026-08-14T12:00:00.000Z",
+  actorId: "migration-operator",
+};
+
+describe("page transform", () => {
+  it("sanitizes content, rewrites inline media, and plans an insert-only initial version", () => {
+    const result = transformPages([{
+      id: 100,
+      title: "Care Guide",
+      handle: "care-guide",
+      body_html: '<h2>Care</h2><img src="https://cdn.example.test/care.png"><script>alert(1)</script><a href="javascript:bad()">bad</a>',
+      published_at: "2024-04-03T02:01:00Z",
+      created_at: "2024-04-01T00:00:00Z",
+      updated_at: "2024-04-02T00:00:00Z",
+    }], options);
+
+    const transformed = result.records[0];
+    expect(transformed.page.content).toContain('/media/pages/');
+    expect(transformed.page.content).not.toContain("<script");
+    expect(transformed.page.content).not.toContain("javascript:");
+    expect(transformed.page.status).toBe("published");
+    expect(transformed.page.published_at).toBe(1_712_109_660);
+    expect(transformed.media[0]).toMatchObject({ contentType: "image/png", role: "page-inline" });
+    expect(transformed.initialVersion.record.content).toBe(transformed.page.content);
+    expect(transformed.initialVersion.record.version).toBe(1);
+    expect(transformed.conflict).toEqual({ strategy: "insert-only", key: "slug", onConflict: "skip" });
+    expect(transformed.sourceFingerprint).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("rejects current reserved storefront slugs and duplicates", () => {
+    const source = { id: 1, title: "Reserved", handle: "checkout", body_html: "" };
+    const duplicate = { id: 3, title: "Duplicate", handle: "safe-page", body_html: "" };
+    const result = transformPages([
+      source,
+      { id: 2, title: "Safe", handle: "safe-page", body_html: "" },
+      duplicate,
+    ], options);
+
+    expect(result.records).toHaveLength(1);
+    expect(result.skipped.map(({ reason }) => reason)).toEqual([
+      "Page slug is reserved by the storefront: checkout",
+      "Duplicate page slug: safe-page",
+    ]);
+  });
+
+  it("fails closed to draft when publication time is absent or invalid", () => {
+    const result = transformPages([{
+      id: 10,
+      title: "Draft",
+      handle: "draft",
+      body_html: "<p>Draft</p>",
+      published_at: "not-a-date",
+    }], options);
+    expect(result.records[0].page).toMatchObject({ status: "draft", published_at: null });
+    expect(result.warnings[0]).toContain("imported as draft");
+  });
+});

--- a/tests/unit/scripts/shopify-migration/transformers/products.test.ts
+++ b/tests/unit/scripts/shopify-migration/transformers/products.test.ts
@@ -330,4 +330,82 @@ describe("catalog transforms", () => {
       reversedCategoryConflicts.skipped.map(({ record }) => record.id),
     );
   });
+
+  it("rejects ambiguous collect and nested provider identities independent of input order", () => {
+    const categories = transformCollections([
+      { id: 50, title: "First", handle: "first" },
+      { id: 51, title: "Second", handle: "second" },
+    ], { generatedAt, allowedMediaHosts: [] });
+    const duplicateCollects = [
+      { id: 60, collection_id: 50, product_id: 10 },
+      { id: 60, collection_id: 51, product_id: 11 },
+    ];
+    expect(() => collectionMembershipByProduct(duplicateCollects, categories.idMap)).toThrow(/ambiguous duplicate/);
+    expect(() => collectionMembershipByProduct([...duplicateCollects].reverse(), categories.idMap)).toThrow(/ambiguous duplicate/);
+
+    const nestedConflicts: ShopifyProduct[] = [];
+    const optionConflict = product("1.00", "option-conflict");
+    optionConflict.options = [
+      { id: 21, name: "Size", values: ["Small"] },
+      { id: 21, name: "Colour", values: ["Red"] },
+    ];
+    nestedConflicts.push(optionConflict);
+    const imageConflict = product("1.00", "image-conflict");
+    imageConflict.id = 11;
+    imageConflict.images.push({ id: 31, src: "https://cdn.shopify.com/other.jpg" });
+    nestedConflicts.push(imageConflict);
+    const variantConflict = product("1.00", "variant-conflict");
+    variantConflict.id = 12;
+    variantConflict.variants.push({ ...variantConflict.variants[0], sku: "OTHER-SKU" });
+    nestedConflicts.push(variantConflict);
+
+    const transform = (input: ShopifyProduct[]) => transformProducts(input, {
+      currency: "USD",
+      generatedAt,
+      inventoryLocationId: "warehouse-main",
+      fulfillmentType: "physical",
+      allowedMediaHosts: ["cdn.shopify.com"],
+    });
+    const first = transform(nestedConflicts);
+    const second = transform([...nestedConflicts].reverse());
+    expect(first.records).toEqual([]);
+    expect(first.skipped.map(({ record, reason }) => [record.id, reason])).toEqual(
+      second.skipped.map(({ record, reason }) => [record.id, reason]),
+    );
+    expect(first.skipped).toHaveLength(3);
+    expect(first.skipped.every(({ reason }) => reason.includes("nested source identities"))).toBe(true);
+  });
+
+  it("keeps missing nested provider identities deterministic across permutations", () => {
+    const source = product("1.00", "natural-identities");
+    source.options = [
+      { name: "Colour", position: 2, values: ["Red"] },
+      { name: "Size", position: 1, values: ["Small"] },
+    ];
+    source.images = [
+      { src: "https://cdn.shopify.com/back.jpg", position: 2 },
+      { src: "https://cdn.shopify.com/front.jpg", position: 1 },
+    ];
+    source.variants = [
+      { sku: "NATURAL-B", price: "2.00", position: 2, option1: "Small", option2: "Red" },
+      { sku: "NATURAL-A", price: "1.00", position: 1, option1: "Small", option2: "Red" },
+    ];
+    const options = {
+      currency: "USD",
+      generatedAt,
+      inventoryLocationId: "warehouse-main",
+      fulfillmentType: "physical" as const,
+      allowedMediaHosts: ["cdn.shopify.com"],
+    };
+    const first = transformProducts([source], options);
+    const second = transformProducts([{
+      ...source,
+      options: [...source.options].reverse(),
+      images: [...source.images].reverse(),
+      variants: [...source.variants].reverse(),
+    }], options);
+    expect(first.records).toEqual(second.records);
+    expect(first.skipped).toEqual(second.skipped);
+    expect(first.warnings).toEqual(second.warnings);
+  });
 });

--- a/tests/unit/scripts/shopify-migration/transformers/products.test.ts
+++ b/tests/unit/scripts/shopify-migration/transformers/products.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { ShopifyCollection, ShopifyProduct } from "@/scripts/shopify-migration/lib/types";
+import { providerFingerprint } from "@/scripts/shopify-migration/lib/ids";
 import { transformCollections } from "@/scripts/shopify-migration/transformers/categories";
 import {
   collectionMembershipByProduct,
@@ -121,16 +122,27 @@ describe("catalog transforms", () => {
 
     const duplicateVariants = product("1");
     duplicateVariants.variants.push({ ...duplicateVariants.variants[0], id: 42 });
-    const duplicateProduct = { ...product("2"), id: 11 };
-    const result = transformProducts([duplicateVariants, duplicateProduct], {
+    const duplicateVariantResult = transformProducts([duplicateVariants], {
       currency: "USD",
       generatedAt,
       allowedMediaHosts: [],
       inventoryLocationId: "warehouse-main",
       fulfillmentType: "physical",
     });
-    expect(result.records[0].variants).toHaveLength(1);
-    expect(result.skipped[0].reason).toContain("Duplicate product slug");
+    expect(duplicateVariantResult.records[0].variants).toHaveLength(1);
+    expect(duplicateVariantResult.warnings.some((warning) => warning.includes("duplicate SKU"))).toBe(true);
+
+    const duplicateProduct = { ...product("2"), id: 11 };
+    const duplicateSlugResult = transformProducts([product("1"), duplicateProduct], {
+      currency: "USD",
+      generatedAt,
+      allowedMediaHosts: [],
+      inventoryLocationId: "warehouse-main",
+      fulfillmentType: "physical",
+    });
+    expect(duplicateSlugResult.records).toEqual([]);
+    expect(duplicateSlugResult.skipped).toHaveLength(2);
+    expect(duplicateSlugResult.skipped.every(({ reason }) => reason.toLowerCase().includes("ambiguous duplicate") && reason.includes("slug"))).toBe(true);
 
     const bad = product("not-money", "bad-price");
     expect(transformProducts([bad], {
@@ -250,11 +262,13 @@ describe("catalog transforms", () => {
   });
 
   it("does not reserve product slugs or SKUs when an earlier product fails later validation", () => {
+    const ids = [100, 101].sort((left, right) => providerFingerprint("shopify", "product", left)
+      .localeCompare(providerFingerprint("shopify", "product", right)));
     const rejected = product("1.00", "shared-product");
-    rejected.id = 100;
+    rejected.id = ids[0];
     rejected.body_html = `<p>${"😀".repeat(21_000)}</p>`;
     const accepted = product("2.00", "shared-product");
-    accepted.id = 101;
+    accepted.id = ids[1];
     accepted.variants[0].id = 102;
 
     const result = transformProducts([rejected, accepted], {
@@ -270,5 +284,50 @@ describe("catalog transforms", () => {
     expect(result.records[0].variants[0].sku).toBe("SKU-ONE");
     expect(result.skipped).toHaveLength(1);
     expect(result.skipped[0].reason).toContain("SQL-safe");
+  });
+
+  it("produces identical catalog rows and collection positions for permuted provider input", () => {
+    const collections: ShopifyCollection[] = [
+      { id: 30, title: "Thirty", handle: "thirty" },
+      { id: 10, title: "Ten", handle: "ten" },
+      { id: 20, title: "Twenty", handle: "twenty" },
+    ];
+    const firstCategories = transformCollections(collections, { generatedAt, allowedMediaHosts: [] });
+    const secondCategories = transformCollections([...collections].reverse(), { generatedAt, allowedMediaHosts: [] });
+    expect(firstCategories.records).toEqual(secondCategories.records);
+    expect(firstCategories.records.map(({ category }) => category.position)).toEqual([1, 2, 3]);
+
+    const products = [
+      { ...product("1.00", "shared"), id: 300, variants: [{ ...product("1.00").variants[0], id: 301, sku: "SKU-A" }] },
+      { ...product("2.00", "shared"), id: 200, variants: [{ ...product("2.00").variants[0], id: 201, sku: "SKU-B" }] },
+      { ...product("3.00", "other"), id: 400, variants: [{ ...product("3.00").variants[0], id: 401, sku: "SKU-A" }] },
+    ];
+    const transform = (input: ShopifyProduct[]) => transformProducts(input, {
+      currency: "USD",
+      generatedAt,
+      inventoryLocationId: "warehouse-main",
+      fulfillmentType: "physical",
+      allowedMediaHosts: ["cdn.shopify.com"],
+    });
+    const first = transform(products);
+    const second = transform([...products].reverse());
+    expect(first.records).toEqual(second.records);
+    expect(first.skipped.map(({ record, reason }) => [record.id, reason])).toEqual(
+      second.skipped.map(({ record, reason }) => [record.id, reason]),
+    );
+    expect(first.warnings).toEqual(second.warnings);
+    expect(first.records).toEqual([]);
+    expect(first.skipped).toHaveLength(3);
+
+    const duplicateCategories = [
+      { id: 1, title: "One", handle: "shared-category" },
+      { id: 2, title: "Two", handle: "shared-category" },
+    ];
+    const categoryConflicts = transformCollections(duplicateCategories, { generatedAt, allowedMediaHosts: [] });
+    const reversedCategoryConflicts = transformCollections([...duplicateCategories].reverse(), { generatedAt, allowedMediaHosts: [] });
+    expect(categoryConflicts.records).toEqual([]);
+    expect(categoryConflicts.skipped.map(({ record }) => record.id)).toEqual(
+      reversedCategoryConflicts.skipped.map(({ record }) => record.id),
+    );
   });
 });

--- a/tests/unit/scripts/shopify-migration/transformers/products.test.ts
+++ b/tests/unit/scripts/shopify-migration/transformers/products.test.ts
@@ -157,11 +157,36 @@ describe("catalog transforms", () => {
       name: JSON.stringify({ en: "Summer & More" }),
       slug: "summer-more",
       status: "inactive",
-      updated_at: generatedAt,
+      updated_at: "1970-01-01T00:00:00.000Z",
     });
     expect(result.records[0].category.description).not.toContain("<script>");
     expect(result.records[0].media[0]).toMatchObject({ contentType: "image/webp" });
     expect([...result.idMap.keys()][0]).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("keeps catalog rows identical across run clocks when source timestamps are unavailable", () => {
+    const source = product("19.99", "clock-stable");
+    source.created_at = "invalid";
+    source.updated_at = undefined;
+    source.variants[0].created_at = undefined;
+    source.variants[0].updated_at = "invalid";
+    const base = {
+      currency: "USD",
+      inventoryLocationId: "warehouse-main",
+      fulfillmentType: "physical" as const,
+      allowedMediaHosts: ["cdn.example.test"],
+    };
+    const first = transformProducts([source], { ...base, generatedAt: "2026-01-01T00:00:00Z" });
+    const second = transformProducts([source], { ...base, generatedAt: "2027-01-01T00:00:00Z" });
+    expect(first.records).toEqual(second.records);
+    expect(first.records[0].product.created_at).toBe("1970-01-01T00:00:00.000Z");
+    expect(first.records[0].variants[0].updated_at).toBe("1970-01-01T00:00:00.000Z");
+
+    const collection = { id: 99, title: "Stable", handle: "stable", updated_at: "invalid" };
+    const firstCategories = transformCollections([collection], { generatedAt: "2026-01-01T00:00:00Z", allowedMediaHosts: [] });
+    const secondCategories = transformCollections([collection], { generatedAt: "2027-01-01T00:00:00Z", allowedMediaHosts: [] });
+    expect(firstCategories.records).toEqual(secondCategories.records);
+    expect(firstCategories.records[0].category.created_at).toBe("1970-01-01T00:00:00.000Z");
   });
 
   it("does not plan product or category media outside the explicit allowlist", () => {

--- a/tests/unit/scripts/shopify-migration/transformers/products.test.ts
+++ b/tests/unit/scripts/shopify-migration/transformers/products.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+
+import type { ShopifyCollection, ShopifyProduct } from "@/scripts/shopify-migration/lib/types";
+import { transformCollections } from "@/scripts/shopify-migration/transformers/categories";
+import {
+  collectionMembershipByProduct,
+  transformProducts,
+} from "@/scripts/shopify-migration/transformers/products";
+
+const generatedAt = "2026-08-14T12:00:00.000Z";
+
+function product(price: string, currencyHandle = "example"): ShopifyProduct {
+  return {
+    id: 10,
+    title: "Configurable product",
+    body_html: "<p>A <strong>useful</strong> item.</p>",
+    handle: currencyHandle,
+    vendor: "Example Vendor",
+    product_type: "Example Type",
+    tags: "New, Featured, new",
+    status: "active",
+    published_at: "2025-01-02T03:04:05Z",
+    created_at: "2025-01-01T03:04:05Z",
+    updated_at: "2025-01-03T03:04:05Z",
+    options: [{ id: 21, name: "Size", values: ["Small", "Large"] }],
+    images: [{ id: 31, src: "https://cdn.example.test/image.JPG?width=800", alt: "Front", width: 800, height: 600 }],
+    variants: [{
+      id: 41,
+      sku: "SKU-ONE",
+      price,
+      inventory_quantity: -5,
+      inventory_policy: "continue",
+      inventory_management: "shopify",
+      requires_shipping: true,
+      taxable: true,
+      option1: "Small",
+      image_id: 31,
+    }],
+  };
+}
+
+describe("catalog transforms", () => {
+  it.each([
+    ["USD", "12.345", 1_235],
+    ["JPY", "12.5", 13],
+    ["KWD", "12.3456", 12_346],
+    ["BHD", "1.2345", 1_235],
+  ])("uses Money.fromMajor semantics for %s", (currency, major, minor) => {
+    const result = transformProducts([product(major, `product-${currency.toLowerCase()}`)], {
+      currency,
+      generatedAt,
+      inventoryLocationId: "warehouse-main",
+      fulfillmentType: "physical",
+    });
+
+    expect(JSON.parse(result.records[0].variants[0].price)).toEqual({ amount: minor, currency });
+  });
+
+  it("produces stable schema-aligned product, variant, inventory, option, and media plans", () => {
+    const source = product("19.99");
+    const collection: ShopifyCollection = {
+      id: 50,
+      title: "Featured",
+      handle: "featured",
+      published_at: "2025-01-01T00:00:00Z",
+      products_count: 1,
+    };
+    const categories = transformCollections([collection], { generatedAt });
+    const memberships = collectionMembershipByProduct(
+      [{ id: 60, collection_id: 50, product_id: 10 }],
+      categories.idMap,
+    );
+    const options = {
+      currency: "USD",
+      generatedAt,
+      inventoryLocationId: "warehouse-main",
+      fulfillmentType: "physical" as const,
+      categoryIdsByProduct: memberships,
+    };
+    const first = transformProducts([source], options);
+    const second = transformProducts([source], options);
+
+    expect(first).toEqual(second);
+    expect(first.skipped).toEqual([]);
+    const transformed = first.records[0];
+    expect(transformed.product.brand).toBe("Example Vendor");
+    expect(transformed.product.tax_category).toBeNull();
+    expect(transformed.product.fulfillment_type).toBe("physical");
+    expect(JSON.parse(transformed.product.categories!)).toEqual([categories.records[0].category.id]);
+    expect(JSON.parse(transformed.product.options!)[0]).toMatchObject({ name: "Size", values: ["Small", "Large"] });
+    expect(JSON.parse(transformed.variants[0].option_values)).toEqual([
+      { option_id: JSON.parse(transformed.product.options!)[0].id, value: "Small" },
+    ]);
+    expect(JSON.parse(transformed.variants[0].inventory)).toEqual({
+      track_inventory: true,
+      quantity: 0,
+      allow_backorder: true,
+    });
+    expect(JSON.parse(transformed.inventory[0].quantities)).toEqual({ on_hand: 0, reserved: 0, available: 0 });
+    expect(transformed.inventory[0].stock_status).toBe("backorder");
+    expect(transformed.media[0]).toMatchObject({
+      objectKey: expect.stringMatching(/^products\/[a-z0-9_]+\/1\.jpg$/),
+      publicPath: expect.stringMatching(/^\/media\/products\//),
+      contentType: "image/jpeg",
+    });
+    expect(JSON.parse(transformed.product.external_references)).toHaveProperty("shopify_fingerprint");
+    expect(transformed.product.external_references).not.toContain('"10"');
+  });
+
+  it("rejects unsupported currencies, duplicate SKUs, bad prices, and duplicate slugs", () => {
+    expect(() => transformProducts([product("1")], {
+      currency: "ZZZ",
+      generatedAt,
+      inventoryLocationId: "warehouse-main",
+      fulfillmentType: "physical",
+    })).toThrow("Unsupported migration currency");
+
+    const duplicateVariants = product("1");
+    duplicateVariants.variants.push({ ...duplicateVariants.variants[0], id: 42 });
+    const duplicateProduct = { ...product("2"), id: 11 };
+    const result = transformProducts([duplicateVariants, duplicateProduct], {
+      currency: "USD",
+      generatedAt,
+      inventoryLocationId: "warehouse-main",
+      fulfillmentType: "physical",
+    });
+    expect(result.records[0].variants).toHaveLength(1);
+    expect(result.skipped[0].reason).toContain("Duplicate product slug");
+
+    const bad = product("not-money", "bad-price");
+    expect(transformProducts([bad], {
+      currency: "USD",
+      generatedAt,
+      inventoryLocationId: "warehouse-main",
+      fulfillmentType: "physical",
+    }).skipped[0].reason).toBe("Product has no importable variants");
+  });
+
+  it("emits localized category records with stable media and fingerprints", () => {
+    const result = transformCollections([{
+      id: "gid://shopify/Collection/9",
+      title: "Summer & More",
+      handle: "summer-more",
+      body_html: "<p>Seasonal <script>bad()</script> choices</p>",
+      image: { src: "https://cdn.example.test/collection.webp", alt: "Seasonal" },
+      published_at: null,
+      updated_at: "bad-date",
+    }], { generatedAt });
+
+    expect(result.records[0].category).toMatchObject({
+      name: JSON.stringify({ en: "Summer & More" }),
+      slug: "summer-more",
+      status: "inactive",
+      updated_at: generatedAt,
+    });
+    expect(result.records[0].category.description).not.toContain("<script>");
+    expect(result.records[0].media[0]).toMatchObject({ contentType: "image/webp" });
+    expect([...result.idMap.keys()][0]).toMatch(/^[a-f0-9]{64}$/);
+  });
+});

--- a/tests/unit/scripts/shopify-migration/transformers/products.test.ts
+++ b/tests/unit/scripts/shopify-migration/transformers/products.test.ts
@@ -231,4 +231,44 @@ describe("catalog transforms", () => {
       handle: "oversized",
     }], { generatedAt, allowedMediaHosts: [] }).records).toEqual([]);
   });
+
+  it("does not reserve category slugs when an earlier record fails later validation", () => {
+    const result = transformCollections([
+      {
+        id: 1,
+        title: "Rejected",
+        handle: "shared-category",
+        body_html: `<p>${"界".repeat(11_000)}</p>`,
+      },
+      { id: 2, title: "Accepted", handle: "shared-category" },
+    ], { generatedAt, allowedMediaHosts: [] });
+
+    expect(result.records).toHaveLength(1);
+    expect(result.records[0].category.name).toBe(JSON.stringify({ en: "Accepted" }));
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0].reason).toContain("SQL-safe");
+  });
+
+  it("does not reserve product slugs or SKUs when an earlier product fails later validation", () => {
+    const rejected = product("1.00", "shared-product");
+    rejected.id = 100;
+    rejected.body_html = `<p>${"😀".repeat(21_000)}</p>`;
+    const accepted = product("2.00", "shared-product");
+    accepted.id = 101;
+    accepted.variants[0].id = 102;
+
+    const result = transformProducts([rejected, accepted], {
+      currency: "USD",
+      generatedAt,
+      inventoryLocationId: "warehouse-main",
+      fulfillmentType: "physical",
+      allowedMediaHosts: ["cdn.example.test"],
+    });
+
+    expect(result.records).toHaveLength(1);
+    expect(result.records[0].product.name).toBe("Configurable product");
+    expect(result.records[0].variants[0].sku).toBe("SKU-ONE");
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0].reason).toContain("SQL-safe");
+  });
 });

--- a/tests/unit/scripts/shopify-migration/transformers/products.test.ts
+++ b/tests/unit/scripts/shopify-migration/transformers/products.test.ts
@@ -23,7 +23,7 @@ function product(price: string, currencyHandle = "example"): ShopifyProduct {
     created_at: "2025-01-01T03:04:05Z",
     updated_at: "2025-01-03T03:04:05Z",
     options: [{ id: 21, name: "Size", values: ["Small", "Large"] }],
-    images: [{ id: 31, src: "https://cdn.example.test/image.JPG?width=800", alt: "Front", width: 800, height: 600 }],
+    images: [{ id: 31, src: "https://cdn.shopify.com/image.JPG?width=800", alt: "Front", width: 800, height: 600 }],
     variants: [{
       id: 41,
       sku: "SKU-ONE",
@@ -49,7 +49,7 @@ describe("catalog transforms", () => {
     const result = transformProducts([product(major, `product-${currency.toLowerCase()}`)], {
       currency,
       generatedAt,
-      allowedMediaHosts: ["cdn.example.test"],
+      allowedMediaHosts: ["cdn.shopify.com"],
       inventoryLocationId: "warehouse-main",
       fulfillmentType: "physical",
     });
@@ -66,7 +66,7 @@ describe("catalog transforms", () => {
       published_at: "2025-01-01T00:00:00Z",
       products_count: 1,
     };
-    const categories = transformCollections([collection], { generatedAt, allowedMediaHosts: ["cdn.example.test"] });
+    const categories = transformCollections([collection], { generatedAt, allowedMediaHosts: ["cdn.shopify.com"] });
     const memberships = collectionMembershipByProduct(
       [{ id: 60, collection_id: 50, product_id: 10 }],
       categories.idMap,
@@ -76,7 +76,7 @@ describe("catalog transforms", () => {
       generatedAt,
       inventoryLocationId: "warehouse-main",
       fulfillmentType: "physical" as const,
-      allowedMediaHosts: ["cdn.example.test"],
+      allowedMediaHosts: ["cdn.shopify.com"],
       categoryIdsByProduct: memberships,
     };
     const first = transformProducts([source], options);
@@ -148,10 +148,10 @@ describe("catalog transforms", () => {
       title: "Summer & More",
       handle: "summer-more",
       body_html: "<p>Seasonal <script>bad()</script> choices</p>",
-      image: { src: "https://cdn.example.test/collection.webp", alt: "Seasonal" },
+      image: { src: "https://cdn.shopify.com/collection.webp", alt: "Seasonal" },
       published_at: null,
       updated_at: "bad-date",
-    }], { generatedAt, allowedMediaHosts: ["cdn.example.test"] });
+    }], { generatedAt, allowedMediaHosts: ["cdn.shopify.com"] });
 
     expect(result.records[0].category).toMatchObject({
       name: JSON.stringify({ en: "Summer & More" }),
@@ -174,7 +174,7 @@ describe("catalog transforms", () => {
       currency: "USD",
       inventoryLocationId: "warehouse-main",
       fulfillmentType: "physical" as const,
-      allowedMediaHosts: ["cdn.example.test"],
+      allowedMediaHosts: ["cdn.shopify.com"],
     };
     const first = transformProducts([source], { ...base, generatedAt: "2026-01-01T00:00:00Z" });
     const second = transformProducts([source], { ...base, generatedAt: "2027-01-01T00:00:00Z" });
@@ -204,7 +204,7 @@ describe("catalog transforms", () => {
       id: 1,
       title: "Denied image",
       handle: "denied-image",
-      image: { src: "https://cdn.example.test/category.png" },
+      image: { src: "https://cdn.shopify.com/category.png" },
     }], { generatedAt, allowedMediaHosts: [] });
     expect(deniedCategory.records[0].media).toEqual([]);
     expect(deniedCategory.records[0].category.primary_image).toBeNull();
@@ -215,14 +215,14 @@ describe("catalog transforms", () => {
     oversized.title = "x".repeat(501);
     oversized.images = Array.from({ length: 251 }, (_, index) => ({
       id: index,
-      src: `https://cdn.example.test/${index}.png`,
+      src: `https://cdn.shopify.com/${index}.png`,
     }));
     expect(transformProducts([oversized], {
       currency: "USD",
       generatedAt,
       inventoryLocationId: "warehouse-main",
       fulfillmentType: "physical",
-      allowedMediaHosts: ["cdn.example.test"],
+      allowedMediaHosts: ["cdn.shopify.com"],
     }).records).toEqual([]);
 
     expect(transformCollections([{
@@ -262,7 +262,7 @@ describe("catalog transforms", () => {
       generatedAt,
       inventoryLocationId: "warehouse-main",
       fulfillmentType: "physical",
-      allowedMediaHosts: ["cdn.example.test"],
+      allowedMediaHosts: ["cdn.shopify.com"],
     });
 
     expect(result.records).toHaveLength(1);

--- a/tests/unit/scripts/shopify-migration/transformers/products.test.ts
+++ b/tests/unit/scripts/shopify-migration/transformers/products.test.ts
@@ -49,6 +49,7 @@ describe("catalog transforms", () => {
     const result = transformProducts([product(major, `product-${currency.toLowerCase()}`)], {
       currency,
       generatedAt,
+      allowedMediaHosts: ["cdn.example.test"],
       inventoryLocationId: "warehouse-main",
       fulfillmentType: "physical",
     });
@@ -65,7 +66,7 @@ describe("catalog transforms", () => {
       published_at: "2025-01-01T00:00:00Z",
       products_count: 1,
     };
-    const categories = transformCollections([collection], { generatedAt });
+    const categories = transformCollections([collection], { generatedAt, allowedMediaHosts: ["cdn.example.test"] });
     const memberships = collectionMembershipByProduct(
       [{ id: 60, collection_id: 50, product_id: 10 }],
       categories.idMap,
@@ -75,6 +76,7 @@ describe("catalog transforms", () => {
       generatedAt,
       inventoryLocationId: "warehouse-main",
       fulfillmentType: "physical" as const,
+      allowedMediaHosts: ["cdn.example.test"],
       categoryIdsByProduct: memberships,
     };
     const first = transformProducts([source], options);
@@ -102,6 +104,7 @@ describe("catalog transforms", () => {
       objectKey: expect.stringMatching(/^products\/[a-z0-9_]+\/1\.jpg$/),
       publicPath: expect.stringMatching(/^\/media\/products\//),
       contentType: "image/jpeg",
+      requiredBeforePersistence: true,
     });
     expect(JSON.parse(transformed.product.external_references)).toHaveProperty("shopify_fingerprint");
     expect(transformed.product.external_references).not.toContain('"10"');
@@ -111,6 +114,7 @@ describe("catalog transforms", () => {
     expect(() => transformProducts([product("1")], {
       currency: "ZZZ",
       generatedAt,
+      allowedMediaHosts: [],
       inventoryLocationId: "warehouse-main",
       fulfillmentType: "physical",
     })).toThrow("Unsupported migration currency");
@@ -121,6 +125,7 @@ describe("catalog transforms", () => {
     const result = transformProducts([duplicateVariants, duplicateProduct], {
       currency: "USD",
       generatedAt,
+      allowedMediaHosts: [],
       inventoryLocationId: "warehouse-main",
       fulfillmentType: "physical",
     });
@@ -131,6 +136,7 @@ describe("catalog transforms", () => {
     expect(transformProducts([bad], {
       currency: "USD",
       generatedAt,
+      allowedMediaHosts: [],
       inventoryLocationId: "warehouse-main",
       fulfillmentType: "physical",
     }).skipped[0].reason).toBe("Product has no importable variants");
@@ -145,7 +151,7 @@ describe("catalog transforms", () => {
       image: { src: "https://cdn.example.test/collection.webp", alt: "Seasonal" },
       published_at: null,
       updated_at: "bad-date",
-    }], { generatedAt });
+    }], { generatedAt, allowedMediaHosts: ["cdn.example.test"] });
 
     expect(result.records[0].category).toMatchObject({
       name: JSON.stringify({ en: "Summer & More" }),
@@ -156,5 +162,48 @@ describe("catalog transforms", () => {
     expect(result.records[0].category.description).not.toContain("<script>");
     expect(result.records[0].media[0]).toMatchObject({ contentType: "image/webp" });
     expect([...result.idMap.keys()][0]).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("does not plan product or category media outside the explicit allowlist", () => {
+    const deniedProduct = transformProducts([product("1")], {
+      currency: "USD",
+      generatedAt,
+      inventoryLocationId: "warehouse-main",
+      fulfillmentType: "physical",
+      allowedMediaHosts: [],
+    });
+    expect(deniedProduct.records[0].media).toEqual([]);
+    expect(deniedProduct.records[0].product.primary_image).toBeNull();
+
+    const deniedCategory = transformCollections([{
+      id: 1,
+      title: "Denied image",
+      handle: "denied-image",
+      image: { src: "https://cdn.example.test/category.png" },
+    }], { generatedAt, allowedMediaHosts: [] });
+    expect(deniedCategory.records[0].media).toEqual([]);
+    expect(deniedCategory.records[0].category.primary_image).toBeNull();
+  });
+
+  it("rejects oversized catalog fields and per-product collections", () => {
+    const oversized = product("1");
+    oversized.title = "x".repeat(501);
+    oversized.images = Array.from({ length: 251 }, (_, index) => ({
+      id: index,
+      src: `https://cdn.example.test/${index}.png`,
+    }));
+    expect(transformProducts([oversized], {
+      currency: "USD",
+      generatedAt,
+      inventoryLocationId: "warehouse-main",
+      fulfillmentType: "physical",
+      allowedMediaHosts: ["cdn.example.test"],
+    }).records).toEqual([]);
+
+    expect(transformCollections([{
+      id: 1,
+      title: "x".repeat(121),
+      handle: "oversized",
+    }], { generatedAt, allowedMediaHosts: [] }).records).toEqual([]);
   });
 });

--- a/tests/unit/scripts/shopify-migration/transformers/redirects.test.ts
+++ b/tests/unit/scripts/shopify-migration/transformers/redirects.test.ts
@@ -18,38 +18,79 @@ describe("redirect transform", () => {
     expect(() => productRedirects([{ legacyHandle: "old", publicSlug: "shopify_product_deadbeef" }])).toThrow(
       "Invalid public route segment",
     );
+    const generated = transformRedirects([], {
+      generated: productRedirects([{ legacyHandle: "old", publicSlug: "new" }]),
+    });
+    expect(generated.records[0].sourceFingerprint).toMatch(/^[a-f0-9]{64}$/);
+    expect(generated.idMap.get(generated.records[0].sourceFingerprint!)).toBe("/products/old");
   });
 
-  it("accepts only safe internal paths and deduplicates identical entries", () => {
+  it("accepts only executable legacy sources and deduplicates identical entries", () => {
     const result = transformRedirects([
-      { id: 1, path: "/old/path", target: "/new/path" },
-      { id: 2, path: "/old/path", target: "/new/path" },
+      { id: 1, path: "/products/old", target: "/product/new" },
+      { id: 2, path: "/products/old", target: "/product/new" },
       { id: 3, path: "/external", target: "https://example.test" },
-      { id: 4, path: "/encoded", target: "/safe/%2e%2e/admin" },
-      { id: 5, path: "/query?x=1", target: "/new" },
+      { id: 4, path: "/pages/encoded", target: "/safe/%2e%2e/admin" },
+      { id: 5, path: "/pages/query?x=1", target: "/new" },
     ]);
     expect(result.records).toHaveLength(1);
-    expect(result.records[0]).toMatchObject({ sourcePath: "/old/path", targetPath: "/new/path" });
+    expect(result.records[0]).toMatchObject({ sourcePath: "/products/old", targetPath: "/product/new" });
     expect(result.warnings[0]).toContain("duplicate");
     expect(result.skipped).toHaveLength(3);
     expect([...result.idMap.keys()].every((key) => /^[a-f0-9]{64}$/.test(key))).toBe(true);
   });
 
-  it("removes conflicting, cyclic, direct-loop, and protected-route redirects", () => {
+  it("accepts every runtime legacy prefix and rejects runtime-inert path forms", () => {
     const result = transformRedirects([
-      { id: 1, path: "/collision", target: "/one" },
-      { id: 2, path: "/collision", target: "/two" },
-      { id: 3, path: "/cycle-a", target: "/cycle-b" },
-      { id: 4, path: "/cycle-b", target: "/cycle-a" },
-      { id: 5, path: "/same", target: "/same" },
-      { id: 6, path: "/checkout", target: "/elsewhere" },
-      { id: 7, path: "/kept", target: "/destination" },
-      { id: 8, path: "/into-cycle", target: "/cycle-a" },
-    ], { protectedSourcePaths: new Set(["/checkout"]) });
+      { id: 1, path: "/products/old", target: "/product/new" },
+      { id: 2, path: "/collections/old", target: "/category/new" },
+      { id: 3, path: "/pages/old", target: "/new" },
+      { id: 4, path: "/blogs/news/old", target: "/blog/new" },
+      { id: 5, path: "/policies/old", target: "/policy/new" },
+      { id: 6, path: "/products/%6f", target: "/product/encoded" },
+      { id: 7, path: "/products/café", target: "/product/unicode" },
+      { id: 8, path: `/products/${Array.from({ length: 12 }, (_, index) => `s${index}`).join("/")}`, target: "/too-many" },
+      { id: 9, path: `/products/${"a".repeat(2040)}`, target: "/long-source" },
+      { id: 10, path: "/products/long-target", target: `/${"a".repeat(2048)}` },
+      { id: 11, path: "/products/legacy-target", target: "/products/new" },
+      { id: 12, path: "/pages/protected", target: "/elsewhere" },
+      { id: undefined, path: "/pages/no-id", target: "/elsewhere" },
+    ] as Parameters<typeof transformRedirects>[0], {
+      protectedSourcePaths: new Set(["/pages/protected"]),
+    });
 
-    expect(result.records.map(({ sourcePath }) => sourcePath)).toEqual(["/kept"]);
-    expect(result.skipped).toHaveLength(7);
-    expect(result.skipped.map(({ reason }) => reason).join(" ")).toMatch(/conflicting targets/);
-    expect(result.skipped.map(({ reason }) => reason).join(" ")).toMatch(/cycle/);
+    expect(result.records.map(({ sourcePath }) => sourcePath)).toEqual([
+      "/blogs/news/old",
+      "/collections/old",
+      "/pages/old",
+      "/policies/old",
+      "/products/old",
+    ]);
+    expect(result.skipped).toHaveLength(8);
+    expect(result.skipped.map(({ reason }) => reason)).toContain(
+      "Shopify redirect requires a bounded source ID and text paths",
+    );
+  });
+
+  it("removes conflicting source mappings", () => {
+    const result = transformRedirects([
+      { id: 1, path: "/products/collision", target: "/product/one" },
+      { id: 2, path: "/products/collision", target: "/product/two" },
+      { id: 3, path: "/products/kept", target: "/product/destination" },
+    ]);
+    expect(result.records.map(({ sourcePath }) => sourcePath)).toEqual(["/products/kept"]);
+    expect(result.skipped).toHaveLength(2);
+    expect(result.skipped[0].reason).toContain("conflicting targets");
+  });
+
+  it("detects cycles before the runtime policy rejects legacy targets", () => {
+    const result = transformRedirects([
+      { id: 1, path: "/products/cycle-a", target: "/products/cycle-b" },
+      { id: 2, path: "/products/cycle-b", target: "/products/cycle-a" },
+      { id: 3, path: "/products/into-cycle", target: "/products/cycle-a" },
+    ]);
+    expect(result.records).toEqual([]);
+    expect(result.skipped).toHaveLength(3);
+    expect(result.skipped.every(({ reason }) => reason.includes("cycle"))).toBe(true);
   });
 });

--- a/tests/unit/scripts/shopify-migration/transformers/redirects.test.ts
+++ b/tests/unit/scripts/shopify-migration/transformers/redirects.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  collectionRedirects,
+  pageRedirects,
+  productRedirects,
+  transformRedirects,
+} from "@/scripts/shopify-migration/transformers/redirects";
+
+describe("redirect transform", () => {
+  it("uses verified public slugs rather than generated entity IDs", () => {
+    expect(productRedirects([{ legacyHandle: "old-product", publicSlug: "new-product" }])[0]).toMatchObject({
+      sourcePath: "/products/old-product",
+      targetPath: "/product/new-product",
+    });
+    expect(collectionRedirects([{ legacyHandle: "old", publicSlug: "new" }])[0].targetPath).toBe("/category/new");
+    expect(pageRedirects([{ legacyHandle: "old", publicSlug: "new" }])[0].targetPath).toBe("/new");
+    expect(() => productRedirects([{ legacyHandle: "old", publicSlug: "shopify_product_deadbeef" }])).toThrow(
+      "Invalid public route segment",
+    );
+  });
+
+  it("accepts only safe internal paths and deduplicates identical entries", () => {
+    const result = transformRedirects([
+      { id: 1, path: "/old/path", target: "/new/path" },
+      { id: 2, path: "/old/path", target: "/new/path" },
+      { id: 3, path: "/external", target: "https://example.test" },
+      { id: 4, path: "/encoded", target: "/safe/%2e%2e/admin" },
+      { id: 5, path: "/query?x=1", target: "/new" },
+    ]);
+    expect(result.records).toHaveLength(1);
+    expect(result.records[0]).toMatchObject({ sourcePath: "/old/path", targetPath: "/new/path" });
+    expect(result.warnings[0]).toContain("duplicate");
+    expect(result.skipped).toHaveLength(3);
+    expect([...result.idMap.keys()].every((key) => /^[a-f0-9]{64}$/.test(key))).toBe(true);
+  });
+
+  it("removes conflicting, cyclic, direct-loop, and protected-route redirects", () => {
+    const result = transformRedirects([
+      { id: 1, path: "/collision", target: "/one" },
+      { id: 2, path: "/collision", target: "/two" },
+      { id: 3, path: "/cycle-a", target: "/cycle-b" },
+      { id: 4, path: "/cycle-b", target: "/cycle-a" },
+      { id: 5, path: "/same", target: "/same" },
+      { id: 6, path: "/checkout", target: "/elsewhere" },
+      { id: 7, path: "/kept", target: "/destination" },
+      { id: 8, path: "/into-cycle", target: "/cycle-a" },
+    ], { protectedSourcePaths: new Set(["/checkout"]) });
+
+    expect(result.records.map(({ sourcePath }) => sourcePath)).toEqual(["/kept"]);
+    expect(result.skipped).toHaveLength(7);
+    expect(result.skipped.map(({ reason }) => reason).join(" ")).toMatch(/conflicting targets/);
+    expect(result.skipped.map(({ reason }) => reason).join(" ")).toMatch(/cycle/);
+  });
+});

--- a/tests/unit/scripts/shopify-migration/transformers/sensitive/customers.test.ts
+++ b/tests/unit/scripts/shopify-migration/transformers/sensitive/customers.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import type { ShopifyCustomer, ShopifyCustomerAddress } from "@/scripts/shopify-migration/lib/types";
+import { transformCustomers } from "@/scripts/shopify-migration/transformers/sensitive/customers";
+
+const generatedAt = "2026-08-14T12:00:00.000Z";
+
+function address(overrides: Partial<ShopifyCustomerAddress> = {}): ShopifyCustomerAddress {
+  return {
+    id: "address-source-private",
+    first_name: "Example",
+    last_name: "Recipient",
+    address1: "1 Example Way",
+    address2: "Unit 2",
+    city: "Example City",
+    province_code: "EX",
+    country_code: "US",
+    zip: "00000",
+    default: true,
+    ...overrides,
+  };
+}
+
+function customer(overrides: Partial<ShopifyCustomer> = {}): ShopifyCustomer {
+  return {
+    id: "customer-source-private",
+    email: "person@example.invalid",
+    first_name: "Example",
+    last_name: "Person",
+    verified_email: true,
+    accepts_marketing: false,
+    tags: "Member, Example, member",
+    orders_count: 2,
+    addresses: [address()],
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-02-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("sensitive customer transform", () => {
+  it("is deterministic and emits current snake-case person and nested address shapes", () => {
+    const first = transformCustomers([customer()], { generatedAt });
+    const second = transformCustomers([customer()], { generatedAt });
+    expect(first).toEqual(second);
+    expect(first.skipped).toEqual([]);
+
+    const transformed = first.records[0];
+    const record = transformed.customer;
+    expect(record.id).toMatch(/^shopify_customer_[a-f0-9]{24}$/);
+    expect(record.status).toBe("active");
+    expect(JSON.parse(record.person)).toEqual({
+      email: "person@example.invalid",
+      first_name: "Example",
+      last_name: "Person",
+      full_name: "Example Person",
+    });
+    expect(JSON.parse(record.person)).not.toHaveProperty("firstName");
+    expect(JSON.parse(record.addresses!)).toEqual([expect.objectContaining({
+      id: expect.stringMatching(/^shopify_customer_address_/),
+      type: "shipping",
+      is_default: true,
+      verification_status: "unverified",
+      address: expect.objectContaining({
+        line1: "1 Example Way",
+        line2: "Unit 2",
+        city: "Example City",
+        region: "EX",
+        postal_code: "00000",
+        country: "US",
+        recipient: "Example Recipient",
+        status: "unverified",
+      }),
+    })]);
+    expect(JSON.parse(record.communication_preferences)).toEqual({
+      email: { opted_in: false, verified: true },
+    });
+    expect(JSON.parse(record.tags!)).toEqual(["Member", "Example"]);
+    expect(transformed.sourceFingerprint).toMatch(/^[a-f0-9]{64}$/);
+    expect(transformed.emailFingerprint).toMatch(/^[a-f0-9]{64}$/);
+    expect([...first.idMap.values()]).toEqual([record.id]);
+    expect([...first.emailIdMap.values()]).toEqual([record.id]);
+  });
+
+  it("persists provider fingerprints instead of raw provider identifiers", () => {
+    const result = transformCustomers([customer()], { generatedAt });
+    const serialized = JSON.stringify(result.records[0]);
+    expect(serialized).not.toContain("customer-source-private");
+    expect(serialized).not.toContain("address-source-private");
+    expect(JSON.parse(result.records[0].customer.external_references)).toEqual({
+      shopify_fingerprint: result.records[0].sourceFingerprint,
+    });
+  });
+
+  it("keeps unverified identity conservative and omits incomplete addresses", () => {
+    const result = transformCustomers([customer({
+      verified_email: false,
+      addresses: [address({ country_code: undefined, country: "Long country name" })],
+    })], { generatedAt });
+    expect(result.records[0].customer.status).toBe("pending_verification");
+    expect(result.records[0].customer.addresses).toBeNull();
+    expect(result.warnings[0]).toContain("address omitted");
+  });
+
+  it("skips invalid, duplicate, and over-bounded sensitive records", () => {
+    const duplicateEmail = customer({ id: "another-source" });
+    const tooManyAddresses = customer({
+      id: "too-many-addresses",
+      email: "many@example.invalid",
+      addresses: Array.from({ length: 26 }, (_, index) => address({ id: index })),
+    });
+    const result = transformCustomers([
+      customer(),
+      duplicateEmail,
+      customer({ id: "bad-email", email: "not-an-email" }),
+      tooManyAddresses,
+    ], { generatedAt });
+
+    expect(result.records).toHaveLength(1);
+    expect(result.skipped.map(({ reason }) => reason)).toEqual([
+      "Duplicate normalized customer email",
+      "Email address is invalid",
+      "Customer has too many addresses",
+    ]);
+    expect(result.skipped.every((entry) => !("record" in entry))).toBe(true);
+  });
+});

--- a/tests/unit/scripts/shopify-migration/transformers/sensitive/customers.test.ts
+++ b/tests/unit/scripts/shopify-migration/transformers/sensitive/customers.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { ShopifyCustomer, ShopifyCustomerAddress } from "@/scripts/shopify-migration/lib/types";
-import { transformCustomers } from "@/scripts/shopify-migration/transformers/sensitive/customers";
+import {
+  materializeCustomers,
+  transformCustomers,
+} from "@/scripts/shopify-migration/transformers/sensitive/customers";
 
 const generatedAt = "2026-08-14T12:00:00.000Z";
 
@@ -45,8 +48,14 @@ describe("sensitive customer transform", () => {
     expect(first.skipped).toEqual([]);
 
     const transformed = first.records[0];
-    const record = transformed.customer;
-    expect(record.id).toMatch(/^shopify_customer_[a-f0-9]{24}$/);
+    expect(transformed).not.toHaveProperty("id");
+    expect(transformed).not.toHaveProperty("customer");
+    expect(transformed.provisioningReference).toMatch(/^shopify_customer_provisioning_[a-f0-9]{24}$/);
+    const materialized = materializeCustomers(first.records, new Map([
+      [transformed.sourceFingerprint, "user_1234567890"],
+    ]));
+    const record = materialized.records[0];
+    expect(record.id).toBe("user_1234567890");
     expect(record.status).toBe("active");
     expect(JSON.parse(record.person)).toEqual({
       email: "person@example.invalid",
@@ -77,8 +86,8 @@ describe("sensitive customer transform", () => {
     expect(JSON.parse(record.tags!)).toEqual(["Member", "Example"]);
     expect(transformed.sourceFingerprint).toMatch(/^[a-f0-9]{64}$/);
     expect(transformed.emailFingerprint).toMatch(/^[a-f0-9]{64}$/);
-    expect([...first.idMap.values()]).toEqual([record.id]);
-    expect([...first.emailIdMap.values()]).toEqual([record.id]);
+    expect([...materialized.idMap.values()]).toEqual([record.id]);
+    expect([...materialized.emailIdMap.values()]).toEqual([record.id]);
   });
 
   it("persists provider fingerprints instead of raw provider identifiers", () => {
@@ -86,7 +95,7 @@ describe("sensitive customer transform", () => {
     const serialized = JSON.stringify(result.records[0]);
     expect(serialized).not.toContain("customer-source-private");
     expect(serialized).not.toContain("address-source-private");
-    expect(JSON.parse(result.records[0].customer.external_references)).toEqual({
+    expect(JSON.parse(result.records[0].customerFields.external_references)).toEqual({
       shopify_fingerprint: result.records[0].sourceFingerprint,
     });
   });
@@ -96,9 +105,41 @@ describe("sensitive customer transform", () => {
       verified_email: false,
       addresses: [address({ country_code: undefined, country: "Long country name" })],
     })], { generatedAt });
-    expect(result.records[0].customer.status).toBe("pending_verification");
-    expect(result.records[0].customer.addresses).toBeNull();
+    expect(result.records[0].customerFields.status).toBe("pending_verification");
+    expect(result.records[0].customerFields.addresses).toBeNull();
     expect(result.warnings[0]).toContain("address omitted");
+  });
+
+  it("cannot materialize provisional or missing identities as customer primary keys", () => {
+    const plans = transformCustomers([customer()], { generatedAt }).records;
+    const fingerprint = plans[0].sourceFingerprint;
+    const missing = materializeCustomers(plans, new Map());
+    const provisional = materializeCustomers(plans, new Map([
+      [fingerprint, plans[0].provisioningReference],
+    ]));
+
+    expect(missing.records).toEqual([]);
+    expect(provisional.records).toEqual([]);
+    expect(provisional.skipped[0].reason).toBe("Customer requires a resolved Clerk user ID");
+    expect(JSON.stringify(provisional)).not.toContain('"id":"shopify_customer_');
+  });
+
+  it("cannot override a resolved Clerk ID through forged insert fields", () => {
+    const plans = transformCustomers([customer()], { generatedAt }).records;
+    const fingerprint = plans[0].sourceFingerprint;
+    const forged = [{
+      ...plans[0],
+      customerFields: {
+        ...plans[0].customerFields,
+        id: "shopify_customer_deadbeefdeadbeefdeadbeef",
+      },
+    }];
+
+    const result = materializeCustomers(forged, new Map([
+      [fingerprint, "user_1234567890"],
+    ]));
+    expect(result.records[0].id).toBe("user_1234567890");
+    expect(JSON.stringify(result.records[0])).not.toContain("shopify_customer_deadbeef");
   });
 
   it("skips invalid, duplicate, and over-bounded sensitive records", () => {

--- a/tests/unit/scripts/shopify-migration/transformers/sensitive/customers.test.ts
+++ b/tests/unit/scripts/shopify-migration/transformers/sensitive/customers.test.ts
@@ -100,6 +100,17 @@ describe("sensitive customer transform", () => {
     });
   });
 
+  it("persists identical plans when only the operator run time changes", () => {
+    const first = transformCustomers([customer({ created_at: undefined, updated_at: undefined })], {
+      generatedAt,
+    });
+    const later = transformCustomers([customer({ created_at: undefined, updated_at: undefined })], {
+      generatedAt: "2027-08-14T12:00:00.000Z",
+    });
+    expect(first).toEqual(later);
+    expect(first.records[0].customerFields.created_at).toBe("1970-01-01T00:00:00.000Z");
+  });
+
   it("keeps unverified identity conservative and omits incomplete addresses", () => {
     const result = transformCustomers([customer({
       verified_email: false,

--- a/tests/unit/scripts/shopify-migration/transformers/sensitive/orders.test.ts
+++ b/tests/unit/scripts/shopify-migration/transformers/sensitive/orders.test.ts
@@ -42,7 +42,7 @@ function order(overrides: Partial<ShopifyOrder> = {}): ShopifyOrder {
 
 function mappings() {
   return {
-    customerIds: new Map([[providerFingerprint("shopify", "customer", "customer-source-private"), "customer_target"]]),
+    customerIds: new Map([[providerFingerprint("shopify", "customer", "customer-source-private"), "user_1234567890"]]),
     productIds: new Map([[providerFingerprint("shopify", "product", "product-source-private"), "product_target"]]),
     variantIds: new Map([[providerFingerprint("shopify", "variant", "variant-source-private"), "variant_target"]]),
   };
@@ -50,7 +50,7 @@ function mappings() {
 
 describe("historical Shopify order transform", () => {
   it("emits deterministic exact Money, OrderItem, address, and timestamp shapes", () => {
-    const options = { generatedAt, ...mappings() };
+    const options = { generatedAt, unresolvedCustomer: "reject" as const, ...mappings() };
     const first = transformHistoricalOrders([order()], options);
     const second = transformHistoricalOrders([order()], options);
     expect(first).toEqual(second);
@@ -58,7 +58,7 @@ describe("historical Shopify order transform", () => {
 
     const record = first.records[0].order;
     expect(record.id).toMatch(/^shopify_order_[a-f0-9]{24}$/);
-    expect(record.customer_id).toBe("customer_target");
+    expect(record.customer_id).toBe("user_1234567890");
     expect(record.status).toBe("shipped");
     expect(record.total_amount).toBe(JSON.stringify({ amount: 2349, currency: "USD" }));
     expect(JSON.parse(record.items)).toEqual([{
@@ -85,7 +85,11 @@ describe("historical Shopify order transform", () => {
   });
 
   it("marks external history read-only and never Stripe-paid or effect-eligible", () => {
-    const result = transformHistoricalOrders([order()], { generatedAt, ...mappings() });
+    const result = transformHistoricalOrders([order()], {
+      generatedAt,
+      unresolvedCustomer: "reject",
+      ...mappings(),
+    });
     const record = result.records[0].order;
     const extensions = JSON.parse(record.extensions);
     const external = JSON.parse(record.external_references);
@@ -109,7 +113,7 @@ describe("historical Shopify order transform", () => {
       order({ id: "refunded", financial_status: "refunded", fulfillment_status: null }),
       order({ id: "voided", financial_status: "voided", cancelled_at: "2025-01-03T00:00:00Z" }),
       order({ id: "partial", financial_status: "partially_paid", fulfillment_status: "partial" }),
-    ], { generatedAt, ...mappings() });
+    ], { generatedAt, unresolvedCustomer: "reject", ...mappings() });
     expect(result.records.map(({ order: value }) => [value.status, value.payment_status])).toEqual([
       ["refunded", "refunded"],
       ["cancelled", "failed"],
@@ -118,7 +122,10 @@ describe("historical Shopify order transform", () => {
   });
 
   it("retains missing catalog identities as deterministic historical references", () => {
-    const result = transformHistoricalOrders([order()], { generatedAt });
+    const result = transformHistoricalOrders([order()], {
+      generatedAt,
+      unresolvedCustomer: "guest",
+    });
     const item = JSON.parse(result.records[0].order.items)[0];
     expect(item.product_id).toMatch(/^shopify_historical_product_/);
     expect(item.variant_id).toMatch(/^shopify_historical_variant_/);
@@ -132,7 +139,7 @@ describe("historical Shopify order transform", () => {
       order({ id: "quantity", line_items: [{ ...order().line_items[0], quantity: 0 }] }),
       order({ id: "discount", line_items: [{ ...order().line_items[0], total_discount: "99.00" }] }),
       order({ id: "oversized", line_items: Array.from({ length: 501 }, () => order().line_items[0]) }),
-    ], { generatedAt, ...mappings() });
+    ], { generatedAt, unresolvedCustomer: "reject", ...mappings() });
     expect(result.records).toEqual([]);
     expect(result.skipped.map(({ reason }) => reason)).toEqual([
       "Unsupported migration currency: ZZZ",
@@ -141,5 +148,38 @@ describe("historical Shopify order transform", () => {
       "Orders require 1-500 line items",
     ]);
     expect(result.skipped.every((entry) => !("record" in entry))).toBe(true);
+  });
+
+  it("never persists provisional customer IDs and requires explicit unresolved handling", () => {
+    const customerFingerprint = providerFingerprint("shopify", "customer", "customer-source-private");
+    const provisional = new Map([
+      [customerFingerprint, "shopify_customer_deadbeefdeadbeefdeadbeef"],
+    ]);
+    const rejected = transformHistoricalOrders([order()], {
+      generatedAt,
+      unresolvedCustomer: "reject",
+      ...mappings(),
+      customerIds: provisional,
+    });
+    const guest = transformHistoricalOrders([order()], {
+      generatedAt,
+      unresolvedCustomer: "guest",
+      ...mappings(),
+      customerIds: provisional,
+    });
+
+    expect(rejected.records).toEqual([]);
+    expect(rejected.skipped[0].reason).toBe("Order customer requires a resolved Clerk user ID");
+    expect(guest.records[0].order.customer_id).toBeNull();
+    expect(JSON.stringify(guest.records[0])).not.toContain("shopify_customer_deadbeef");
+  });
+
+  it("rejects a missing unresolved-customer policy at runtime", () => {
+    expect(() => transformHistoricalOrders([order()], {
+      generatedAt,
+      ...mappings(),
+    } as unknown as Parameters<typeof transformHistoricalOrders>[1])).toThrow(
+      "unresolvedCustomer must explicitly be reject or guest",
+    );
   });
 });

--- a/tests/unit/scripts/shopify-migration/transformers/sensitive/orders.test.ts
+++ b/tests/unit/scripts/shopify-migration/transformers/sensitive/orders.test.ts
@@ -108,6 +108,18 @@ describe("historical Shopify order transform", () => {
     expect(JSON.stringify(record)).not.toContain("order-source-private");
   });
 
+  it("persists identical rows when only the operator run time changes", () => {
+    const input = order({ created_at: undefined, updated_at: undefined });
+    const options = { unresolvedCustomer: "reject" as const, ...mappings() };
+    const first = transformHistoricalOrders([input], { generatedAt, ...options });
+    const later = transformHistoricalOrders([input], {
+      generatedAt: "2027-08-14T12:00:00.000Z",
+      ...options,
+    });
+    expect(first).toEqual(later);
+    expect(first.records[0].order.created_at).toBe("1970-01-01T00:00:00.000Z");
+  });
+
   it("uses conservative payment and fulfillment mappings", () => {
     const result = transformHistoricalOrders([
       order({ id: "refunded", financial_status: "refunded", fulfillment_status: null }),

--- a/tests/unit/scripts/shopify-migration/transformers/sensitive/orders.test.ts
+++ b/tests/unit/scripts/shopify-migration/transformers/sensitive/orders.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+import type { ShopifyOrder } from "@/scripts/shopify-migration/lib/types";
+import { providerFingerprint } from "@/scripts/shopify-migration/lib/ids";
+import { transformHistoricalOrders } from "@/scripts/shopify-migration/transformers/sensitive/orders";
+
+const generatedAt = "2026-08-14T12:00:00.000Z";
+
+function order(overrides: Partial<ShopifyOrder> = {}): ShopifyOrder {
+  return {
+    id: "order-source-private",
+    name: "#1001",
+    email: "buyer@example.invalid",
+    customer: { id: "customer-source-private" },
+    financial_status: "paid",
+    fulfillment_status: "fulfilled",
+    total_price: "23.49",
+    currency: "USD",
+    line_items: [{
+      id: "line-source-private",
+      product_id: "product-source-private",
+      variant_id: "variant-source-private",
+      title: "Example item",
+      sku: "SKU-EXAMPLE",
+      quantity: 2,
+      price: "10.00",
+      total_discount: "1.51",
+    }],
+    shipping_address: {
+      first_name: "Example",
+      last_name: "Recipient",
+      address1: "1 Example Way",
+      city: "Example City",
+      province_code: "EX",
+      zip: "00000",
+      country_code: "US",
+    },
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-01-02T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function mappings() {
+  return {
+    customerIds: new Map([[providerFingerprint("shopify", "customer", "customer-source-private"), "customer_target"]]),
+    productIds: new Map([[providerFingerprint("shopify", "product", "product-source-private"), "product_target"]]),
+    variantIds: new Map([[providerFingerprint("shopify", "variant", "variant-source-private"), "variant_target"]]),
+  };
+}
+
+describe("historical Shopify order transform", () => {
+  it("emits deterministic exact Money, OrderItem, address, and timestamp shapes", () => {
+    const options = { generatedAt, ...mappings() };
+    const first = transformHistoricalOrders([order()], options);
+    const second = transformHistoricalOrders([order()], options);
+    expect(first).toEqual(second);
+    expect(first.skipped).toEqual([]);
+
+    const record = first.records[0].order;
+    expect(record.id).toMatch(/^shopify_order_[a-f0-9]{24}$/);
+    expect(record.customer_id).toBe("customer_target");
+    expect(record.status).toBe("shipped");
+    expect(record.total_amount).toBe(JSON.stringify({ amount: 2349, currency: "USD" }));
+    expect(JSON.parse(record.items)).toEqual([{
+      id: expect.stringMatching(/^shopify_order_item_/),
+      product_id: "product_target",
+      variant_id: "variant_target",
+      sku: "SKU-EXAMPLE",
+      quantity: 2,
+      unit_price: { amount: 1000, currency: "USD" },
+      total_price: { amount: 1849, currency: "USD" },
+      product_name: "Example item",
+    }]);
+    expect(JSON.parse(record.shipping_address!)).toEqual(expect.objectContaining({
+      line1: "1 Example Way",
+      city: "Example City",
+      region: "EX",
+      postal_code: "00000",
+      country: "US",
+      recipient: "Example Recipient",
+      status: "unverified",
+    }));
+    expect(record.created_at).toBe("2025-01-01T00:00:00.000Z");
+    expect(record.updated_at).toBe("2025-01-02T00:00:00.000Z");
+  });
+
+  it("marks external history read-only and never Stripe-paid or effect-eligible", () => {
+    const result = transformHistoricalOrders([order()], { generatedAt, ...mappings() });
+    const record = result.records[0].order;
+    const extensions = JSON.parse(record.extensions);
+    const external = JSON.parse(record.external_references);
+
+    expect(record.payment_status).toBe("pending");
+    expect(record.payment_method).toBeNull();
+    expect(external).toEqual({ shopify_fingerprint: result.records[0].sourceFingerprint });
+    expect(extensions.migration).toMatchObject({ historical: true, read_only: true, imported: true });
+    expect(extensions.payment_provenance).toEqual({
+      authority: "external_unverified",
+      refundable: false,
+      paid_effects_eligible: false,
+      source_status: "paid",
+    });
+    expect(JSON.stringify(record)).not.toMatch(/payment_intent_id|checkout_total|checkout_tender|discount_codes/);
+    expect(JSON.stringify(record)).not.toContain("order-source-private");
+  });
+
+  it("uses conservative payment and fulfillment mappings", () => {
+    const result = transformHistoricalOrders([
+      order({ id: "refunded", financial_status: "refunded", fulfillment_status: null }),
+      order({ id: "voided", financial_status: "voided", cancelled_at: "2025-01-03T00:00:00Z" }),
+      order({ id: "partial", financial_status: "partially_paid", fulfillment_status: "partial" }),
+    ], { generatedAt, ...mappings() });
+    expect(result.records.map(({ order: value }) => [value.status, value.payment_status])).toEqual([
+      ["refunded", "refunded"],
+      ["cancelled", "failed"],
+      ["shipped", "pending"],
+    ]);
+  });
+
+  it("retains missing catalog identities as deterministic historical references", () => {
+    const result = transformHistoricalOrders([order()], { generatedAt });
+    const item = JSON.parse(result.records[0].order.items)[0];
+    expect(item.product_id).toMatch(/^shopify_historical_product_/);
+    expect(item.variant_id).toMatch(/^shopify_historical_variant_/);
+    expect(result.records[0].order.customer_id).toBeNull();
+    expect(result.warnings[0]).toContain("guest history");
+  });
+
+  it("skips unsupported currency, invalid quantities, unsafe discounts, and oversized orders", () => {
+    const result = transformHistoricalOrders([
+      order({ id: "currency", currency: "ZZZ" }),
+      order({ id: "quantity", line_items: [{ ...order().line_items[0], quantity: 0 }] }),
+      order({ id: "discount", line_items: [{ ...order().line_items[0], total_discount: "99.00" }] }),
+      order({ id: "oversized", line_items: Array.from({ length: 501 }, () => order().line_items[0]) }),
+    ], { generatedAt, ...mappings() });
+    expect(result.records).toEqual([]);
+    expect(result.skipped.map(({ reason }) => reason)).toEqual([
+      "Unsupported migration currency: ZZZ",
+      "Order item quantity is invalid",
+      "Order item discount exceeds its gross total",
+      "Orders require 1-500 line items",
+    ]);
+    expect(result.skipped.every((entry) => !("record" in entry))).toBe(true);
+  });
+});

--- a/tests/unit/scripts/shopify-migration/transformers/sensitive/reviews.test.ts
+++ b/tests/unit/scripts/shopify-migration/transformers/sensitive/reviews.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { JudgeMeFileRow, JudgeMeReview } from "@/scripts/shopify-migration/lib/types";
 import { providerFingerprint } from "@/scripts/shopify-migration/lib/ids";
 import {
+  type ImportedReviewAttribution,
   judgeMeReviewFingerprint,
   normalizeJudgeMeFileRow,
   normalizeJudgeMeFileRows,
@@ -10,7 +11,7 @@ import {
 
 const generatedAt = "2026-08-14T12:00:00.000Z";
 const productId = "product_target";
-const customerId = "customer_target";
+const customerId = "user_1234567890";
 
 function review(overrides: Partial<JudgeMeReview> = {}): JudgeMeReview {
   return {
@@ -27,7 +28,7 @@ function review(overrides: Partial<JudgeMeReview> = {}): JudgeMeReview {
   };
 }
 
-function mappings() {
+function mappings(inputs: readonly JudgeMeReview[] = [review()]) {
   return {
     productIds: new Map([
       [providerFingerprint("shopify", "product", "product-source-private"), productId],
@@ -36,6 +37,11 @@ function mappings() {
     customerIdsByEmailFingerprint: new Map([
       [providerFingerprint("shopify", "customer_email", "reviewer@example.invalid"), customerId],
     ]),
+    reviewAttributions: new Map<string, ImportedReviewAttribution>(inputs.map((input) => [judgeMeReviewFingerprint(input), {
+      productId,
+      orderId: "order_target",
+      customerId,
+    }])),
   };
 }
 
@@ -98,7 +104,7 @@ describe("Judge.me review transform", () => {
       id: expect.stringMatching(/^judge_me_review_/),
       product_id: productId,
       customer_id: customerId,
-      order_id: expect.stringMatching(/^judge_me_imported_order_/),
+      order_id: "order_target",
       order_item_id: null,
       status: "pending",
       is_verified: false,
@@ -114,9 +120,20 @@ describe("Judge.me review transform", () => {
     expect(JSON.stringify(transformed)).not.toContain("product-source-private");
   });
 
+  it("persists identical rows when only the operator run time changes", () => {
+    const input = review();
+    const options = mappings([input]);
+    const first = transformJudgeMeReviews([input], { generatedAt, ...options });
+    const later = transformJudgeMeReviews([input], {
+      generatedAt: "2027-08-14T12:00:00.000Z",
+      ...options,
+    });
+    expect(first).toEqual(later);
+  });
+
   it("fingerprints bounded long review content without persisting it in identity metadata", () => {
     const input = review({ body: "Synthetic sentence. ".repeat(300) });
-    const result = transformJudgeMeReviews([input], { generatedAt, ...mappings() });
+    const result = transformJudgeMeReviews([input], { generatedAt, ...mappings([input]) });
     expect(result.records).toHaveLength(1);
     expect(result.records[0].sourceFingerprint).toMatch(/^[a-f0-9]{64}$/);
     expect(result.records[0].review.metadata).not.toContain("Synthetic sentence");
@@ -125,9 +142,16 @@ describe("Judge.me review transform", () => {
   it("sets verified only from explicit matching order provenance", () => {
     const input = review({ status: "published" });
     const fingerprint = judgeMeReviewFingerprint(input);
+    const resolvedMappings = mappings([input]);
+    resolvedMappings.reviewAttributions.set(fingerprint, {
+      productId,
+      customerId,
+      orderId: "order_target",
+      orderItemId: "line_target",
+    });
     const result = transformJudgeMeReviews([input], {
       generatedAt,
-      ...mappings(),
+      ...resolvedMappings,
       verifiedPurchases: new Map([[fingerprint, {
         verified: true,
         productId,
@@ -153,7 +177,7 @@ describe("Judge.me review transform", () => {
     const fingerprint = judgeMeReviewFingerprint(input);
     const result = transformJudgeMeReviews([input], {
       generatedAt,
-      ...mappings(),
+      ...mappings([input]),
       verifiedPurchases: new Map([[fingerprint, {
         verified: true,
         productId: "different_product",
@@ -169,11 +193,12 @@ describe("Judge.me review transform", () => {
   });
 
   it("maps only explicit publication and suppression states", () => {
-    const result = transformJudgeMeReviews([
+    const inputs = [
       review({ review_date: "2025-01-01", status: "approved" }),
       review({ review_date: "2025-01-02", status: "spam" }),
       review({ review_date: "2025-01-03", status: "unknown" }),
-    ], { generatedAt, ...mappings() });
+    ];
+    const result = transformJudgeMeReviews(inputs, { generatedAt, ...mappings(inputs) });
     expect(result.records.map(({ review: value }) => [value.status, Boolean(value.published_at)])).toEqual([
       ["published", true],
       ["suppressed", false],
@@ -189,13 +214,19 @@ describe("Judge.me review transform", () => {
       providerFingerprint("shopify", "product_handle", "example-product"),
       "different_product",
     );
-    const invalid = transformJudgeMeReviews([
+    const invalidInputs = [
       review({ rating: 4.5 }),
       review({ review_date: "2025-01-02", body: "" }),
-    ], { generatedAt, ...mappings() });
+    ];
+    const invalid = transformJudgeMeReviews(invalidInputs, {
+      generatedAt,
+      ...mappings(invalidInputs),
+    });
     const ambiguousResult = transformJudgeMeReviews([ambiguous], {
       generatedAt,
       ...ambiguousMappings,
+      ...mappings([ambiguous]),
+      productIds: ambiguousMappings.productIds,
     });
     const duplicates = transformJudgeMeReviews([duplicate, duplicate], { generatedAt, ...mappings() });
 
@@ -209,5 +240,44 @@ describe("Judge.me review transform", () => {
     expect(duplicates.skipped[0].reason).toBe("Duplicate review source identity");
     expect([...invalid.skipped, ...ambiguousResult.skipped, ...duplicates.skipped]
       .every((entry) => !("record" in entry))).toBe(true);
+  });
+
+  it("refuses dangling synthetic order or customer identities", () => {
+    const input = review();
+    const missing = transformJudgeMeReviews([input], {
+      generatedAt,
+      ...mappings([input]),
+      reviewAttributions: new Map(),
+    });
+    const provisional = transformJudgeMeReviews([input], {
+      generatedAt,
+      ...mappings([input]),
+      reviewAttributions: new Map([[judgeMeReviewFingerprint(input), {
+        productId,
+        orderId: "judge_me_imported_order_deadbeef",
+        customerId,
+      }]]),
+    });
+    const provisionalCustomer = transformJudgeMeReviews([input], {
+      generatedAt,
+      ...mappings([input]),
+      reviewAttributions: new Map([[judgeMeReviewFingerprint(input), {
+        productId,
+        orderId: "order_target",
+        customerId: "judge_me_imported_customer_deadbeef",
+      }]]),
+    });
+
+    expect(missing.records).toEqual([]);
+    expect(provisional.records).toEqual([]);
+    expect(provisionalCustomer.records).toEqual([]);
+    expect(missing.skipped[0].reason).toContain("real matching order");
+    expect(JSON.stringify([
+      ...missing.records,
+      ...provisional.records,
+      ...provisionalCustomer.records,
+    ])).not.toMatch(
+      /judge_me_imported_(?:order|customer)/,
+    );
   });
 });

--- a/tests/unit/scripts/shopify-migration/transformers/sensitive/reviews.test.ts
+++ b/tests/unit/scripts/shopify-migration/transformers/sensitive/reviews.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
-import type { JudgeMeReview } from "@/scripts/shopify-migration/lib/types";
+import type { JudgeMeFileRow, JudgeMeReview } from "@/scripts/shopify-migration/lib/types";
 import { providerFingerprint } from "@/scripts/shopify-migration/lib/ids";
 import {
   judgeMeReviewFingerprint,
+  normalizeJudgeMeFileRow,
+  normalizeJudgeMeFileRows,
   transformJudgeMeReviews,
 } from "@/scripts/shopify-migration/transformers/sensitive/reviews";
 
@@ -38,6 +40,51 @@ function mappings() {
 }
 
 describe("Judge.me review transform", () => {
+  it("normalizes bounded Judge.me CSV strings into typed reviews", () => {
+    const row: JudgeMeFileRow = {
+      title: "  Example review  ",
+      body: "Line one.\r\nLine two.",
+      rating: " 5 ",
+      created_at: " 2025-01-01T00:00:00Z ",
+      reviewer_name: " Example Reviewer ",
+      reviewer_email: " REVIEWER@EXAMPLE.INVALID ",
+      product_id: " product-source-private ",
+      product_handle: " example-product ",
+      status: " approved ",
+      ignored_private_column: "not retained",
+    };
+
+    expect(normalizeJudgeMeFileRow(row)).toEqual({
+      title: "Example review",
+      body: "Line one.\nLine two.",
+      rating: 5,
+      review_date: "2025-01-01T00:00:00Z",
+      reviewer_name: "Example Reviewer",
+      reviewer_email: "reviewer@example.invalid",
+      product_id: "product-source-private",
+      product_handle: "example-product",
+      status: "approved",
+    });
+  });
+
+  it("rejects invalid CSV ratings and bounds without retaining raw rows", () => {
+    const privateMarker = "private-reviewer@example.invalid";
+    const result = normalizeJudgeMeFileRows([
+      { rating: "4.5", body: "Synthetic body", product_handle: "example-product" },
+      { rating: "5", body: "x".repeat(10_001), product_handle: "example-product" },
+      { rating: "5", body: "Synthetic body", reviewer_email: privateMarker },
+    ]);
+
+    expect(result.records).toEqual([]);
+    expect(result.skipped.map(({ reason }) => reason)).toEqual([
+      "Review rating must be an integer from 1 to 5",
+      "Text exceeds 10000 characters",
+      "Review product identity is missing",
+    ]);
+    expect(result.skipped.every((entry) => entry.sourceFingerprint === null)).toBe(true);
+    expect(JSON.stringify(result)).not.toContain(privateMarker);
+  });
+
   it("is deterministic and defaults to pending, unverified history", () => {
     const options = { generatedAt, ...mappings() };
     const first = transformJudgeMeReviews([review()], options);

--- a/tests/unit/scripts/shopify-migration/transformers/sensitive/reviews.test.ts
+++ b/tests/unit/scripts/shopify-migration/transformers/sensitive/reviews.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from "vitest";
+import type { JudgeMeReview } from "@/scripts/shopify-migration/lib/types";
+import { providerFingerprint } from "@/scripts/shopify-migration/lib/ids";
+import {
+  judgeMeReviewFingerprint,
+  transformJudgeMeReviews,
+} from "@/scripts/shopify-migration/transformers/sensitive/reviews";
+
+const generatedAt = "2026-08-14T12:00:00.000Z";
+const productId = "product_target";
+const customerId = "customer_target";
+
+function review(overrides: Partial<JudgeMeReview> = {}): JudgeMeReview {
+  return {
+    title: "Example review",
+    body: "A synthetic review body for migration tests.",
+    rating: 5,
+    review_date: "2025-01-01T00:00:00Z",
+    reviewer_name: "Example Reviewer",
+    reviewer_email: "reviewer@example.invalid",
+    product_id: "product-source-private",
+    product_handle: "example-product",
+    source: "judge.me",
+    ...overrides,
+  };
+}
+
+function mappings() {
+  return {
+    productIds: new Map([
+      [providerFingerprint("shopify", "product", "product-source-private"), productId],
+      [providerFingerprint("shopify", "product_handle", "example-product"), productId],
+    ]),
+    customerIdsByEmailFingerprint: new Map([
+      [providerFingerprint("shopify", "customer_email", "reviewer@example.invalid"), customerId],
+    ]),
+  };
+}
+
+describe("Judge.me review transform", () => {
+  it("is deterministic and defaults to pending, unverified history", () => {
+    const options = { generatedAt, ...mappings() };
+    const first = transformJudgeMeReviews([review()], options);
+    const second = transformJudgeMeReviews([review()], options);
+    expect(first).toEqual(second);
+    expect(first.skipped).toEqual([]);
+
+    const transformed = first.records[0];
+    expect(transformed.sourceFingerprint).toMatch(/^[a-f0-9]{64}$/);
+    expect(transformed.review).toMatchObject({
+      id: expect.stringMatching(/^judge_me_review_/),
+      product_id: productId,
+      customer_id: customerId,
+      order_id: expect.stringMatching(/^judge_me_imported_order_/),
+      order_item_id: null,
+      status: "pending",
+      is_verified: false,
+      submitted_at: "2025-01-01T00:00:00.000Z",
+      published_at: null,
+    });
+    expect(JSON.parse(transformed.review.metadata)).toMatchObject({
+      verified_purchase_provenance: "none",
+      reviewer_name: "Example Reviewer",
+      migration: { provider: "judge_me", imported: true },
+    });
+    expect(JSON.stringify(transformed)).not.toContain("reviewer@example.invalid");
+    expect(JSON.stringify(transformed)).not.toContain("product-source-private");
+  });
+
+  it("fingerprints bounded long review content without persisting it in identity metadata", () => {
+    const input = review({ body: "Synthetic sentence. ".repeat(300) });
+    const result = transformJudgeMeReviews([input], { generatedAt, ...mappings() });
+    expect(result.records).toHaveLength(1);
+    expect(result.records[0].sourceFingerprint).toMatch(/^[a-f0-9]{64}$/);
+    expect(result.records[0].review.metadata).not.toContain("Synthetic sentence");
+  });
+
+  it("sets verified only from explicit matching order provenance", () => {
+    const input = review({ status: "published" });
+    const fingerprint = judgeMeReviewFingerprint(input);
+    const result = transformJudgeMeReviews([input], {
+      generatedAt,
+      ...mappings(),
+      verifiedPurchases: new Map([[fingerprint, {
+        verified: true,
+        productId,
+        customerId,
+        orderId: "order_target",
+        orderItemId: "line_target",
+      }]]),
+    });
+    expect(result.records[0].review).toMatchObject({
+      is_verified: true,
+      status: "published",
+      order_id: "order_target",
+      order_item_id: "line_target",
+      customer_id: customerId,
+      published_at: "2025-01-01T00:00:00.000Z",
+    });
+    expect(JSON.parse(result.records[0].review.metadata).verified_purchase_provenance)
+      .toBe("explicit_order_match");
+  });
+
+  it("rejects mismatched provenance and omits unverified external media", () => {
+    const input = review({ picture_urls: "https://media.example.invalid/review.png" });
+    const fingerprint = judgeMeReviewFingerprint(input);
+    const result = transformJudgeMeReviews([input], {
+      generatedAt,
+      ...mappings(),
+      verifiedPurchases: new Map([[fingerprint, {
+        verified: true,
+        productId: "different_product",
+        customerId,
+        orderId: "order_target",
+      }]]),
+    });
+    expect(result.records[0].review.is_verified).toBe(false);
+    expect(result.warnings).toHaveLength(2);
+    expect(result.warnings.join(" ")).toContain("invalid verified-purchase provenance");
+    expect(result.warnings.join(" ")).toContain("media omitted");
+    expect(result.records[0].review.metadata).not.toContain("media.example.invalid");
+  });
+
+  it("maps only explicit publication and suppression states", () => {
+    const result = transformJudgeMeReviews([
+      review({ review_date: "2025-01-01", status: "approved" }),
+      review({ review_date: "2025-01-02", status: "spam" }),
+      review({ review_date: "2025-01-03", status: "unknown" }),
+    ], { generatedAt, ...mappings() });
+    expect(result.records.map(({ review: value }) => [value.status, Boolean(value.published_at)])).toEqual([
+      ["published", true],
+      ["suppressed", false],
+      ["pending", false],
+    ]);
+  });
+
+  it("skips invalid ratings, missing bodies, ambiguous products, and duplicates", () => {
+    const duplicate = review();
+    const ambiguous = review({ review_date: "2025-02-01" });
+    const ambiguousMappings = mappings();
+    ambiguousMappings.productIds.set(
+      providerFingerprint("shopify", "product_handle", "example-product"),
+      "different_product",
+    );
+    const invalid = transformJudgeMeReviews([
+      review({ rating: 4.5 }),
+      review({ review_date: "2025-01-02", body: "" }),
+    ], { generatedAt, ...mappings() });
+    const ambiguousResult = transformJudgeMeReviews([ambiguous], {
+      generatedAt,
+      ...ambiguousMappings,
+    });
+    const duplicates = transformJudgeMeReviews([duplicate, duplicate], { generatedAt, ...mappings() });
+
+    expect(invalid.records).toEqual([]);
+    expect(invalid.skipped.map(({ reason }) => reason)).toEqual([
+      "Review rating must be an integer from 1 to 5",
+      "Required text is empty",
+    ]);
+    expect(ambiguousResult.skipped[0].reason).toBe("Review product mapping is missing or ambiguous");
+    expect(duplicates.records).toHaveLength(1);
+    expect(duplicates.skipped[0].reason).toBe("Duplicate review source identity");
+    expect([...invalid.skipped, ...ambiguousResult.skipped, ...duplicates.skipped]
+      .every((entry) => !("record" in entry))).toBe(true);
+  });
+});

--- a/tests/unit/scripts/shopify-migration/transformers/sensitive/schema-contract.test.ts
+++ b/tests/unit/scripts/shopify-migration/transformers/sensitive/schema-contract.test.ts
@@ -1,0 +1,88 @@
+import { getTableColumns } from "drizzle-orm";
+import type { AnySQLiteTable } from "drizzle-orm/sqlite-core";
+import { describe, expect, it } from "vitest";
+import { customers } from "@/lib/db/schema/customer";
+import { orders } from "@/lib/db/schema/order";
+import { product_reviews } from "@/lib/db/schema/reviews";
+import type { ShopifyCustomer, ShopifyOrder } from "@/scripts/shopify-migration/lib/types";
+import { providerFingerprint } from "@/scripts/shopify-migration/lib/ids";
+import {
+  materializeCustomers,
+  transformCustomers,
+} from "@/scripts/shopify-migration/transformers/sensitive/customers";
+import { transformHistoricalOrders } from "@/scripts/shopify-migration/transformers/sensitive/orders";
+import {
+  judgeMeReviewFingerprint,
+  transformJudgeMeReviews,
+} from "@/scripts/shopify-migration/transformers/sensitive/reviews";
+
+const generatedAt = "2026-08-14T12:00:00.000Z";
+
+function columnNames(table: AnySQLiteTable): string[] {
+  return Object.values(getTableColumns(table)).map((column) => column.name).sort();
+}
+
+describe("sensitive insert record schema contracts", () => {
+  it("emits only current customer columns and deliberately omits unused MACH fields", () => {
+    const source: ShopifyCustomer = { id: "customer-source", email: "schema@example.invalid" };
+    const [plan] = transformCustomers([source], { generatedAt }).records;
+    const [record] = materializeCustomers([plan], new Map([
+      [plan.sourceFingerprint, "user_1234567890"],
+    ])).records;
+    const emitted = Object.keys(record).sort();
+    const schema = columnNames(customers);
+
+    expect(emitted.every((column) => schema.includes(column))).toBe(true);
+    expect(schema.filter((column) => !emitted.includes(column))).toEqual([
+      "authentication",
+      "company",
+      "contacts",
+      "loyalty",
+      "segments",
+    ]);
+  });
+
+  it("matches every fully migrated order column including shipping_carrier", () => {
+    const source: ShopifyOrder = {
+      id: "order-source",
+      customer: { id: "customer-source" },
+      currency: "USD",
+      total_price: "1.00",
+      line_items: [{ title: "Schema item", quantity: 1, price: "1.00" }],
+    };
+    const fingerprint = providerFingerprint("shopify", "customer", "customer-source");
+    const result = transformHistoricalOrders([source], {
+      generatedAt,
+      unresolvedCustomer: "reject",
+      customerIds: new Map([[fingerprint, "user_1234567890"]]),
+    });
+
+    expect(Object.keys(result.records[0].order).sort()).toEqual(columnNames(orders));
+    expect(result.records[0].order).toHaveProperty("shipping_carrier", null);
+  });
+
+  it("matches every current product-review column with real attribution", () => {
+    const source = {
+      body: "Synthetic schema review",
+      rating: 5,
+      product_handle: "schema-product",
+      reviewer_email: "schema@example.invalid",
+    };
+    const reviewFingerprint = judgeMeReviewFingerprint(source);
+    const productId = "product_target";
+    const result = transformJudgeMeReviews([source], {
+      generatedAt,
+      productIds: new Map([[
+        providerFingerprint("shopify", "product_handle", "schema-product"),
+        productId,
+      ]]),
+      reviewAttributions: new Map([[reviewFingerprint, {
+        productId,
+        orderId: "order_target",
+        customerId: "user_1234567890",
+      }]]),
+    });
+
+    expect(Object.keys(result.records[0].review).sort()).toEqual(columnNames(product_reviews));
+  });
+});

--- a/tests/unit/scripts/shopify-migration/wrangler-target.test.ts
+++ b/tests/unit/scripts/shopify-migration/wrangler-target.test.ts
@@ -33,6 +33,8 @@ describe("canonical Wrangler migration targets", () => {
   it("never falls back from a selected environment to root bindings", () => {
     expect(resolveMediaTarget(config, { target: "production", environment: "staging" }).bucketName).toBe("stage-media");
     expect(() => resolveMediaTarget(config, { target: "production", environment: "missing" })).toThrow(/refusing root fallback/);
+    const arrayEnvironment = parseWranglerJsonc(`{ "env": { "staging": [] } }`);
+    expect(() => resolveMediaTarget(arrayEnvironment, { target: "production", environment: "staging" })).toThrow(/refusing root fallback/);
     const missingBinding = parseWranglerJsonc(`{ "r2_buckets": [{ "binding": "OTHER", "bucket_name": "other" }] }`);
     expect(() => resolveMediaTarget(missingBinding, { target: "production" })).toThrow(/exactly one.*MEDIA/);
   });

--- a/tests/unit/scripts/shopify-migration/wrangler-target.test.ts
+++ b/tests/unit/scripts/shopify-migration/wrangler-target.test.ts
@@ -44,6 +44,15 @@ describe("canonical Wrangler migration targets", () => {
     }`);
     expect(() => resolveMediaTarget(noPreview, { target: "preview" })).toThrow("preview_bucket_name");
     expect(() => resolveDatabaseTarget(noPreview, { target: "preview" })).toThrow("preview_database_id");
+    expect(resolveDatabaseTarget(noPreview, { target: "local" })).toEqual({
+      databaseName: "store-db",
+      target: "local",
+    });
+    const nameOnly = parseWranglerJsonc(`{
+      "d1_databases": [{ "binding": "DB", "database_name": "local-db" }]
+    }`);
+    expect(resolveDatabaseTarget(nameOnly, { target: "local" })).toEqual({ databaseName: "local-db", target: "local" });
+    expect(() => resolveDatabaseTarget(nameOnly, { target: "production" })).toThrow("database_id");
   });
 
   it("treats an operator resource name only as an exact assertion", () => {

--- a/tests/unit/scripts/shopify-migration/wrangler-target.test.ts
+++ b/tests/unit/scripts/shopify-migration/wrangler-target.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseWranglerJsonc,
+  resolveDatabaseTarget,
+  resolveMediaTarget,
+} from "@/scripts/shopify-migration/lib/wrangler-target";
+
+const config = parseWranglerJsonc(`{
+  // Comments and URLs remain valid.
+  "url": "https://example.test/a,}",
+  "d1_databases": [{
+    "binding": "DB", "database_name": "store-db", "database_id": "production-database-id",
+    "preview_database_id": "preview-database-id",
+  }],
+  "r2_buckets": [{
+    "binding": "MEDIA", "bucket_name": "store-media", "preview_bucket_name": "store-media-preview",
+  }],
+  "env": {
+    "staging": {
+      "d1_databases": [{ "binding": "DB", "database_name": "stage-db", "database_id": "stage-database-id", "preview_database_id": "stage-preview-id" }],
+      "r2_buckets": [{ "binding": "MEDIA", "bucket_name": "stage-media", "preview_bucket_name": "stage-media-preview" }],
+    },
+  },
+}`);
+
+describe("canonical Wrangler migration targets", () => {
+  it("resolves production and preview resources from exact binding names", () => {
+    expect(resolveMediaTarget(config, { target: "production" }).bucketName).toBe("store-media");
+    expect(resolveMediaTarget(config, { target: "preview" }).bucketName).toBe("store-media-preview");
+    expect(resolveDatabaseTarget(config, { target: "preview" }).databaseId).toBe("preview-database-id");
+  });
+
+  it("never falls back from a selected environment to root bindings", () => {
+    expect(resolveMediaTarget(config, { target: "production", environment: "staging" }).bucketName).toBe("stage-media");
+    expect(() => resolveMediaTarget(config, { target: "production", environment: "missing" })).toThrow(/refusing root fallback/);
+    const missingBinding = parseWranglerJsonc(`{ "r2_buckets": [{ "binding": "OTHER", "bucket_name": "other" }] }`);
+    expect(() => resolveMediaTarget(missingBinding, { target: "production" })).toThrow(/exactly one.*MEDIA/);
+  });
+
+  it("requires explicit preview resource identifiers without production fallback", () => {
+    const noPreview = parseWranglerJsonc(`{
+      "d1_databases": [{ "binding": "DB", "database_name": "store-db", "database_id": "production-id" }],
+      "r2_buckets": [{ "binding": "MEDIA", "bucket_name": "store-media" }]
+    }`);
+    expect(() => resolveMediaTarget(noPreview, { target: "preview" })).toThrow("preview_bucket_name");
+    expect(() => resolveDatabaseTarget(noPreview, { target: "preview" })).toThrow("preview_database_id");
+  });
+
+  it("treats an operator resource name only as an exact assertion", () => {
+    expect(resolveMediaTarget(config, { target: "production", expectedName: "store-media" }).bucketName).toBe("store-media");
+    expect(() => resolveMediaTarget(config, { target: "production", expectedName: "attacker-bucket" })).toThrow(/refusing override/);
+    expect(() => resolveDatabaseTarget(config, { target: "production", expectedName: "other-db" })).toThrow(/refusing override/);
+  });
+
+  it("rejects malformed, duplicate, and oversized config", () => {
+    expect(() => parseWranglerJsonc(`{ "r2_buckets": [`)).toThrow(/truncated|valid JSONC/);
+    const duplicate = parseWranglerJsonc(`{ "r2_buckets": [
+      { "binding": "MEDIA", "bucket_name": "one-bucket" },
+      { "binding": "MEDIA", "bucket_name": "two-bucket" }
+    ] }`);
+    expect(() => resolveMediaTarget(duplicate, { target: "production" })).toThrow(/exactly one/);
+    expect(() => parseWranglerJsonc(`{"padding":"${"x".repeat(1024 * 1024)}"}`)).toThrow(/too large/);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a reusable, dry-run-first Shopify/Judge.me migration toolkit for Mercora without importing any BeauTeas content or data.

The toolkit covers:

- Shopify API and bounded file extraction for collections, products, pages, blogs/articles, redirects, customers, and orders
- schema-aligned, deterministic transforms for catalog, CMS, Blog, customer, historical order, and review data
- exact legacy redirect mapping and a hardened same-origin public media route
- bounded, verified Shopify media ingestion into R2
- explicitly confirmed Clerk customer provisioning with fingerprint-only identity resolution
- idempotent D1 planning, live schema/target preflight, drift detection, and post-write validation
- a dry-run-default operator CLI and neutral runbook

## Safety model

- Dry-run is the default and constructs no write-capable adapters.
- Apply requires explicit target, sensitive-data, overwrite, and Clerk auto-verification confirmations as applicable.
- Local apply never constructs remote R2 or Clerk clients.
- Preview/production bind the reviewed Wrangler account, R2 account/bucket, configured Clerk instance, and credential-backed Clerk instance/environment before mutation.
- Read-only D1 target/schema/ledger preflight runs before any R2 or Clerk mutation; the receipt is revalidated before D1 writes.
- Apply order is media → Clerk → D1, with fail-fast behavior and rerun-safe deterministic identities.
- Logs, reports, and artifacts exclude raw customer PII and provider payloads.

No migration, deployment, credential use, resource creation, network import, or external write was performed while developing this PR.

## Runtime changes

- Adds the expand-only `0020_add_redirect_map.sql` migration.
- Resolves only exact validated legacy redirects.
- Serves only allowlisted inert image prefixes through `/media`, with ETag revalidation, `nosniff`, and restrictive CSP.

## Validation

- Node 24 unit suite: 196 files / 1,278 tests
- Workers suite: 19 files / 82 tests
- Observability Worker: 1 file / 3 tests
- TypeScript and post-build generated-route typecheck
- Cloudflare generated-types check
- ESLint: 0 errors
- Deploy configuration check
- Migration safety: `0020` expand-only
- Diff, neutral-content, secret-pattern, and private-artifact checks
- Independent exact-tip security/correctness review: PASS

The production build reached the existing `next/font` Google Fonts fetch and could not continue because network access was intentionally prohibited. The generated Next route types produced by that attempt were subsequently checked successfully.

## Operator impact

The new `npm run migrate:shopify` command is intended for deliberate operator use. See `docs/shopify-migration.md` for required inputs, confirmations, preflight sequence, target binding, rollback strategy, and known structural-image-validation limitations.
