### PR TITLE
O07: Gift cards

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,15 @@ ORDER_STATUS_SECRET=
 # STORE_FEATURE_SUBSCRIPTION_RECONCILIATION=false
 # STORE_FEATURE_SUBSCRIPTION_ACQUISITION=false
 # STORE_SUBSCRIPTION_TERMS_VERSION=2026-08-15
+# Gift cards use separate acquisition and reconciliation switches. Acquisition
+# requires reconciliation. Keep reconciliation enabled while any durable
+# reservation or balance exists, even when new bearer-code entry is disabled.
+# STORE_FEATURE_GIFT_CARD_RECONCILIATION=false
+# STORE_FEATURE_GIFT_CARD_ACQUISITION=false
+# Server-only versioned HMAC lookup ring. Put real values in `.dev.vars` or
+# encrypted Workers secrets; never prefix these variables with NEXT_PUBLIC_.
+# GIFT_CARD_CODE_HMAC_CURRENT_VERSION=1
+# GIFT_CARD_CODE_HMAC_KEYS_JSON={"1":"generate-at-least-32-random-bytes"}
 # EMAIL_UNSUBSCRIBE_SECRET_CURRENT=generate-at-least-32-random-characters
 # EMAIL_UNSUBSCRIBE_SECRET_PREVIOUS=previous-key-during-a-bounded-rotation-window
 # EMAIL_UNSUBSCRIBE_TTL_SECONDS=2592000

--- a/app/account/gift-cards/page.tsx
+++ b/app/account/gift-cards/page.tsx
@@ -1,0 +1,8 @@
+import { notFound } from 'next/navigation';
+import { GiftCardDashboard } from '@/components/account/GiftCardDashboard';
+import { getStoreConfig } from '@/lib/store-config';
+
+export default function AccountGiftCardsPage() {
+  if (!getStoreConfig().commerce.features.giftCardReconciliation) notFound();
+  return <div><h1 className="text-3xl font-bold text-white">Gift cards</h1><p className="mt-2 text-gray-400">Review the gift cards you have purchased and their delivery state. Gift codes are never displayed here.</p><div className="mt-8"><GiftCardDashboard /></div></div>;
+}

--- a/app/admin/gift-cards/page.tsx
+++ b/app/admin/gift-cards/page.tsx
@@ -1,0 +1,5 @@
+import GiftCardQueue from '@/components/admin/GiftCardQueue';
+
+export default function AdminGiftCardsPage() {
+  return <div className="space-y-6"><div><h1 className="text-2xl font-bold text-white">Gift cards</h1><p className="mt-1 max-w-3xl text-gray-400">Operational gift-card status and delivery queue. Bearer codes, hashes, encryption material, recipient details, and internal card identities are intentionally unavailable.</p></div><GiftCardQueue /></div>;
+}

--- a/app/api/admin/gift-cards/route.ts
+++ b/app/api/admin/gift-cards/route.ts
@@ -1,0 +1,51 @@
+import { getCloudflareContext } from '@opennextjs/cloudflare';
+import { NextRequest, NextResponse } from 'next/server';
+import { checkAdminPermissions } from '@/lib/auth/admin-middleware';
+import { listAdminGiftCardPresentations } from '@/lib/gift-cards/presentations';
+
+const DEFAULT_LIMIT = 25;
+const MAX_LIMIT = 100;
+const MAX_OFFSET = 1_000_000;
+
+function boundedInteger(value: string | null, fallback: number, maximum: number): number | null {
+  if (value === null) return fallback;
+  if (!/^\d+$/.test(value)) return null;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed >= 0 && parsed <= maximum ? parsed : null;
+}
+
+/** Operational queue projection: intentionally no code material, hash, or account identity. */
+export async function GET(request: NextRequest) {
+  const authorization = await checkAdminPermissions(request);
+  if (!authorization.success) {
+    return NextResponse.json({ code: 'unauthorized', error: authorization.error ?? 'Admin access required' }, { status: 401 });
+  }
+  const params = request.nextUrl.searchParams;
+  const rawStatus = params.get('status');
+  const status = rawStatus === 'active' || rawStatus === 'disabled' ? rawStatus : undefined;
+  const limit = boundedInteger(params.get('limit'), DEFAULT_LIMIT, MAX_LIMIT);
+  const offset = boundedInteger(params.get('offset'), 0, MAX_OFFSET);
+  if (params.getAll('status').length > 1 || (rawStatus !== null && !status)
+    || params.getAll('limit').length > 1 || params.getAll('offset').length > 1
+    || limit === null || limit < 1 || offset === null) {
+    return NextResponse.json({ code: 'invalid_query', error: 'Invalid gift-card queue query' }, { status: 400 });
+  }
+  try {
+    const { env } = await getCloudflareContext({ async: true });
+    const environment = env as unknown as Record<string, unknown> & { DB?: D1Database };
+    if (String(environment.STORE_FEATURE_GIFT_CARD_RECONCILIATION ?? '').trim().toLowerCase() !== 'true') {
+      return NextResponse.json({ cards: [], total: 0, meta: { limit, offset } });
+    }
+    if (!environment.DB) throw new Error('D1 binding unavailable');
+    const result = await listAdminGiftCardPresentations({
+      database: environment.DB,
+      now: Math.floor(Date.now() / 1_000),
+      limit,
+      offset,
+      status,
+    });
+    return NextResponse.json({ ...result, meta: { limit, offset } });
+  } catch {
+    return NextResponse.json({ code: 'gift_cards_read_failed', error: 'Gift cards are temporarily unavailable' }, { status: 503 });
+  }
+}

--- a/app/api/gift-cards/balance/route.ts
+++ b/app/api/gift-cards/balance/route.ts
@@ -23,7 +23,9 @@ export async function POST(request: NextRequest) {
   try {
     const { env } = await getCloudflareContext({ async: true });
     const raw = env as unknown as Record<string, unknown> & { DB?: D1Database };
-    if (String(raw.STORE_FEATURE_GIFT_CARD_ACQUISITION ?? '').trim().toLowerCase() !== 'true' || !raw.DB) {
+    // Existing-card redemption and balance checks remain available during a
+    // sales rollback; only new issuance is controlled by acquisition.
+    if (String(raw.STORE_FEATURE_GIFT_CARD_RECONCILIATION ?? '').trim().toLowerCase() !== 'true' || !raw.DB) {
       return NextResponse.json({ valid: false });
     }
     const keyRing = parseGiftCardCodeKeyRing(raw);

--- a/app/api/gift-cards/balance/route.ts
+++ b/app/api/gift-cards/balance/route.ts
@@ -1,0 +1,41 @@
+import { getCloudflareContext } from '@opennextjs/cloudflare';
+import { NextRequest, NextResponse } from 'next/server';
+import { toWireMoney } from '@/lib/money';
+import { parseGiftCardCodeKeyRing } from '@/lib/gift-cards/config';
+import { giftCardLookupCandidates } from '@/lib/gift-cards/code';
+import { createGiftCardRepository } from '@/lib/gift-cards/repository';
+import { enforceRateLimit, getClientIp } from '@/lib/rate-limit';
+import { isBoundedString, isPlainRecord } from '@/lib/public-request-validation';
+
+/**
+ * Public balance lookup intentionally has one generic invalid response. It
+ * reveals neither account IDs nor code-hash rotation state and never logs the
+ * submitted bearer code.
+ */
+export async function POST(request: NextRequest) {
+  const limited = await enforceRateLimit('PUBLIC_RATE_LIMITER', `gift-card-balance:${getClientIp(request)}`);
+  if (limited) return limited;
+  let body: unknown;
+  try { body = await request.json(); } catch { return NextResponse.json({ valid: false }); }
+  if (!isPlainRecord(body) || !isBoundedString(body.code, 512)) {
+    return NextResponse.json({ valid: false });
+  }
+  try {
+    const { env } = await getCloudflareContext({ async: true });
+    const raw = env as unknown as Record<string, unknown> & { DB?: D1Database };
+    if (String(raw.STORE_FEATURE_GIFT_CARD_ACQUISITION ?? '').trim().toLowerCase() !== 'true' || !raw.DB) {
+      return NextResponse.json({ valid: false });
+    }
+    const keyRing = parseGiftCardCodeKeyRing(raw);
+    const candidates = await giftCardLookupCandidates(body.code, keyRing);
+    const repository = createGiftCardRepository(raw.DB);
+    const found = await Promise.all(candidates.map((candidate) => repository.findAccountByCodeHash(candidate)));
+    const accounts = [...new Map(found.filter(Boolean).map((account) => [account!.id, account!])).values()];
+    if (accounts.length !== 1 || accounts[0].status !== 'active') return NextResponse.json({ valid: false });
+    const balance = await repository.readBalance(accounts[0].id, Math.floor(Date.now() / 1_000));
+    if (!balance || balance.availableBalance.isZero()) return NextResponse.json({ valid: false });
+    return NextResponse.json({ valid: true, balance: toWireMoney(balance.availableBalance.toJSON()) });
+  } catch {
+    return NextResponse.json({ valid: false });
+  }
+}

--- a/app/api/gift-cards/route.ts
+++ b/app/api/gift-cards/route.ts
@@ -1,0 +1,32 @@
+import { getCloudflareContext } from '@opennextjs/cloudflare';
+import { auth } from '@clerk/nextjs/server';
+import { NextResponse } from 'next/server';
+import { enforceRateLimit } from '@/lib/rate-limit';
+import { listCustomerGiftCardPresentations } from '@/lib/gift-cards/presentations';
+
+const CUSTOMER_CARD_LIMIT = 100;
+
+/** List cards purchased by the authenticated customer without exposing codes or card identities. */
+export async function GET() {
+  const { userId } = await auth();
+  if (!userId) return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
+  const limited = await enforceRateLimit('PUBLIC_RATE_LIMITER', `gift-card-account:${userId}`);
+  if (limited) return limited;
+  try {
+    const { env } = await getCloudflareContext({ async: true });
+    const environment = env as unknown as Record<string, unknown> & { DB?: D1Database };
+    if (String(environment.STORE_FEATURE_GIFT_CARD_RECONCILIATION ?? '').trim().toLowerCase() !== 'true') {
+      return NextResponse.json({ cards: [] });
+    }
+    if (!environment.DB) return NextResponse.json({ error: 'Gift cards are temporarily unavailable' }, { status: 503 });
+    const cards = await listCustomerGiftCardPresentations({
+      database: environment.DB,
+      customerId: userId,
+      now: Math.floor(Date.now() / 1_000),
+      limit: CUSTOMER_CARD_LIMIT,
+    });
+    return NextResponse.json({ cards });
+  } catch {
+    return NextResponse.json({ error: 'Gift cards are temporarily unavailable' }, { status: 503 });
+  }
+}

--- a/app/api/mcp/schema/route.ts
+++ b/app/api/mcp/schema/route.ts
@@ -160,7 +160,7 @@ export async function GET(request: NextRequest) {
       },
       {
         name: "create_payment_intent",
-        description: "Create a server-priced pending order and bound Stripe PaymentIntent",
+        description: "Create a server-priced order and a Stripe PaymentIntent only when cash remains after gift tender",
         inputSchema: {
           type: "object",
           properties: {
@@ -181,6 +181,7 @@ export async function GET(request: NextRequest) {
             shippingMethodId: { type: "string" },
             discountCodes: { type: "array", items: { type: "string" } },
             giftCardToken: { type: "string" },
+            giftCardRequestKey: { type: "string", description: "Stable opaque ID reused only when retrying this checkout request" },
             session_id: { type: "string" }
           },
           required: ["shippingAddress", "shippingMethodId", "session_id"]
@@ -196,7 +197,7 @@ export async function GET(request: NextRequest) {
             paymentIntentId: { type: "string" },
             session_id: { type: "string" }
           },
-          required: ["orderId", "paymentIntentId", "session_id"]
+          required: ["orderId", "session_id"]
         }
       },
       {

--- a/app/api/mcp/tools/payment/create-intent/route.ts
+++ b/app/api/mcp/tools/payment/create-intent/route.ts
@@ -43,6 +43,7 @@ export async function POST(request: NextRequest) {
       ? input.discountCodes.filter((code): code is string => typeof code === 'string')
       : undefined,
     giftCardToken: typeof input.giftCardToken === 'string' ? input.giftCardToken : undefined,
+    giftCardRequestKey: typeof input.giftCardRequestKey === 'string' ? input.giftCardRequestKey : undefined,
   }, sessionId, auth.agentId!);
   return NextResponse.json(result, { status: result.success ? 200 : 400 });
 }

--- a/app/api/orders/refund/route.ts
+++ b/app/api/orders/refund/route.ts
@@ -4,6 +4,7 @@ import { authenticateRequest, PERMISSIONS } from '@/lib/auth/unified-auth';
 import { getDbAsync } from '@/lib/db';
 import { Money } from '@/lib/money';
 import { getStripeClient } from '@/lib/stripe';
+import { resolveRuntimeCommerceCapabilities } from '@/lib/commerce/runtime';
 import { isBoundedArray, isBoundedString, isPlainRecord } from '@/lib/public-request-validation';
 import { normalizeRefundLineIds } from '@/lib/payments/refund-idempotency';
 import { decideRefundLedgerAction } from '@/lib/payments/refund-ledger';
@@ -11,12 +12,15 @@ import {
   mutateRefundLedger,
   parseRefundExtensions,
   type RefundLedgerContext,
+  type RefundOrderRow,
 } from '@/lib/payments/refund-ledger-store';
 import {
   classifyRefundStatus,
   computeRefundedTotal,
   type RefundRecord,
 } from '@/lib/utils/refund-validation';
+import { allocateRefundTender } from '@/lib/payments/refund-tender';
+import type { Order } from '@/lib/types/order';
 import { recordTelemetry } from '@/lib/observability/telemetry';
 
 interface RefundRequest {
@@ -33,8 +37,16 @@ interface Reservation {
   requestFingerprint: string;
   refundAmount: number;
   entryIndex: number;
+  cashAmount: number;
+  giftAmount: number;
   stripeRefundId?: string;
   requestedAt?: string;
+}
+
+interface TenderSnapshot {
+  cashPaid: number;
+  giftTender: number;
+  state?: unknown;
 }
 
 const MAX_UNRESOLVED_CREATE_RETRY_MS = 23 * 60 * 60 * 1000;
@@ -94,6 +106,73 @@ function orderLineIds(context: RefundLedgerContext): string[] | null {
   return ids;
 }
 
+function nonnegativeMinor(value: unknown): number | null {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0 ? value : null;
+}
+
+/** Read only server-written checkout tender state; bearer codes are never retained here. */
+function tenderSnapshot(context: RefundLedgerContext, totalAmount: number): TenderSnapshot | null {
+  try {
+    const tender = Money.fromStored(context.extensions.checkout_tender ?? 0, context.order.currency_code)
+      .toMinorUnits();
+    if (!Number.isSafeInteger(tender) || tender < 0 || tender > totalAmount) return null;
+    if (tender > 0 && context.extensions.checkout_tender_state === undefined) return null;
+    return {
+      cashPaid: totalAmount - tender,
+      giftTender: tender,
+      ...(tender > 0 ? { state: context.extensions.checkout_tender_state } : {}),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Every active (including pending) refund consumes its planned allocation.
+ * That makes a concurrent retry unable to over-allocate either original tender.
+ */
+function priorTenderAllocation(refunds: RefundRecord[], giftTender: number): {
+  refundedCash: number;
+  restoredGift: number;
+} | null {
+  let refundedCash = 0;
+  let restoredGift = 0;
+  for (const record of refunds) {
+    if (classifyRefundStatus(record.status) === 'released') continue;
+    const refundAmount = nonnegativeMinor(record.amount);
+    if (refundAmount === null || refundAmount === 0) return null;
+    const cashAmount = record.cash_amount === undefined
+      ? (giftTender === 0 ? refundAmount : null)
+      : nonnegativeMinor(record.cash_amount);
+    const giftAmount = record.gift_amount === undefined
+      ? (giftTender === 0 ? 0 : null)
+      : nonnegativeMinor(record.gift_amount);
+    if (cashAmount === null || giftAmount === null || cashAmount + giftAmount !== refundAmount) return null;
+    if (refundedCash > Number.MAX_SAFE_INTEGER - cashAmount ||
+        restoredGift > Number.MAX_SAFE_INTEGER - giftAmount) return null;
+    refundedCash += cashAmount;
+    restoredGift += giftAmount;
+  }
+  return { refundedCash, restoredGift };
+}
+
+function recordTenderAllocation(record: RefundRecord, giftTender: number): {
+  cashAmount: number;
+  giftAmount: number;
+} | null {
+  const refundAmount = nonnegativeMinor(record.amount);
+  if (refundAmount === null || refundAmount === 0) return null;
+  const cashAmount = record.cash_amount === undefined
+    ? (giftTender === 0 ? refundAmount : null)
+    : nonnegativeMinor(record.cash_amount);
+  const giftAmount = record.gift_amount === undefined
+    ? (giftTender === 0 ? 0 : null)
+    : nonnegativeMinor(record.gift_amount);
+  return cashAmount === null || giftAmount === null || cashAmount + giftAmount !== refundAmount
+    ? null
+    : { cashAmount, giftAmount };
+}
+
 function responseForStoreFailure(reason: string) {
   if (reason === 'not_found') {
     return NextResponse.json({ error: 'Order not found' }, { status: 404 });
@@ -104,9 +183,11 @@ function responseForStoreFailure(reason: string) {
   return NextResponse.json({ error: 'Refund reservation conflicted; retry the request' }, { status: 503 });
 }
 
-export async function POST(request: NextRequest) {
+export async function POST(request: NextRequest): Promise<NextResponse> {
   const authResult = await authenticateRequest(request, PERMISSIONS.ORDERS_UPDATE);
-  if (!authResult.success) return authResult.response!;
+  if (!authResult.success) {
+    return authResult.response ?? NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
 
   let body: unknown;
   try {
@@ -131,7 +212,7 @@ export async function POST(request: NextRequest) {
     reservation?: Reservation;
     completed?: {
       refundAmount: number;
-      stripeRefundId: string;
+      refundId: string;
       providerStatus: string;
     };
     rejection?: { status: number; error: string };
@@ -149,16 +230,6 @@ export async function POST(request: NextRequest) {
       state.rejection = { status: 400, error: 'Refund contains an unknown or ambiguous order line' };
       return { action: 'skip' };
     }
-    const external = asRecord(context.order.external_references);
-    const extensionPaymentIntent = context.extensions.payment_intent_id;
-    const externalPaymentIntent = external.payment_intent_id;
-    if (typeof extensionPaymentIntent !== 'string' ||
-        typeof externalPaymentIntent !== 'string' ||
-        extensionPaymentIntent !== externalPaymentIntent) {
-      state.bindingError = 'Order PaymentIntent binding is missing or inconsistent';
-      return { action: 'skip' };
-    }
-
     let totalAmount: number;
     try {
       totalAmount = Money.fromStored(
@@ -167,6 +238,11 @@ export async function POST(request: NextRequest) {
       ).toMinorUnits();
     } catch {
       state.rejection = { status: 409, error: 'Order total is invalid' };
+      return { action: 'skip' };
+    }
+    const tender = tenderSnapshot(context, totalAmount);
+    if (!tender) {
+      state.rejection = { status: 409, error: 'Order tender snapshot is invalid' };
       return { action: 'skip' };
     }
     const hasStripeRefundedFloor = Object.prototype.hasOwnProperty.call(
@@ -199,17 +275,23 @@ export async function POST(request: NextRequest) {
     if (decision.action === 'completed') {
       state.completed = {
         refundAmount: decision.refundAmount,
-        stripeRefundId: decision.stripeRefundId,
+        refundId: decision.stripeRefundId ?? decision.idempotencyKey,
         providerStatus: decision.providerStatus,
       };
       return { action: 'skip' };
     }
     if (decision.action === 'reconcile') {
+      const allocation = recordTenderAllocation(context.refunds[decision.entryIndex], tender.giftTender);
+      if (!allocation) {
+        state.rejection = { status: 409, error: 'Refund tender allocation requires reconciliation' };
+        return { action: 'skip' };
+      }
       state.reservation = {
         idempotencyKey: decision.idempotencyKey,
         requestFingerprint: decision.requestFingerprint,
         refundAmount: decision.refundAmount,
         entryIndex: decision.entryIndex,
+        ...allocation,
         ...(decision.stripeRefundId ? { stripeRefundId: decision.stripeRefundId } : {}),
         ...(decision.requestedAt ? { requestedAt: decision.requestedAt } : {}),
       };
@@ -218,6 +300,36 @@ export async function POST(request: NextRequest) {
     if (context.order.payment_status !== 'paid') {
       state.rejection = { status: 409, error: 'Only paid orders can be refunded' };
       return { action: 'skip' };
+    }
+
+    const prior = priorTenderAllocation(context.refunds, tender.giftTender);
+    if (!prior) {
+      state.rejection = { status: 409, error: 'Refund tender allocation requires reconciliation' };
+      return { action: 'skip' };
+    }
+    let allocation: { cashAmount: number; giftAmount: number };
+    try {
+      allocation = allocateRefundTender({
+        refundAmount: decision.refundAmount,
+        cashPaid: tender.cashPaid,
+        giftTender: tender.giftTender,
+        refundedCash: prior.refundedCash,
+        restoredGift: prior.restoredGift,
+      });
+    } catch {
+      state.rejection = { status: 409, error: 'Refund exceeds original tender allocation' };
+      return { action: 'skip' };
+    }
+    if (allocation.cashAmount > 0) {
+      const external = asRecord(context.order.external_references);
+      const extensionPaymentIntent = context.extensions.payment_intent_id;
+      const externalPaymentIntent = external.payment_intent_id;
+      if (typeof extensionPaymentIntent !== 'string' ||
+          typeof externalPaymentIntent !== 'string' ||
+          extensionPaymentIntent !== externalPaymentIntent) {
+        state.bindingError = 'Order PaymentIntent binding is missing or inconsistent';
+        return { action: 'skip' };
+      }
     }
 
     const entry: RefundRecord = {
@@ -233,6 +345,9 @@ export async function POST(request: NextRequest) {
       settled_sequence: decision.settledSequence,
       requested_at: context.nowIso,
       requested_by: actor,
+      cash_amount: allocation.cashAmount,
+      gift_amount: allocation.giftAmount,
+      ...(allocation.giftAmount > 0 ? { gift_restoration_status: 'pending' } : {}),
     };
     const refunds = [...context.refunds, entry];
     state.reservation = {
@@ -240,6 +355,7 @@ export async function POST(request: NextRequest) {
       requestFingerprint: decision.requestFingerprint,
       refundAmount: decision.refundAmount,
       entryIndex: refunds.length - 1,
+      ...allocation,
     };
     return {
       action: 'write',
@@ -261,7 +377,7 @@ export async function POST(request: NextRequest) {
       success: true,
       duplicate: true,
       refund: {
-        id: state.completed.stripeRefundId,
+        id: state.completed.refundId,
         amount: state.completed.refundAmount,
         type: input.type,
         reason: input.reason,
@@ -281,173 +397,187 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Refund reservation could not be established' }, { status: 503 });
   }
 
-  const paymentIntentId = asRecord(reserved.order.external_references).payment_intent_id as string;
-  const refundParams: Stripe.RefundCreateParams = {
-    payment_intent: paymentIntentId,
-    amount: reservation.refundAmount,
-    reason: 'requested_by_customer',
-    metadata: {
-      orderId: input.orderId,
-      refundType: input.type,
-      refundReason: input.reason,
-      lineCount: String(input.lineIds.length),
-      refundRequestId: reservation.idempotencyKey,
-    },
+  const paymentIntentId = asRecord(reserved.order.external_references).payment_intent_id;
+  if (reservation.cashAmount > 0 && typeof paymentIntentId !== 'string') {
+    return NextResponse.json({ error: 'Order PaymentIntent binding is missing or inconsistent' }, { status: 409 });
+  }
+
+  /** Persist provider and restoration progress before performing the next durable leg. */
+  const persist = async (args: {
+    status: 'pending' | 'requires_action' | 'succeeded' | 'failed';
+    providerStatus: string;
+    stripeRefundId?: string;
+    giftRestorationStatus?: 'pending' | 'succeeded';
+  }): Promise<{ kind: 'response'; response: NextResponse } | { kind: 'order'; order: RefundOrderRow }> => {
+    let conflict = false;
+    try {
+      const result = await mutateRefundLedger(db, input.orderId, (context) => {
+        conflict = false;
+        const entryIndex = context.refunds.findIndex(
+          (entry) => entry.idempotency_key === reservation.idempotencyKey
+        );
+        if (entryIndex < 0) {
+          conflict = true;
+          return { action: 'skip' };
+        }
+        const current = context.refunds[entryIndex];
+        const allocation = recordTenderAllocation(current, reservation.giftAmount > 0 ? reservation.giftAmount : 0);
+        if (!allocation || allocation.cashAmount !== reservation.cashAmount || allocation.giftAmount !== reservation.giftAmount) {
+          conflict = true;
+          return { action: 'skip' };
+        }
+        if (current.status === 'succeeded' && args.status === 'succeeded') return { action: 'skip' };
+        const refunds = context.refunds.slice();
+        refunds[entryIndex] = {
+          ...current,
+          status: args.status,
+          provider_status: args.providerStatus,
+          ...(args.stripeRefundId ? { stripe_refund_id: args.stripeRefundId } : {}),
+          ...(args.giftRestorationStatus ? { gift_restoration_status: args.giftRestorationStatus } : {}),
+          processed_at: context.nowIso,
+        };
+        const extensions = { ...context.extensions, refunds, refunds_version: context.nextVersion };
+        const total = Money.fromStored(context.order.total_amount, context.order.currency_code).toMinorUnits();
+        const fullySettled = args.status === 'succeeded' && computeRefundedTotal({ refunds }) === total;
+        return {
+          action: 'write', extensions,
+          ...(fullySettled ? { columns: { status: 'cancelled' as const, payment_status: 'refunded' as const } } : {}),
+        };
+      });
+      if (!result.ok) {
+        recordTelemetry('refund.settlement_failed', {
+          operation: 'persist', outcome: result.reason === 'cas_exhausted' ? 'conflict' : 'failed',
+          provider: 'd1', retryable: result.reason === 'cas_exhausted',
+          path: '/api/orders/refund', trigger: 'request',
+        });
+        return { kind: 'response', response: responseForStoreFailure(result.reason) };
+      }
+      if (conflict) {
+        recordTelemetry('refund.settlement_failed', {
+          operation: 'persist', outcome: 'conflict', provider: 'd1', retryable: true,
+          path: '/api/orders/refund', trigger: 'request',
+        });
+        return { kind: 'response', response: NextResponse.json(
+          { error: 'Refund was accepted but ledger reconciliation is pending' },
+          { status: 503, headers: { 'Retry-After': '5' } }
+        ) };
+      }
+      return { kind: 'order', order: result.order };
+    } catch (error) {
+      recordTelemetry('refund.settlement_failed', {
+        operation: 'persist', outcome: 'failed', provider: 'd1', retryable: true,
+        path: '/api/orders/refund', trigger: 'request',
+      }, error);
+      throw error;
+    }
   };
 
-  let stripeRefund: Stripe.Refund;
-  const stripe = getStripeClient();
-  try {
-    if (reservation.stripeRefundId) {
-      stripeRefund = await stripe.refunds.retrieve(reservation.stripeRefundId);
-    } else {
-      const requestedAt = reservation.requestedAt
-        ? new Date(reservation.requestedAt).getTime()
-        : Date.now();
-      if (!Number.isFinite(requestedAt) || Date.now() - requestedAt > MAX_UNRESOLVED_CREATE_RETRY_MS) {
-        return NextResponse.json(
-          { error: 'Refund requires provider reconciliation before it can be retried' },
-          { status: 409 }
-        );
+  let providerStatus = 'not_applicable';
+  let stripeRefundId: string | undefined;
+  let normalizedStatus: 'pending' | 'requires_action' | 'succeeded' | 'failed' = 'succeeded';
+  if (reservation.cashAmount > 0) {
+    const refundParams: Stripe.RefundCreateParams = {
+      payment_intent: paymentIntentId as string,
+      amount: reservation.cashAmount,
+      reason: 'requested_by_customer',
+      metadata: {
+        orderId: input.orderId, refundType: input.type, refundReason: input.reason,
+        lineCount: String(input.lineIds.length), refundRequestId: reservation.idempotencyKey,
+      },
+    };
+    let stripeRefund: Stripe.Refund;
+    const stripe = getStripeClient();
+    try {
+      if (reservation.stripeRefundId) {
+        stripeRefund = await stripe.refunds.retrieve(reservation.stripeRefundId);
+      } else {
+        const requestedAt = reservation.requestedAt ? new Date(reservation.requestedAt).getTime() : Date.now();
+        if (!Number.isFinite(requestedAt) || Date.now() - requestedAt > MAX_UNRESOLVED_CREATE_RETRY_MS) {
+          return NextResponse.json({ error: 'Refund requires provider reconciliation before it can be retried' }, { status: 409 });
+        }
+        stripeRefund = await stripe.refunds.create(refundParams, { idempotencyKey: reservation.idempotencyKey });
       }
-      stripeRefund = await stripe.refunds.create(
-        refundParams,
-        { idempotencyKey: reservation.idempotencyKey }
-      );
+    } catch (error) {
+      recordTelemetry('refund.provider_unresolved', {
+        operation: 'process', outcome: 'unresolved', provider: 'stripe', retryable: true,
+        path: '/api/orders/refund', trigger: 'request',
+      }, error);
+      return NextResponse.json({ error: 'Refund status is unresolved; retry this same request' },
+        { status: 503, headers: { 'Retry-After': '5' } });
     }
-  } catch (error) {
-    // A transport error is ambiguous: Stripe may have accepted the request.
-    // Keep the exact reservation pending so a retry reuses the same provider key.
-    recordTelemetry('refund.provider_unresolved', {
-      operation: 'process', outcome: 'unresolved', provider: 'stripe',
-      retryable: true, path: '/api/orders/refund', trigger: 'request',
-    }, error);
-    return NextResponse.json(
-      { error: 'Refund status is unresolved; retry this same request' },
-      { status: 503, headers: { 'Retry-After': '5' } }
-    );
+    const providerPaymentIntent = typeof stripeRefund.payment_intent === 'string'
+      ? stripeRefund.payment_intent : stripeRefund.payment_intent?.id;
+    if (
+      stripeRefund.id.length === 0 ||
+      (reservation.stripeRefundId !== undefined && stripeRefund.id !== reservation.stripeRefundId) ||
+      providerPaymentIntent !== paymentIntentId ||
+      !Number.isSafeInteger(stripeRefund.amount) || stripeRefund.amount !== reservation.cashAmount
+    ) {
+      recordTelemetry('refund.provider_inconsistent', {
+        operation: 'validate', outcome: 'invalid', provider: 'stripe', http_status: 502,
+        path: '/api/orders/refund', trigger: 'request',
+      });
+      return NextResponse.json({ error: 'Payment provider returned an inconsistent refund' }, { status: 502 });
+    }
+    stripeRefundId = stripeRefund.id;
+    providerStatus = stripeRefund.status ?? 'unknown';
+    const providerClass = classifyRefundStatus(providerStatus);
+    normalizedStatus = providerClass === 'settled' ? 'succeeded'
+      : providerClass === 'released' ? 'failed'
+        : providerStatus === 'requires_action' ? 'requires_action' : 'pending';
   }
 
-  const providerPaymentIntent = typeof stripeRefund.payment_intent === 'string'
-    ? stripeRefund.payment_intent
-    : stripeRefund.payment_intent?.id;
-  const providerResultIsConsistent =
-    stripeRefund.id.length > 0 &&
-    (!reservation.stripeRefundId || stripeRefund.id === reservation.stripeRefundId) &&
-    providerPaymentIntent === paymentIntentId &&
-    Number.isSafeInteger(stripeRefund.amount) &&
-    stripeRefund.amount === reservation.refundAmount;
-  if (!providerResultIsConsistent) {
-    // Keep the reservation pending: an inconsistent response must be reconciled,
-    // never released or settled against the wrong order or amount.
-    recordTelemetry('refund.provider_inconsistent', {
-      operation: 'validate', outcome: 'invalid', provider: 'stripe',
-      http_status: 502, path: '/api/orders/refund', trigger: 'request',
-    });
-    return NextResponse.json(
-      { error: 'Payment provider returned an inconsistent refund' },
-      { status: 502 }
-    );
+  if (normalizedStatus !== 'succeeded') {
+    const outcome = await persist({ status: normalizedStatus, providerStatus, stripeRefundId,
+      ...(reservation.giftAmount > 0 ? { giftRestorationStatus: 'pending' as const } : {}) });
+    if (outcome.kind === 'response') return outcome.response;
+    if (normalizedStatus === 'failed') return NextResponse.json({ error: 'Stripe rejected the refund' }, { status: 502 });
+    return NextResponse.json({ success: true, refund: {
+      id: stripeRefundId, amount: reservation.refundAmount, type: input.type, reason: input.reason,
+      items: input.lineIds, status: normalizedStatus, providerStatus,
+    }, order: { id: input.orderId, status: outcome.order.status, payment_status: outcome.order.payment_status } }, { status: 202 });
   }
 
-  const providerStatus = stripeRefund.status ?? 'unknown';
-  const providerClass = classifyRefundStatus(providerStatus);
-  const normalizedStatus = providerClass === 'settled'
-    ? 'succeeded'
-    : providerClass === 'released'
-      ? 'failed'
-      : providerStatus === 'requires_action'
-        ? 'requires_action'
-        : 'pending';
-  let settlementConflict = false;
-  let settled: Awaited<ReturnType<typeof mutateRefundLedger>>;
-  try {
-    settled = await mutateRefundLedger(db, input.orderId, (context) => {
-      settlementConflict = false;
-      const entryIndex = context.refunds.findIndex(
-        (entry) => entry.idempotency_key === reservation!.idempotencyKey
-      );
-      if (entryIndex < 0) {
-        settlementConflict = true;
-        return { action: 'skip' };
-      }
-      const current = context.refunds[entryIndex];
-      if (current.status === 'succeeded' && current.stripe_refund_id === stripeRefund.id) {
-        return { action: 'skip' };
-      }
-      const refunds = context.refunds.slice();
-      refunds[entryIndex] = {
-        ...current,
-        status: normalizedStatus,
-        provider_status: providerStatus,
-        stripe_refund_id: stripeRefund.id,
-        processed_at: context.nowIso,
-      };
-      const extensions = {
-        ...context.extensions,
-        refunds,
-        refunds_version: context.nextVersion,
-      };
-      const total = Money.fromStored(
-        context.order.total_amount,
-        context.order.currency_code
-      ).toMinorUnits();
-      const fullySettled = normalizedStatus === 'succeeded' &&
-        computeRefundedTotal({ refunds }) === total;
-      return {
-        action: 'write',
-        extensions,
-        ...(fullySettled ? {
-          columns: { status: 'cancelled' as const, payment_status: 'refunded' as const },
-        } : {}),
-      };
+  if (reservation.giftAmount > 0) {
+    // The cash result is durable before restoration. If restoration is interrupted,
+    // retries retrieve this exact provider refund and restore with the same opaque key.
+    const cashRecorded = await persist({
+      status: 'pending', providerStatus, stripeRefundId, giftRestorationStatus: 'pending',
     });
-  } catch (error) {
-    recordTelemetry('refund.settlement_failed', {
-      operation: 'persist', outcome: 'failed', provider: 'd1',
-      retryable: true, path: '/api/orders/refund', trigger: 'request',
-    }, error);
-    throw error;
-  }
-  if (!settled.ok) {
-    recordTelemetry('refund.settlement_failed', {
-      operation: 'persist',
-      outcome: settled.reason === 'cas_exhausted' ? 'conflict' : 'failed',
-      provider: 'd1', retryable: settled.reason === 'cas_exhausted',
-      path: '/api/orders/refund', trigger: 'request',
-    });
-    return responseForStoreFailure(settled.reason);
-  }
-  if (settlementConflict) {
-    recordTelemetry('refund.settlement_failed', {
-      operation: 'persist', outcome: 'conflict', provider: 'd1',
-      retryable: true, path: '/api/orders/refund', trigger: 'request',
-    });
-    return NextResponse.json(
-      { error: 'Refund was accepted but ledger reconciliation is pending' },
-      { status: 503, headers: { 'Retry-After': '5' } }
-    );
-  }
-  if (normalizedStatus === 'failed') {
-    return NextResponse.json({ error: 'Stripe rejected the refund' }, { status: 502 });
+    if (cashRecorded.kind === 'response') return cashRecorded.response;
+    try {
+      const capabilities = await resolveRuntimeCommerceCapabilities();
+      const restoreTender = capabilities.giftCards.restoreTender;
+      if (!restoreTender) throw new Error('Gift-card restoration is not configured');
+      await restoreTender({
+        order: reserved.order as Order,
+        state: asRecord(reserved.order.extensions).checkout_tender_state,
+        refundKey: reservation.idempotencyKey,
+        amount: Money.fromMinor(reservation.giftAmount, reserved.order.currency_code),
+      });
+    } catch (error) {
+      recordTelemetry('refund.gift_restoration_unresolved', {
+        operation: 'process', outcome: 'unresolved', provider: 'gift_card', retryable: true,
+        path: '/api/orders/refund', trigger: 'request',
+      }, error);
+      return NextResponse.json({ error: 'Refund cash settlement succeeded; gift restoration is pending' },
+        { status: 503, headers: { 'Retry-After': '5' } });
+    }
   }
 
+  const completed = await persist({
+    status: 'succeeded', providerStatus, stripeRefundId,
+    ...(reservation.giftAmount > 0 ? { giftRestorationStatus: 'succeeded' as const } : {}),
+  });
+  if (completed.kind === 'response') return completed.response;
   return NextResponse.json({
     success: true,
     refund: {
-      id: stripeRefund.id,
-      amount: reservation.refundAmount,
-      type: input.type,
-      reason: input.reason,
-      items: input.lineIds,
-      status: normalizedStatus,
-      providerStatus,
+      id: stripeRefundId ?? reservation.idempotencyKey,
+      amount: reservation.refundAmount, type: input.type, reason: input.reason,
+      items: input.lineIds, status: 'succeeded', providerStatus,
       processed_at: new Date().toISOString(),
     },
-    order: {
-      id: input.orderId,
-      status: settled.order.status,
-      payment_status: settled.order.payment_status,
-    },
-  }, { status: normalizedStatus === 'succeeded' ? 200 : 202 });
+    order: { id: input.orderId, status: completed.order.status, payment_status: completed.order.payment_status },
+  });
 }

--- a/app/api/orders/route.ts
+++ b/app/api/orders/route.ts
@@ -27,6 +27,7 @@ import {
 import { enforceRateLimit, getClientIp } from '@/lib/rate-limit';
 import { recordTelemetry } from '@/lib/observability/telemetry';
 import { toAdminOrder, toCustomerOrder } from '@/lib/models/mach/order-serializer';
+import { resolveRuntimeCommerceCapabilities } from '@/lib/commerce/runtime';
 
 
 
@@ -195,6 +196,7 @@ export async function POST(request: NextRequest) {
       customerId: userId ?? undefined,
       enforceOwnership: true,
       sendEmail: true,
+      capabilities: await resolveRuntimeCommerceCapabilities(),
     });
     return NextResponse.json({
       data: { id: result.order.id },

--- a/app/api/payment-intent/route.ts
+++ b/app/api/payment-intent/route.ts
@@ -14,6 +14,13 @@ import {
   InventoryUnavailableError,
 } from '@/lib/services/inventory-adjustments';
 import { recordTelemetry } from '@/lib/observability/telemetry';
+import { resolveRuntimeCommerceCapabilities } from '@/lib/commerce/runtime';
+import { hasPhysicalCheckoutLines } from '@/lib/gift-cards/checkout';
+import { finalizeZeroCashGiftOrder } from '@/lib/services/order-finalization';
+import {
+  noOpCommerceCapabilities,
+  type CommerceCapabilities,
+} from '@/lib/commerce/capabilities';
 
 interface PaymentIntentRequest {
   items: CheckoutLineInput[];
@@ -21,6 +28,7 @@ interface PaymentIntentRequest {
   shippingMethodId: string;
   discountCodes?: string[];
   giftCardToken?: string;
+  giftCardRequestKey?: string;
 }
 
 function normalizeAddress(value: unknown): Address | null {
@@ -81,22 +89,28 @@ export async function POST(request: NextRequest) {
   if (
     !shippingAddress ||
     !isBoundedString(input.shippingMethodId, 128) ||
-    (input.giftCardToken !== undefined && !isBoundedString(input.giftCardToken, 512))
+    (input.giftCardToken !== undefined && !isBoundedString(input.giftCardToken, 512)) ||
+    (input.giftCardRequestKey !== undefined && !isBoundedString(input.giftCardRequestKey, 256))
   ) {
     return NextResponse.json({ error: 'Invalid checkout details' }, { status: 400 });
   }
 
   const { userId } = await auth();
-  let quote;
+  let quote: Awaited<ReturnType<typeof priceCheckout>>;
+  let capabilities: CommerceCapabilities;
   try {
+    capabilities = input.giftCardToken
+      ? await resolveRuntimeCommerceCapabilities()
+      : noOpCommerceCapabilities;
     quote = await priceCheckout({
       items: input.items,
       shippingAddress,
       shippingMethodId: input.shippingMethodId,
       discountCodes: input.discountCodes,
       giftCardToken: input.giftCardToken,
+      giftCardRequestKey: input.giftCardRequestKey,
       customerId: userId ?? undefined,
-    });
+    }, { capabilities });
   } catch (error) {
     recordTelemetry('payment.pricing_rejected', {
       operation: 'validate', outcome: 'rejected', path: '/api/payment-intent',
@@ -108,13 +122,6 @@ export async function POST(request: NextRequest) {
   }
 
   const total = Money.fromStored(quote.total);
-  if (!total.gt(Money.zero(total.currency))) {
-    return NextResponse.json(
-      { error: 'This checkout requires a positive payment amount' },
-      { status: 400 }
-    );
-  }
-
   try {
     await assertCheckoutInventoryAvailable(quote.items);
   } catch (error) {
@@ -163,8 +170,8 @@ export async function POST(request: NextRequest) {
   }
 
   const orderId = newOrderId(userId);
-  let paymentIntent: Awaited<ReturnType<typeof createPaymentIntent>>;
-  try {
+  let paymentIntent: Awaited<ReturnType<typeof createPaymentIntent>> | undefined;
+  if (total.gt(Money.zero(total.currency))) try {
     paymentIntent = await createPaymentIntent({
       amount: total.toMinorUnits(),
       currency: total.currency.toLowerCase(),
@@ -188,6 +195,12 @@ export async function POST(request: NextRequest) {
       description: `Order ${orderId}`,
     });
   } catch (error) {
+    if (quote.tenderState !== undefined) {
+      await capabilities.giftCards.releaseTender?.({
+        state: quote.tenderState,
+        reason: 'cash payment initialization failed',
+      }).catch(() => undefined);
+    }
     recordTelemetry('payment.intent_create_failed', {
       operation: 'create', outcome: 'failed', provider: 'stripe',
       retryable: true, path: '/api/payment-intent',
@@ -195,14 +208,14 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Payment provider is unavailable' }, { status: 503 });
   }
 
-  const providerAmount = Number(paymentIntent.amount);
-  const providerCurrency = String(paymentIntent.currency || '').toUpperCase();
-  if (
+  const providerAmount = paymentIntent ? Number(paymentIntent.amount) : total.toMinorUnits();
+  const providerCurrency = paymentIntent ? String(paymentIntent.currency || '').toUpperCase() : total.currency;
+  if (paymentIntent && (
     !Number.isSafeInteger(providerAmount) ||
     providerAmount !== total.toMinorUnits() ||
     providerCurrency !== total.currency ||
     !paymentIntent.client_secret
-  ) {
+  )) {
     recordTelemetry('payment.intent_invalid', {
       operation: 'validate', outcome: 'invalid', provider: 'stripe',
       http_status: 502, path: '/api/payment-intent',
@@ -213,6 +226,12 @@ export async function POST(request: NextRequest) {
         retryable: true, path: '/api/payment-intent',
       }, error);
     });
+    if (quote.tenderState !== undefined) {
+      await capabilities.giftCards.releaseTender?.({
+        state: quote.tenderState,
+        reason: 'cash payment validation failed',
+      }).catch(() => undefined);
+    }
     return NextResponse.json({ error: 'Payment provider returned an invalid intent' }, { status: 502 });
   }
 
@@ -222,7 +241,7 @@ export async function POST(request: NextRequest) {
   const shippingDiscount = Money.fromStored(quote.shippingDiscount, quote.currency);
   const extensions = {
     email: shippingAddress.email,
-    payment_intent_id: paymentIntent.id,
+    ...(paymentIntent ? { payment_intent_id: paymentIntent.id } : {}),
     checkout_catalog_subtotal: catalogSubtotal.toJSON(),
     checkout_subtotal: catalogSubtotal.subtract(merchandiseDiscount).toJSON(),
     checkout_discount: quote.discount,
@@ -235,7 +254,7 @@ export async function POST(request: NextRequest) {
     checkout_line_allocations: quote.lineAllocations,
     checkout_tender: quote.tender,
     checkout_tender_state: quote.tenderState,
-    checkout_total: Money.fromMinor(providerAmount, providerCurrency).toJSON(),
+    checkout_total: total.toJSON(),
     discount_codes: quote.discountCodes,
     tax_source: quote.taxSource,
   };
@@ -246,15 +265,15 @@ export async function POST(request: NextRequest) {
       id: orderId,
       customer_id: userId,
       status: 'pending',
-      total_amount: Money.fromMinor(providerAmount, providerCurrency).toJSON(),
+      total_amount: total.toJSON(),
       currency_code: providerCurrency,
-      shipping_address: shippingAddress,
+      shipping_address: hasPhysicalCheckoutLines(quote.items) ? shippingAddress : null,
       billing_address: shippingAddress,
       items: quote.items,
-      shipping_method: quote.shippingMethod.label,
-      payment_method: 'stripe',
+      shipping_method: hasPhysicalCheckoutLines(quote.items) ? quote.shippingMethod.label : null,
+      payment_method: paymentIntent ? 'stripe' : 'gift_card',
       payment_status: 'pending',
-      external_references: { payment_intent_id: paymentIntent.id },
+      external_references: paymentIntent ? { payment_intent_id: paymentIntent.id } : null,
       extensions,
       created_at: new Date().toISOString(),
       updated_at: new Date().toISOString(),
@@ -264,7 +283,11 @@ export async function POST(request: NextRequest) {
       operation: 'persist', outcome: 'failed', provider: 'd1',
       retryable: true, path: '/api/payment-intent',
     }, error);
-    await cancelPaymentIntent(paymentIntent.id).catch((cancelError) => {
+    if (quote.tenderState !== undefined) {
+      await capabilities.giftCards.releaseTender?.({ state: quote.tenderState, reason: 'checkout persistence failed' })
+        .catch(() => undefined);
+    }
+    if (paymentIntent) await cancelPaymentIntent(paymentIntent.id).catch((cancelError) => {
       recordTelemetry('payment.intent_cancel_failed', {
         operation: 'process', outcome: 'failed', provider: 'stripe',
         retryable: true, path: '/api/payment-intent',
@@ -276,6 +299,39 @@ export async function POST(request: NextRequest) {
       { error: 'Could not reserve the order; no payment was accepted' },
       { status: 503 }
     );
+  }
+
+  if (!paymentIntent) {
+    try {
+      const finalized = await finalizeZeroCashGiftOrder({
+        orderId,
+        customerId: userId ?? undefined,
+        enforceOwnership: true,
+        sendEmail: true,
+        capabilities,
+      });
+      return NextResponse.json({
+        noCash: true,
+        orderId: finalized.order.id,
+        amount: toWireMoney(total.toJSON()),
+        quote: {
+          items: quote.items.map((item) => ({
+            productId: item.product_id, variantId: item.variant_id, name: item.product_name,
+            quantity: item.quantity, unitPrice: toWireMoney(item.unit_price, providerCurrency),
+            lineTotal: toWireMoney(item.total_price, providerCurrency),
+          })),
+          subtotal: toWireMoney(quote.subtotal), discount: toWireMoney(quote.discount),
+          shipping: toWireMoney(quote.shipping), tax: toWireMoney(quote.tax),
+          tender: toWireMoney(quote.tender), total: toWireMoney(total.toJSON()),
+          currency: providerCurrency, taxSource: quote.taxSource,
+        },
+      });
+    } catch (error) {
+      recordTelemetry('order.finalization_failed', {
+        operation: 'finalize', outcome: 'failed', retryable: true, path: '/api/payment-intent',
+      }, error);
+      return NextResponse.json({ error: 'Gift-card checkout could not be finalized' }, { status: 409 });
+    }
   }
 
   return NextResponse.json({

--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -50,6 +50,7 @@ import {
 } from '@/app/api/webhooks/stripe/handlers/refund-handlers';
 import { recordTelemetry } from '@/lib/observability/telemetry';
 import { handleSubscriptionStripeEvent } from '@/app/api/webhooks/stripe/handlers/subscription-handlers';
+import { resolveRuntimeCommerceCapabilities } from '@/lib/commerce/runtime';
 
 const MAX_STRIPE_SIGNATURE_BYTES = 4_096;
 const MAX_STRIPE_WEBHOOK_BODY_BYTES = 1_048_576;
@@ -319,6 +320,7 @@ async function handlePaymentSucceeded(
       paymentIntentId: paymentIntent.id,
       enforceOwnership: false,
       sendEmail: true,
+      capabilities: await resolveRuntimeCommerceCapabilities(),
     });
     return 'handled';
   } catch (error) {

--- a/components/account/AccountNav.tsx
+++ b/components/account/AccountNav.tsx
@@ -1,12 +1,15 @@
 import Link from "next/link";
 import { getStoreConfig } from "@/lib/store-config";
 
-export function accountLinks(subscriptionReconciliation: boolean) {
+export function accountLinks(subscriptionReconciliation: boolean, giftCardReconciliation = false) {
   return [
     ["Overview", "/account"],
     ["Orders", "/account/orders"],
     ...(subscriptionReconciliation
       ? [["Subscriptions", "/account/subscriptions"] as const]
+      : []),
+    ...(giftCardReconciliation
+      ? [["Gift cards", "/account/gift-cards"] as const]
       : []),
     ["Addresses", "/account/addresses"],
     ["Settings", "/account/settings"],
@@ -16,6 +19,7 @@ export function accountLinks(subscriptionReconciliation: boolean) {
 export function AccountNav() {
   const links = accountLinks(
     getStoreConfig().commerce.features.subscriptionReconciliation,
+    getStoreConfig().commerce.features.giftCardReconciliation,
   );
   return (
     <nav aria-label="Account" className="mb-8 flex flex-wrap gap-2 md:w-48 md:flex-col">

--- a/components/account/GiftCardDashboard.tsx
+++ b/components/account/GiftCardDashboard.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { Money, type MachMoney } from '@/lib/money';
+
+interface GiftCardSummary {
+  issuedAmount: MachMoney;
+  availableBalance: MachMoney;
+  status: 'active' | 'disabled';
+  createdAt: number;
+  delivery?: { status: 'pending' | 'processing' | 'sent' | 'needs_review'; attempts: number };
+}
+
+function formatMoney(value: MachMoney): string {
+  return Money.fromMajor(value.amount, value.currency).format();
+}
+
+function deliveryLabel(status: GiftCardSummary['delivery']): string | undefined {
+  if (!status) return undefined;
+  if (status.status === 'sent') return 'Delivery sent';
+  if (status.status === 'needs_review') return 'Delivery needs support review';
+  return 'Delivery pending';
+}
+
+export function GiftCardDashboard() {
+  const [cards, setCards] = useState<GiftCardSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const load = useCallback(async () => {
+    try {
+      const response = await fetch('/api/gift-cards');
+      const payload = await response.json() as { cards?: GiftCardSummary[]; error?: string };
+      if (!response.ok) throw new Error(payload.error ?? 'Gift cards could not be loaded');
+      setCards(Array.isArray(payload.cards) ? payload.cards : []);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : 'Gift cards could not be loaded');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+  useEffect(() => {
+    let active = true;
+    void fetch('/api/gift-cards')
+      .then(async (response) => {
+        const payload = await response.json() as { cards?: GiftCardSummary[]; error?: string };
+        if (!response.ok) throw new Error(payload.error ?? 'Gift cards could not be loaded');
+        if (active) setCards(Array.isArray(payload.cards) ? payload.cards : []);
+      })
+      .catch((cause: unknown) => {
+        if (active) setError(cause instanceof Error ? cause.message : 'Gift cards could not be loaded');
+      })
+      .finally(() => { if (active) setLoading(false); });
+    return () => { active = false; };
+  }, []);
+
+  if (loading) return <div role="status" className="rounded-lg border border-neutral-700 bg-neutral-900 p-6 text-sm text-gray-300">Loading gift cards…</div>;
+  if (error) return <div role="alert" className="rounded-lg border border-red-900 bg-red-950/30 p-5 text-sm text-red-100"><p>{error}</p><button type="button" onClick={() => { setLoading(true); setError(''); void load(); }} className="mt-4 rounded-md border border-red-700 px-3 py-2 hover:border-red-500">Try again</button></div>;
+  if (cards.length === 0) return <div className="rounded-lg border border-neutral-700 bg-neutral-900 p-6"><h2 className="font-semibold">No purchased gift cards</h2><p className="mt-2 text-sm text-gray-400">Gift cards you purchase will appear here. For safety, gift codes are only delivered to their recipient.</p></div>;
+  return <div className="space-y-4">{cards.map((card, index) => <article key={`${card.createdAt}-${index}`} className="rounded-lg border border-neutral-700 bg-neutral-900 p-5"><div className="flex flex-wrap items-start justify-between gap-3"><div><h2 className="font-semibold text-white">Gift card purchase</h2><p className="mt-1 text-sm text-gray-400">Purchased {new Date(card.createdAt * 1000).toLocaleDateString()}</p></div><span className="rounded-full border border-neutral-600 px-3 py-1 text-xs text-gray-200">{card.status === 'active' ? 'Active' : 'Disabled'}</span></div><dl className="mt-5 grid gap-4 sm:grid-cols-2"><div><dt className="text-xs font-medium uppercase tracking-wide text-gray-500">Issued value</dt><dd className="mt-1 text-lg text-white">{formatMoney(card.issuedAmount)}</dd></div><div><dt className="text-xs font-medium uppercase tracking-wide text-gray-500">Available balance</dt><dd className="mt-1 text-lg text-white">{formatMoney(card.availableBalance)}</dd></div></dl>{deliveryLabel(card.delivery) && <p className="mt-4 text-sm text-gray-400">{deliveryLabel(card.delivery)}</p>}</article>)}</div>;
+}

--- a/components/admin/AdminSidebar.tsx
+++ b/components/admin/AdminSidebar.tsx
@@ -42,7 +42,8 @@ import {
   FileEdit,
   MessageSquare,
   Newspaper,
-  Repeat2
+  Repeat2,
+  Gift
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useStoreConfig } from "@/lib/store";
@@ -84,6 +85,12 @@ const navItems: NavItem[] = [
     href: "/admin/orders",
     icon: ClipboardList,
     description: "Order management"
+  },
+  {
+    label: "Gift cards",
+    href: "/admin/gift-cards",
+    icon: Gift,
+    description: "Stored-value operations",
   },
   {
     label: "Reviews",

--- a/components/admin/GiftCardQueue.tsx
+++ b/components/admin/GiftCardQueue.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { Money, type MachMoney } from '@/lib/money';
+
+interface AdminGiftCard {
+  issuedAmount: MachMoney;
+  availableBalance: MachMoney;
+  status: 'active' | 'disabled';
+  createdAt: number;
+  issuedOrderId?: string;
+  issuedLineId?: string;
+  delivery?: { status: 'pending' | 'processing' | 'sent' | 'needs_review'; attempts: number };
+}
+
+function money(value: MachMoney) { return Money.fromMajor(value.amount, value.currency).format(); }
+
+export default function GiftCardQueue() {
+  const [cards, setCards] = useState<AdminGiftCard[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const load = useCallback(async () => {
+    try {
+      const response = await fetch('/api/admin/gift-cards');
+      const payload = await response.json() as { cards?: AdminGiftCard[]; error?: string };
+      if (!response.ok) throw new Error(payload.error ?? 'Gift cards could not be loaded');
+      setCards(Array.isArray(payload.cards) ? payload.cards : []);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : 'Gift cards could not be loaded');
+    } finally { setLoading(false); }
+  }, []);
+  useEffect(() => {
+    let active = true;
+    void fetch('/api/admin/gift-cards')
+      .then(async (response) => {
+        const payload = await response.json() as { cards?: AdminGiftCard[]; error?: string };
+        if (!response.ok) throw new Error(payload.error ?? 'Gift cards could not be loaded');
+        if (active) setCards(Array.isArray(payload.cards) ? payload.cards : []);
+      })
+      .catch((cause: unknown) => {
+        if (active) setError(cause instanceof Error ? cause.message : 'Gift cards could not be loaded');
+      })
+      .finally(() => { if (active) setLoading(false); });
+    return () => { active = false; };
+  }, []);
+  if (loading) return <div role="status" className="rounded-lg border border-neutral-700 bg-neutral-900 p-6 text-sm text-gray-300">Loading gift cards…</div>;
+  if (error) return <div role="alert" className="rounded-lg border border-red-900 bg-red-950/30 p-5 text-sm text-red-100"><p>{error}</p><button type="button" onClick={() => { setLoading(true); setError(''); void load(); }} className="mt-4 rounded-md border border-red-700 px-3 py-2 hover:border-red-500">Try again</button></div>;
+  return <div className="overflow-x-auto rounded-lg border border-neutral-700"><table className="w-full min-w-[680px] text-left text-sm"><thead className="bg-neutral-900 text-xs uppercase tracking-wide text-gray-500"><tr><th className="p-4">Issued</th><th className="p-4">Available</th><th className="p-4">Status</th><th className="p-4">Delivery</th><th className="p-4">Order reference</th></tr></thead><tbody>{cards.map((card, index) => <tr key={`${card.createdAt}-${index}`} className="border-t border-neutral-800 text-gray-200"><td className="p-4">{money(card.issuedAmount)}</td><td className="p-4">{money(card.availableBalance)}</td><td className="p-4">{card.status}</td><td className="p-4">{card.delivery ? `${card.delivery.status}${card.delivery.attempts ? ` (${card.delivery.attempts} attempts)` : ''}` : 'Not queued'}</td><td className="p-4 text-gray-400">{card.issuedOrderId ?? '—'}</td></tr>)}</tbody></table>{cards.length === 0 && <p className="p-6 text-sm text-gray-400">No gift cards match this queue.</p>}</div>;
+}

--- a/components/cart/CartDrawer.tsx
+++ b/components/cart/CartDrawer.tsx
@@ -108,7 +108,7 @@ export default function CartDrawer() {
           ) : (
             <div className="space-y-4">
               {items.map((item) => (
-                <CartItemCard key={item.variantId} item={item} />
+                <CartItemCard key={item.lineId} item={item} />
               ))}
               
               <div className="border-t border-gray-700 pt-4">

--- a/components/cart/CartItemCard.tsx
+++ b/components/cart/CartItemCard.tsx
@@ -2,13 +2,13 @@
 
 import Image from "next/image";
 import { useCartStore } from "@/lib/stores/cart-store";
-import type { CartItem } from "@/lib/types/cartitem";
+import type { StableCartItem } from "@/lib/types/cartitem";
 import { Button } from "@/components/ui/button";
 import { usePathname } from "next/navigation";
 import { cartItemTotal, Money } from "@/lib/money";
 
 interface CartItemCardProps {
-  item: CartItem;
+  item: StableCartItem;
 }
 
 export default function CartItemCard({ item }: CartItemCardProps) {
@@ -37,7 +37,7 @@ export default function CartItemCard({ item }: CartItemCardProps) {
               variant="outline"
               size="sm"
               className="h-10 w-10 p-0 text-base touch-manipulation bg-neutral-100 text-black border border-gray-300 hover:bg-neutral-200"
-              onClick={() => updateQuantity(item.variantId, item.quantity - 1)}
+              onClick={() => updateQuantity(item.lineId, item.quantity - 1)}
             >
               -
             </Button>
@@ -48,7 +48,7 @@ export default function CartItemCard({ item }: CartItemCardProps) {
               variant="outline"
               size="sm"
               className="h-10 w-10 p-0 text-base touch-manipulation bg-neutral-100 text-black border border-gray-300 hover:bg-neutral-200"
-              onClick={() => updateQuantity(item.variantId, item.quantity + 1)}
+              onClick={() => updateQuantity(item.lineId, item.quantity + 1)}
             >
               +
             </Button>
@@ -57,12 +57,20 @@ export default function CartItemCard({ item }: CartItemCardProps) {
         <p className="text-xs sm:text-sm text-gray-500 mt-1">
           {Money.fromStored(item.price).format()} × {item.quantity} : {cartItemTotal(item).format()}
         </p>
+        {item.giftCardCustomization && (
+          <p className="mt-1 text-xs text-gray-600">
+            For {item.giftCardCustomization.recipientName || item.giftCardCustomization.recipientEmail}
+            {item.giftCardCustomization.deliveryDate
+              ? ` · Delivery ${item.giftCardCustomization.deliveryDate}`
+              : ''}
+          </p>
+        )}
         {!isCheckoutPage && (
           <Button
             variant="outline"
             size="sm"
             className="text-red-600 mt-2 border border-red-200 bg-red-50 hover:bg-orange-500 hover:text-white text-sm h-12 touch-manipulation"
-            onClick={() => removeItem(item.variantId)}
+            onClick={() => removeItem(item.lineId)}
           >
             Remove
           </Button>

--- a/components/checkout/CheckoutClient.tsx
+++ b/components/checkout/CheckoutClient.tsx
@@ -28,7 +28,7 @@
 
 "use client";
 
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { useCartStore } from '@/lib/stores/cart-store';
 import StripeProvider from './StripeProvider';
 import PaymentForm from './PaymentForm';
@@ -80,6 +80,8 @@ export default function CheckoutClient({ userId }: CheckoutClientProps) {
   const [authoritativeQuote, setAuthoritativeQuote] = useState<AuthoritativeCheckoutQuote>();
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string>('');
+  const [giftCardToken, setGiftCardToken] = useState('');
+  const giftCardRequestKey = useRef<string | undefined>(undefined);
 
   // Handle address form changes
   const handleAddressChange = (
@@ -167,6 +169,10 @@ export default function CheckoutClient({ userId }: CheckoutClientProps) {
           shippingAddress,
           shippingMethodId: selectedShippingOption.id,
           discountCodes: appliedDiscounts.map((discount) => discount.code),
+          ...(giftCardToken.trim() ? {
+            giftCardToken: giftCardToken.trim(),
+            giftCardRequestKey: giftCardRequestKey.current ??= crypto.randomUUID(),
+          } : {}),
         }),
       });
 
@@ -176,6 +182,7 @@ export default function CheckoutClient({ userId }: CheckoutClientProps) {
       }
 
       const data = await res.json() as {
+        noCash?: boolean;
         clientSecret: string;
         paymentIntentId: string;
         orderId: string;
@@ -184,12 +191,16 @@ export default function CheckoutClient({ userId }: CheckoutClientProps) {
       setOrderId(data.orderId);
       setTaxAmount(Money.fromMajor(data.quote.tax.amount, data.quote.tax.currency).toJSON());
       setAuthoritativeQuote(data.quote);
-      savePendingCheckout({
-        orderId: data.orderId,
-        paymentIntentId: data.paymentIntentId,
-      });
-      setClientSecret(data.clientSecret);
-      setCurrentStep('payment');
+      if (data.noCash) {
+        clearCart();
+        setGiftCardToken('');
+        giftCardRequestKey.current = undefined;
+        setCurrentStep('confirmation');
+      } else {
+        savePendingCheckout({ orderId: data.orderId, paymentIntentId: data.paymentIntentId });
+        setClientSecret(data.clientSecret);
+        setCurrentStep('payment');
+      }
 
     } catch (err: unknown) {
       throw err;
@@ -359,6 +370,27 @@ export default function CheckoutClient({ userId }: CheckoutClientProps) {
             }
             authoritativeQuote={authoritativeQuote}
           />
+
+          {currentStep === 'shipping' && (
+            <div className="bg-white p-4 rounded-xl text-black">
+              <label htmlFor="gift-card-code" className="block text-sm font-medium mb-1">
+                Gift card
+              </label>
+              <input
+                id="gift-card-code"
+                value={giftCardToken}
+                onChange={(event) => {
+                  setGiftCardToken(event.target.value);
+                  giftCardRequestKey.current = undefined;
+                }}
+                autoComplete="off"
+                maxLength={512}
+                className="w-full rounded border border-gray-300 px-3 py-2"
+                placeholder="Enter gift card code"
+              />
+              <p className="mt-1 text-xs text-gray-600">Applied securely when the checkout quote is created.</p>
+            </div>
+          )}
 
           {/* Payment Form */}
           {currentStep === 'payment' && clientSecret && (

--- a/components/checkout/CheckoutClient.tsx
+++ b/components/checkout/CheckoutClient.tsx
@@ -40,6 +40,7 @@ import OrderConfirmationModal from './OrderConfirmationModal';
 import type { Address, ShippingOption } from '@/lib/types';
 import { Money } from '@/lib/money';
 import { clearPendingCheckout, savePendingCheckout } from '@/lib/checkout/order-payload';
+import { projectCartLineForCheckout } from '@/lib/gift-cards/line-identity';
 
 interface CheckoutClientProps {
   userId: string | null;
@@ -162,11 +163,7 @@ export default function CheckoutClient({ userId }: CheckoutClientProps) {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          items: items.map((item) => ({
-            productId: item.productId,
-            variantId: item.variantId,
-            quantity: item.quantity,
-          })),
+          items: items.map(projectCartLineForCheckout),
           shippingAddress,
           shippingMethodId: selectedShippingOption.id,
           discountCodes: appliedDiscounts.map((discount) => discount.code),

--- a/components/checkout/OrderItemCard.tsx
+++ b/components/checkout/OrderItemCard.tsx
@@ -37,6 +37,11 @@ export default function OrderItemCard({ item, authoritativeLine }: OrderItemCard
         <div className="text-xs text-gray-500">
           {quantity} × {unitPrice.format()}
         </div>
+        {item?.giftCardCustomization && (
+          <div className="text-xs text-gray-500">
+            For {item.giftCardCustomization.recipientName || item.giftCardCustomization.recipientEmail}
+          </div>
+        )}
       </div>
 
       <div className="text-sm font-medium text-right min-w-[64px]">

--- a/components/checkout/OrderSummary.tsx
+++ b/components/checkout/OrderSummary.tsx
@@ -16,6 +16,7 @@ export interface AuthoritativeCheckoutQuote {
 }
 
 export interface AuthoritativeCheckoutLine {
+  lineId?: string;
   productId: string;
   variantId?: string;
   name: string;
@@ -72,20 +73,22 @@ export default function OrderSummary({
       <div className="space-y-1">
         {authoritativeQuote
           ? authoritativeQuote.items.map((line, idx) => {
-              const item = items.find((candidate) =>
-                candidate.productId === line.productId &&
-                candidate.variantId === line.variantId
-              );
+              const item = line.lineId
+                ? items.find((candidate) => candidate.lineId === line.lineId)
+                : items[idx] ?? items.find((candidate) =>
+                  candidate.productId === line.productId &&
+                  candidate.variantId === line.variantId
+                );
               return (
                 <OrderItemCard
-                  key={`${line.productId}:${line.variantId ?? ''}:${idx}`}
+                  key={line.lineId ?? item?.lineId ?? `${line.productId}:${line.variantId ?? ''}:${idx}`}
                   item={item}
                   authoritativeLine={line}
                 />
               );
             })
-          : items.map((item, idx) => (
-              <OrderItemCard key={idx} item={item} />
+          : items.map((item) => (
+              <OrderItemCard key={item.lineId} item={item} />
             ))}
       </div>
 

--- a/docs/migration-reservations.md
+++ b/docs/migration-reservations.md
@@ -9,7 +9,7 @@ ledger. Reservations prevent parallel feature branches from reusing a number.
 | `0019` | `O02` | Blog and neutral structured content publishing | Merged |
 | `0020` | `O05` | Exact legacy redirects for the Shopify migration toolkit | In review on PR `#75` |
 | `0021` | `O06` | Subscription plans, lifecycle, audit, and renewal-order identity | Reserved on `agent/o06-subscriptions` |
-| `0022` | `O07` | Gift-card account, ledger, reservation, and delivery state | Reserved for `O07` |
+| `0022` | `O07` | Gift-card account, ledger, reservation, and delivery state | Reserved on `agent/o07-gift-cards` |
 
 The next unreserved schema-bearing extraction must start at `0023` and
 reconcile against the then-current main branch before it commits a migration.

--- a/docs/o07-gift-cards-plan.md
+++ b/docs/o07-gift-cards-plan.md
@@ -99,3 +99,37 @@ refund foundations` → `O07 gift cards`.
 O07 remains one draft PR based on `agent/o06-subscriptions`; it must not merge
 or rebase against the unrelated BeauTeas `main` history. The expected reviewer
 assignment is Russell.
+
+## Implementation status and completion audit (2026-08-21)
+
+This section is deliberately a release gate rather than a progress claim. A
+passing focused test, build, or local commit does not make O07 ready to hand
+off. Only the conditions in wave 7 do.
+
+| Wave | Status | Evidence / remaining release gate |
+| --- | --- | --- |
+| 1. Authoritative calculation and snapshots | Implemented | Server checkout classifies the bounded digital gift-card line, omits shipping for digital-only orders, retains physical shipping for mixed orders, excludes gift cards from inventory mutation, and snapshots tender-eligible value without a bearer code. Focused checkout-pricing coverage is present. |
+| 2. Checkout and MCP tender lifecycle | Implemented | Stable request identity drives reservation/release; partial tender follows the cash payment boundary and wholly gift-funded orders use the no-cash finalizer. MCP uses the same authoritative checkout path. Final suite still needs to exercise the finished paths together. |
+| 3. Issuance and delivery | Implemented and focused-tested | Paid effects issue deterministic account identities and encrypted retry records. Delivery has a durable claim/lease/retry path. Real-D1 coverage proves issue-once/retry behavior, corrupted retry material becomes review-only, and the bearer code is absent from persisted state. |
+| 4. Refund convergence | In progress | The deterministic allocation and idempotent restoration primitive exist. The HTTP cash-provider leg, gift-restoration leg, and terminal dual-leg convergence must all be finalized and regression-tested before handoff. |
+| 5. Safe presentation surfaces | In progress | Customer/admin projections are intentionally secret-safe and bearer-code-free. Their authorization, pagination/input bounds, enumeration/rate-limit behavior, and UI/API tests remain a final completion gate. |
+| 6. Runtime composition and audit | Partially implemented | The five-minute scheduler drains gift-card delivery only when reconciliation is enabled; this is tested with acquisition disabled. Final operational documentation and full cross-surface audit remain. |
+| 7. Stack validation and handoff | Not started | Confirm the O06 ancestry without rewriting O07, run final lint/typecheck/build/unit/Worker/API/MCP/UI validation on the completed tree, then perform the separately authorized push and one draft PR assignment. No provider, email, deployment, or external write occurs during development validation. |
+
+### Current focused verification
+
+- `tests/integration/lib/gift-cards/repository.test.ts` covers real-D1 ledger,
+  reservation, settlement, and restoration atomicity/concurrency.
+- `tests/integration/lib/services/gift-card-fulfillment.test.ts` covers
+  idempotent issuance, retryable encrypted delivery, corrupt-material review,
+  and bearer-code non-persistence.
+- `tests/unit/lib/gift-cards/{code,config,customization,domain,encryption,
+  capability,runtime}.test.ts` covers the codec/configuration boundaries,
+  bounded line customization, key rotation, and lazy runtime behavior.
+- `tests/unit/worker-cron-routing.test.ts` proves reconciliation-only scheduler
+  delivery retries work while acquisition is disabled and that disabled
+  reconciliation does not open that boundary.
+
+The final regression matrix must add finished refund-route and customer/admin
+surface tests, then be rerun as one clean suite after all concurrent O07 work
+has landed. Until then, this branch is explicitly **not PR-ready**.

--- a/docs/o07-gift-cards-plan.md
+++ b/docs/o07-gift-cards-plan.md
@@ -1,0 +1,101 @@
+# O07 Gift Cards: Completion Plan
+
+## Scope and completed foundation
+
+O07 provides generic stored-value gift cards for Mercora, stacked on
+`agent/o06-subscriptions`. The branch currently contains the security and
+ledger foundation:
+
+- Cart lines have stable identifiers and bounded gift-card recipient fields.
+- Migration `0022` and the Drizzle schema model cards, append-only ledger
+  entries, and delivery state.
+- Bearer codes are versioned 140-bit values represented in storage only by a
+  keyed HMAC digest; raw codes are never persisted with an order or card.
+- Cards support append-only issuance, reservation, settlement, release,
+  expiration, and refund-restoration guards.
+- Retry-delivery material is encrypted with AES-GCM, and checkout acquisition
+  is a separately configurable lazy capability while reconciliation remains
+  available.
+- D1 migration, atomicity, and concurrency tests exercise the foundation.
+
+## Implementation waves
+
+1. **Authoritative mixed-cart calculation and snapshots.** Classify digital
+   gift-card lines in server pricing; exclude them from shipping and inventory;
+   retain physical shipping for mixed carts; calculate promotion/tax/shipping
+   using the current framework contracts; persist immutable order snapshots
+   without bearer codes.
+2. **Checkout and MCP tender lifecycle.** Add web and MCP acquisition,
+   request-identity-bound reservation and explicit release/expiry. Finalize
+   partial-gift purchases with positive cash through the payment boundary, and
+   finalize fully funded purchases through a genuine no-Stripe, zero-cash
+   path. Gift-card value must never pay for a gift-card line.
+3. **Issuance and delivery.** Issue cards idempotently only after successful
+   order finalization; deliver through a provider-neutral, retryable email
+   boundary. The raw code exists only transiently in encrypted retry material
+   and delivery rendering.
+4. **Refund convergence.** Allocate refunds between cash and gift tender,
+   restore gift value exactly once, and mark a refund complete only after its
+   cash and gift restoration legs have both converged.
+5. **Safe presentation surfaces.** Add customer/admin APIs and UI, public
+   rate limiting and enumeration-resistant responses, and secret-safe
+   projections with no raw code or encrypted material leakage.
+6. **Runtime composition and audit.** Connect scheduler/runtime composition
+   for reconciliation, reservation expiry, and delivery retries; finish docs
+   and the complete unit, integration, worker, API/MCP, and UI test matrix.
+7. **Stack validation and handoff.** Rebase the completed worktree on
+   `agent/o06-subscriptions` without rewriting the existing O07 history,
+   validate the full suite, push, and open one draft O07 PR stacked on O06 and
+   assigned to Russell. This final wave requires explicit GitHub/network action
+   only when requested/available; development performs no provider calls.
+
+## Provenance and exclusions
+
+Behavioral provenance is frozen downstream source
+`/Users/devon/git/mercora-beauteas-v1.0.0`, principally its Phase 8 migration
+plan and gift-card behavior/follow-ups at `30a70f5`, `a965cfe`, `ba58808`,
+`0c64aec`, `7b7da32`, `6f64b57`, `fe15622`, `7371ed5`, and `1fa7c81`.
+Those commits are inspected as evidence, not merged, rebased, or blindly
+cherry-picked. Mercora implementations must use current upstream contracts and
+exclude BeauTeas branding, copy, catalog/denominations, merchant policy,
+provider/infrastructure identifiers, credentials, and plaintext-code design.
+
+## Security and commerce invariants
+
+- Raw bearer codes never enter D1, logs, telemetry, order metadata, API/MCP
+  projections, or UI state beyond the immediate redemption/delivery boundary.
+- Code storage remains a keyed digest; retry material remains encrypted and is
+  revealed only transiently for a claimed delivery attempt.
+- Reconciliation can run when acquisition is disabled. Reservation operations
+  use a stable request identity and explicit release or expiry.
+- Gift tender cannot purchase gift-card value. A full gift tender finalizes
+  through a real zero-cash path, never a fabricated zero-dollar Stripe intent.
+- Digital-only orders have no shipping; mixed orders preserve physical shipping.
+  Gift-card products are never inventory-adjusted.
+- All final order amounts, tender allocation, inventory actions, and issuance
+  eligibility are server authoritative and snapshot-based.
+- Issuance, delivery, settlement, releases, and refund restoration are
+  idempotent. Refund completion requires both cash and gift legs to converge.
+- No development or tests invoke payment/email providers, send email, use
+  credentials, deploy, or write external resources.
+
+## Test matrix
+
+| Area | Required coverage |
+| --- | --- |
+| Pricing and fulfillment | Digital-only, physical-only, and mixed carts; promotion/tax/shipping; no gift-card self-purchase; immutable snapshots; no gift inventory mutation |
+| Tender lifecycle | Web and MCP acquire/retry/release/expiry; stable request identity; partial and full tender finalization; positive-cash payment binding |
+| Issuance and delivery | Idempotent issuance; encrypted retry material; claim/release single-flight delivery; no raw-code persistence or projection leakage |
+| Refunds | Cash-only, gift-only, split tender, retry/idempotency, and dual-leg completion convergence |
+| Public/admin surfaces | Input bounds, rate limit fail mode, enumeration resistance, authorization, and safe customer/admin projections |
+| Runtime and D1 | Scheduler composition, migration application/order, real-D1 atomicity/concurrency, reconciliation, expiry, and worker-safe configuration |
+| Regression | Focused unit/API/MCP/worker/UI tests plus lint, typecheck, build, and relevant existing checkout/subscription suites |
+
+## PR dependency chain
+
+`O03 runtime safety` → `O06 subscriptions / order-trust + webhook-inventory-
+refund foundations` → `O07 gift cards`.
+
+O07 remains one draft PR based on `agent/o06-subscriptions`; it must not merge
+or rebase against the unrelated BeauTeas `main` history. The expected reviewer
+assignment is Russell.

--- a/docs/o07-gift-cards-plan.md
+++ b/docs/o07-gift-cards-plan.md
@@ -109,12 +109,12 @@ off. Only the conditions in wave 7 do.
 | Wave | Status | Evidence / remaining release gate |
 | --- | --- | --- |
 | 1. Authoritative calculation and snapshots | Implemented | Server checkout classifies the bounded digital gift-card line, omits shipping for digital-only orders, retains physical shipping for mixed orders, excludes gift cards from inventory mutation, and snapshots tender-eligible value without a bearer code. Focused checkout-pricing coverage is present. |
-| 2. Checkout and MCP tender lifecycle | Implemented | Stable request identity drives reservation/release; partial tender follows the cash payment boundary and wholly gift-funded orders use the no-cash finalizer. MCP uses the same authoritative checkout path. Final suite still needs to exercise the finished paths together. |
+| 2. Checkout and MCP tender lifecycle | Implemented | Stable request identity drives reservation/release; partial tender follows the cash payment boundary and wholly gift-funded orders use the no-cash finalizer. MCP uses the same authoritative checkout path. |
 | 3. Issuance and delivery | Implemented and focused-tested | Paid effects issue deterministic account identities and encrypted retry records. Delivery has a durable claim/lease/retry path. Real-D1 coverage proves issue-once/retry behavior, corrupted retry material becomes review-only, and the bearer code is absent from persisted state. |
-| 4. Refund convergence | In progress | The deterministic allocation and idempotent restoration primitive exist. The HTTP cash-provider leg, gift-restoration leg, and terminal dual-leg convergence must all be finalized and regression-tested before handoff. |
-| 5. Safe presentation surfaces | In progress | Customer/admin projections are intentionally secret-safe and bearer-code-free. Their authorization, pagination/input bounds, enumeration/rate-limit behavior, and UI/API tests remain a final completion gate. |
-| 6. Runtime composition and audit | Partially implemented | The five-minute scheduler drains gift-card delivery only when reconciliation is enabled; this is tested with acquisition disabled. Final operational documentation and full cross-surface audit remain. |
-| 7. Stack validation and handoff | Not started | Confirm the O06 ancestry without rewriting O07, run final lint/typecheck/build/unit/Worker/API/MCP/UI validation on the completed tree, then perform the separately authorized push and one draft PR assignment. No provider, email, deployment, or external write occurs during development validation. |
+| 4. Refund convergence | Implemented | Deterministic allocation persists cash and gift legs; Stripe is called only for positive cash, restoration is keyed to the settled opaque reservation, and terminal status waits for both legs. Retries retrieve the known provider refund and retry only restoration. |
+| 5. Safe presentation surfaces | Implemented | Customer and admin read surfaces use strict bounds/auth/rate limits and secret-safe projections; balance remains available with reconciliation enabled after acquisition is disabled. |
+| 6. Runtime composition and audit | Implemented | The five-minute scheduler drains delivery only when reconciliation is enabled; delivery/secret-leak and reconciliation-only runtime coverage are included. |
+| 7. Stack validation and handoff | Validation complete; external handoff pending | O06 is an ancestor of O07 without rebase/rewrite. Final lint/typecheck/build, unit, Worker/D1, API/MCP/UI coverage, and whitespace checks pass. Push and draft PR assignment remain an external GitHub action, excluded from development by the no-external-write constraint. |
 
 ### Current focused verification
 
@@ -130,6 +130,7 @@ off. Only the conditions in wave 7 do.
   delivery retries work while acquisition is disabled and that disabled
   reconciliation does not open that boundary.
 
-The final regression matrix must add finished refund-route and customer/admin
-surface tests, then be rerun as one clean suite after all concurrent O07 work
-has landed. Until then, this branch is explicitly **not PR-ready**.
+Final combined verification after all O07 work landed: 230 unit files / 1,677
+tests pass; 27 Worker/D1 files / 147 tests pass; typecheck, production build,
+and whitespace checks pass. Lint has 52 pre-existing warnings and no errors.
+The branch is **ready for the separately authorized external PR handoff**.

--- a/docs/runtime-configuration.md
+++ b/docs/runtime-configuration.md
@@ -15,6 +15,9 @@ time.
 | Theme | `NEXT_PUBLIC_THEME_PRIMARY`, `NEXT_PUBLIC_STORE_LOGO_PATH` |
 | Contact and legal links | `STORE_SUPPORT_EMAIL`, `STORE_SENDER_EMAIL`, `STORE_REPLY_TO_EMAIL`, `STORE_MERCHANT_NOTIFICATION_EMAIL`, `STORE_POSTAL_ADDRESS`, `STORE_SUPPORT_HOURS`, `NEXT_PUBLIC_PRIVACY_URL`, `NEXT_PUBLIC_TERMS_URL`, `NEXT_PUBLIC_RETURNS_URL` |
 | Commerce formatting | `STORE_LOCALE` (canonical BCP 47 locale, defaults to `en-US`), `STORE_CURRENCY` (must match active catalog variant currency; Mercora checkout is single-currency per cart) |
+| Gift-card reconciliation | `STORE_FEATURE_GIFT_CARD_RECONCILIATION=true` (defaults off; keep enabled while reservations or balances exist) |
+| Optional gift-card acquisition | `STORE_FEATURE_GIFT_CARD_ACQUISITION=true` (defaults off and requires reconciliation enabled) |
+| Gift-card bearer lookup secrets | Server-only `GIFT_CARD_CODE_HMAC_CURRENT_VERSION` plus `GIFT_CARD_CODE_HMAC_KEYS_JSON` (at most four versioned keys; never `NEXT_PUBLIC_*`) |
 | Subscription reconciliation | `STORE_FEATURE_SUBSCRIPTION_RECONCILIATION=true` (defaults off; keep enabled after the first subscription is sold) |
 | Optional subscription acquisition | `STORE_FEATURE_SUBSCRIPTION_ACQUISITION=true` plus a bounded `STORE_SUBSCRIPTION_TERMS_VERSION` matching the published recurring terms (defaults off and requires reconciliation enabled) |
 | Outbound email | `EMAIL_PROVIDER=cloudflare\|resend`; Cloudflare `EMAIL` binding (recommended) or encrypted `RESEND_API_KEY` |
@@ -36,6 +39,23 @@ cancellation, payment recovery, or retryable notifications for existing
 subscriptions. Enabling acquisition without installed reconciliation is a
 configuration error. Deploy the additive schema first, install reconciliation,
 then enable the acquisition flag.
+
+Gift cards use the same acquisition/reconciliation rollback discipline. Leave
+both flags off before installing the additive schema and runtime factory; this
+path does not open D1 or parse bearer-code keys. Enable reconciliation first,
+then acquisition. After accepting a gift-card reservation or balance, disable
+acquisition to stop new bearer-code entry while leaving reconciliation enabled
+for verification, settlement, and release. The HMAC key ring is read from the
+request-scoped Workers environment only when a nonempty bearer token is being
+resolved. Reconciliation-only calls do not require those lookup keys.
+
+`GIFT_CARD_CODE_HMAC_KEYS_JSON` is a JSON object whose canonical positive
+integer property names are key versions, for example `{"1":"<32+ byte
+secret>","2":"<32+ byte secret>"}`. The current version must be present,
+and the ring is bounded to four keys. Store these values in local `.dev.vars`
+or encrypted Cloudflare secrets. They are intentionally absent from
+`StoreConfig`, browser configuration, committed deployment files, telemetry,
+and errors.
 
 Core one-time checkout never interprets catalog products as subscription
 acquisition. Products that also have subscription plans remain available for a

--- a/lib/commerce/capabilities.ts
+++ b/lib/commerce/capabilities.ts
@@ -7,6 +7,11 @@ export interface GiftCardCheckoutCapability {
     token?: string;
     currency: string;
     amountDue: Money;
+    /**
+     * Transitional legacy seam. A repository-backed capability requires this
+     * complete server-authored identity whenever `token` is nonempty.
+     */
+    requestIdentity?: GiftCardTenderRequestIdentity;
   }): Promise<{ amount: Money; state?: unknown }>;
   /** Fail closed unless the persisted reservation still covers `expectedTender`. */
   verifyReservedTender(args: {
@@ -16,6 +21,15 @@ export interface GiftCardCheckoutCapability {
   }): Promise<void>;
   /** Idempotently settle an already verified reservation after the paid CAS. */
   applyTender(args: { order: Order; state?: unknown }): Promise<void>;
+  /** Idempotently release an open reservation when checkout is abandoned. */
+  releaseTender?(args: { state?: unknown; reason?: string }): Promise<void>;
+}
+
+export interface GiftCardTenderRequestIdentity {
+  requestKey: string;
+  quoteFingerprint: string;
+  reservedAt: number;
+  expiresAt: number;
 }
 
 export interface SubscriptionCheckoutCapability {
@@ -24,7 +38,10 @@ export interface SubscriptionCheckoutCapability {
 }
 
 export interface CommerceFeatureFlags {
-  giftCards: boolean;
+  /** Customer-facing bearer-code acceptance and new reservations. */
+  giftCardAcquisition: boolean;
+  /** Existing reservation verification, settlement, and release. */
+  giftCardReconciliation: boolean;
   /** Customer-facing acquisition/UI. Safe rollback switch for new sales. */
   subscriptionAcquisition: boolean;
   /** Existing lifecycle/invoice reconciliation. Remains on after first sale. */
@@ -37,6 +54,13 @@ export interface CommerceCapabilityFactories {
 }
 
 export class CommerceCapabilityConfigurationError extends Error {}
+
+export class CommerceCapabilityDisabledError extends Error {
+  constructor() {
+    super("Gift-card tender capability is disabled");
+    this.name = "CommerceCapabilityDisabledError";
+  }
+}
 
 /** Protected order metadata written only while reconciling a verified subscription invoice order. */
 export const SUBSCRIPTION_ACQUISITION_EXTENSION = "subscription_acquisition_id";
@@ -57,7 +81,10 @@ export interface CommerceCapabilities {
 
 export const noOpCommerceCapabilities: CommerceCapabilities = {
   giftCards: {
-    async resolveTender({ currency }) {
+    async resolveTender({ token, currency }) {
+      if (token !== undefined && token !== "") {
+        throw new CommerceCapabilityDisabledError();
+      }
       return { amount: Money.zero(currency) };
     },
     async verifyReservedTender({ expectedTender }) {
@@ -65,7 +92,21 @@ export const noOpCommerceCapabilities: CommerceCapabilities = {
         throw new Error('No gift-card capability is configured for nonzero tender');
       }
     },
-    async applyTender() {},
+    async applyTender({ order }) {
+      try {
+        const tender = Money.fromStored(
+          order.extensions?.checkout_tender ?? 0,
+          order.currency_code,
+        );
+        if (!tender.isZero()) throw new CommerceCapabilityDisabledError();
+      } catch (error) {
+        if (error instanceof CommerceCapabilityDisabledError) throw error;
+        throw new CommerceCapabilityDisabledError();
+      }
+    },
+    async releaseTender({ state }) {
+      if (state !== undefined) throw new CommerceCapabilityDisabledError();
+    },
   },
   subscriptions: {
     async orderPaid(order) {
@@ -104,6 +145,11 @@ export function resolveCommerceCapabilities(
       "Subscription acquisition requires lifecycle and invoice reconciliation",
     );
   }
+  if (flags.giftCardAcquisition && !flags.giftCardReconciliation) {
+    throw new CommerceCapabilityConfigurationError(
+      "Gift-card acquisition requires reservation reconciliation",
+    );
+  }
 
   const subscriptions = resolve(
     flags.subscriptionAcquisition || flags.subscriptionReconciliation,
@@ -122,13 +168,35 @@ export function resolveCommerceCapabilities(
         },
       };
 
+  const giftCards = resolve(
+    flags.giftCardAcquisition || flags.giftCardReconciliation,
+    factories.giftCards,
+    noOpCommerceCapabilities.giftCards,
+    "Gift cards",
+  );
+  const gatedGiftCards: GiftCardCheckoutCapability = (
+    giftCards === noOpCommerceCapabilities.giftCards || flags.giftCardAcquisition
+  ) ? giftCards : {
+      async resolveTender({ token, currency }) {
+        if (token !== undefined && token !== "") {
+          throw new CommerceCapabilityDisabledError();
+        }
+        return { amount: Money.zero(currency) };
+      },
+      verifyReservedTender: (args) => giftCards.verifyReservedTender(args),
+      applyTender: (args) => giftCards.applyTender(args),
+      releaseTender: async (args) => {
+        if (!giftCards.releaseTender) {
+          throw new CommerceCapabilityConfigurationError(
+            "Gift-card reconciliation release is not configured",
+          );
+        }
+        await giftCards.releaseTender(args);
+      },
+    };
+
   return {
-    giftCards: resolve(
-      flags.giftCards,
-      factories.giftCards,
-      noOpCommerceCapabilities.giftCards,
-      "Gift cards",
-    ),
+    giftCards: gatedGiftCards,
     subscriptions: gatedSubscriptions,
   };
 }

--- a/lib/commerce/capabilities.ts
+++ b/lib/commerce/capabilities.ts
@@ -23,6 +23,13 @@ export interface GiftCardCheckoutCapability {
   applyTender(args: { order: Order; state?: unknown }): Promise<void>;
   /** Idempotently release an open reservation when checkout is abandoned. */
   releaseTender?(args: { state?: unknown; reason?: string }): Promise<void>;
+  /** Restore part of a settled tender exactly once for one refund ledger key. */
+  restoreTender?(args: {
+    order: Order;
+    state?: unknown;
+    refundKey: string;
+    amount: Money;
+  }): Promise<void>;
 }
 
 export interface GiftCardTenderRequestIdentity {
@@ -106,6 +113,9 @@ export const noOpCommerceCapabilities: CommerceCapabilities = {
     },
     async releaseTender({ state }) {
       if (state !== undefined) throw new CommerceCapabilityDisabledError();
+    },
+    async restoreTender({ amount }) {
+      if (!amount.isZero()) throw new CommerceCapabilityDisabledError();
     },
   },
   subscriptions: {
@@ -192,6 +202,9 @@ export function resolveCommerceCapabilities(
           );
         }
         await giftCards.releaseTender(args);
+      },
+      restoreTender: async (args) => {
+        if (!args.amount.isZero()) throw new CommerceCapabilityDisabledError();
       },
     };
 

--- a/lib/commerce/capabilities.ts
+++ b/lib/commerce/capabilities.ts
@@ -204,7 +204,12 @@ export function resolveCommerceCapabilities(
         await giftCards.releaseTender(args);
       },
       restoreTender: async (args) => {
-        if (!args.amount.isZero()) throw new CommerceCapabilityDisabledError();
+        if (!giftCards.restoreTender) {
+          throw new CommerceCapabilityConfigurationError(
+            "Gift-card reconciliation restoration is not configured",
+          );
+        }
+        await giftCards.restoreTender(args);
       },
     };
 

--- a/lib/commerce/runtime.ts
+++ b/lib/commerce/runtime.ts
@@ -1,0 +1,37 @@
+import { getCloudflareContext } from '@opennextjs/cloudflare';
+import {
+  resolveCommerceCapabilities,
+  noOpCommerceCapabilities,
+  type CommerceCapabilities,
+  type CommerceFeatureFlags,
+} from '@/lib/commerce/capabilities';
+import { createRuntimeGiftCardCapabilityFactory } from '@/lib/gift-cards/runtime';
+
+type RuntimeEnvironment = Record<string, unknown>;
+
+function enabled(environment: RuntimeEnvironment, key: string): boolean {
+  return typeof environment[key] === 'string' && environment[key].trim().toLowerCase() === 'true';
+}
+
+/**
+ * Resolve optional commerce features from request-scoped Worker bindings.
+ * This deliberately avoids build-time `process.env` capture and never touches
+ * the gift-card key ring unless either gift-card capability is enabled.
+ */
+export async function resolveRuntimeCommerceCapabilities(): Promise<CommerceCapabilities> {
+  const { env } = await getCloudflareContext({ async: true });
+  const environment = env as unknown as RuntimeEnvironment;
+  const flags: CommerceFeatureFlags = {
+    giftCardAcquisition: enabled(environment, 'STORE_FEATURE_GIFT_CARD_ACQUISITION'),
+    giftCardReconciliation: enabled(environment, 'STORE_FEATURE_GIFT_CARD_RECONCILIATION'),
+    subscriptionAcquisition: enabled(environment, 'STORE_FEATURE_SUBSCRIPTION_ACQUISITION'),
+    subscriptionReconciliation: enabled(environment, 'STORE_FEATURE_SUBSCRIPTION_RECONCILIATION'),
+  };
+  return resolveCommerceCapabilities(flags, {
+    giftCards: createRuntimeGiftCardCapabilityFactory(),
+    // Subscription runtime composition remains owned by O06. Supplying its
+    // inert boundary preserves ordinary checkout while an unsupported marked
+    // subscription order still fails closed in the capability itself.
+    subscriptions: () => noOpCommerceCapabilities.subscriptions,
+  });
+}

--- a/lib/db/schema/gift-cards.ts
+++ b/lib/db/schema/gift-cards.ts
@@ -193,6 +193,7 @@ export const giftCardDeliveries = sqliteTable("gift_card_deliveries", {
     enum: ["pending", "processing", "sent", "needs_review"],
   }).notNull().default("pending"),
   attemptCount: integer("attempt_count").notNull().default(0),
+  deliverAfter: integer("deliver_after").notNull().default(0),
   claimToken: text("claim_token"),
   leaseExpiresAt: integer("lease_expires_at"),
   codeCiphertext: text("code_ciphertext"),
@@ -203,7 +204,7 @@ export const giftCardDeliveries = sqliteTable("gift_card_deliveries", {
   completedAt: integer("completed_at"),
 }, (table) => [
   index("gift_card_deliveries_retry_idx")
-    .on(table.status, table.leaseExpiresAt, table.updatedAt),
+    .on(table.status, table.deliverAfter, table.leaseExpiresAt, table.updatedAt),
   check("gift_card_deliveries_id_check", sql`length(${table.id}) BETWEEN 1 AND 128`),
   check("gift_card_deliveries_recipient_check", sql`
     length(${table.recipientEmail}) BETWEEN 3 AND 320

--- a/lib/db/schema/gift-cards.ts
+++ b/lib/db/schema/gift-cards.ts
@@ -1,0 +1,228 @@
+import { sql } from "drizzle-orm";
+import {
+  check,
+  foreignKey,
+  index,
+  integer,
+  sqliteTable,
+  text,
+  uniqueIndex,
+} from "drizzle-orm/sqlite-core";
+import { customers } from "./customer";
+import { orders } from "./order";
+
+export type GiftCardAccountStatus = "active" | "disabled";
+export type GiftCardLedgerEntryType =
+  | "issuance"
+  | "redemption"
+  | "restoration"
+  | "adjustment";
+export type GiftCardDeliveryStatus =
+  | "pending"
+  | "processing"
+  | "sent"
+  | "needs_review";
+
+const safeInteger = 9_007_199_254_740_991;
+
+export const giftCardAccounts = sqliteTable("gift_card_accounts", {
+  id: text("id").primaryKey(),
+  codeHash: text("code_hash").notNull(),
+  codeHashVersion: integer("code_hash_version").notNull(),
+  currencyCode: text("currency_code").notNull(),
+  status: text("status", { enum: ["active", "disabled"] }).notNull().default("active"),
+  issuanceEntryId: text("issuance_entry_id").notNull().unique(),
+  issuanceBusinessKey: text("issuance_business_key").notNull().unique(),
+  issuedAmountMinor: integer("issued_amount_minor").notNull(),
+  issuedOrderId: text("issued_order_id").references(() => orders.id, { onDelete: "restrict" }),
+  issuedLineId: text("issued_line_id"),
+  purchaserCustomerId: text("purchaser_customer_id")
+    .references(() => customers.id, { onDelete: "restrict" }),
+  createdAt: integer("created_at").notNull(),
+  disabledAt: integer("disabled_at"),
+}, (table) => [
+  uniqueIndex("gift_card_accounts_code_hash_unique")
+    .on(table.codeHashVersion, table.codeHash),
+  uniqueIndex("gift_card_accounts_identity_currency_unique")
+    .on(table.id, table.currencyCode),
+  index("gift_card_accounts_status_idx").on(table.status, table.currencyCode),
+  index("gift_card_accounts_order_idx").on(table.issuedOrderId, table.issuedLineId),
+  check("gift_card_accounts_id_check", sql`length(${table.id}) BETWEEN 1 AND 128`),
+  check("gift_card_accounts_hash_check", sql`
+    length(${table.codeHash}) = 64
+    AND ${table.codeHash} = lower(${table.codeHash})
+    AND ${table.codeHash} NOT GLOB '*[^0-9a-f]*'
+  `),
+  check("gift_card_accounts_hash_version_check", sql`
+    ${table.codeHashVersion} BETWEEN 1 AND ${safeInteger}
+  `),
+  check("gift_card_accounts_currency_check", sql`
+    length(${table.currencyCode}) = 3
+    AND ${table.currencyCode} = upper(${table.currencyCode})
+    AND ${table.currencyCode} NOT GLOB '*[^A-Z]*'
+  `),
+  check("gift_card_accounts_amount_check", sql`
+    ${table.issuedAmountMinor} BETWEEN 1 AND ${safeInteger}
+  `),
+  check("gift_card_accounts_status_check", sql`
+    (${table.status} = 'active' AND ${table.disabledAt} IS NULL)
+    OR (${table.status} = 'disabled' AND ${table.disabledAt} IS NOT NULL)
+  `),
+  check("gift_card_accounts_source_check", sql`
+    (${table.issuedOrderId} IS NULL AND ${table.issuedLineId} IS NULL)
+    OR (${table.issuedOrderId} IS NOT NULL AND ${table.issuedLineId} IS NOT NULL)
+  `),
+]);
+
+export const giftCardReservations = sqliteTable("gift_card_reservations", {
+  id: text("id").primaryKey(),
+  giftCardId: text("gift_card_id").notNull(),
+  currencyCode: text("currency_code").notNull(),
+  requestKey: text("request_key").notNull().unique(),
+  quoteFingerprint: text("quote_fingerprint").notNull(),
+  requestedAmountMinor: integer("requested_amount_minor").notNull(),
+  amountMinor: integer("amount_minor").notNull(),
+  reservedAt: integer("reserved_at").notNull(),
+  expiresAt: integer("expires_at").notNull(),
+  committedOrderId: text("committed_order_id")
+    .references(() => orders.id, { onDelete: "restrict" }),
+  committedAt: integer("committed_at"),
+  releasedAt: integer("released_at"),
+  releaseReason: text("release_reason"),
+}, (table) => [
+  foreignKey({
+    columns: [table.giftCardId, table.currencyCode],
+    foreignColumns: [giftCardAccounts.id, giftCardAccounts.currencyCode],
+  }).onDelete("restrict"),
+  index("gift_card_reservations_account_idx")
+    .on(table.giftCardId, table.releasedAt, table.committedAt, table.expiresAt),
+  index("gift_card_reservations_order_idx").on(table.committedOrderId),
+  check("gift_card_reservations_id_check", sql`length(${table.id}) BETWEEN 1 AND 128`),
+  check("gift_card_reservations_request_check", sql`
+    length(${table.requestKey}) BETWEEN 8 AND 256
+  `),
+  check("gift_card_reservations_fingerprint_check", sql`
+    length(${table.quoteFingerprint}) = 64
+    AND ${table.quoteFingerprint} = lower(${table.quoteFingerprint})
+    AND ${table.quoteFingerprint} NOT GLOB '*[^0-9a-f]*'
+  `),
+  check("gift_card_reservations_amount_check", sql`
+    ${table.requestedAmountMinor} BETWEEN 1 AND ${safeInteger}
+    AND ${table.amountMinor} BETWEEN 1 AND ${table.requestedAmountMinor}
+  `),
+  check("gift_card_reservations_time_check", sql`
+    ${table.reservedAt} BETWEEN 0 AND ${safeInteger}
+    AND ${table.expiresAt} BETWEEN 1 AND ${safeInteger}
+    AND ${table.expiresAt} > ${table.reservedAt}
+  `),
+  check("gift_card_reservations_commit_check", sql`
+    (${table.committedOrderId} IS NULL AND ${table.committedAt} IS NULL)
+    OR (${table.committedOrderId} IS NOT NULL AND ${table.committedAt} IS NOT NULL)
+  `),
+  check("gift_card_reservations_release_check", sql`
+    ((${table.releasedAt} IS NULL AND ${table.releaseReason} IS NULL)
+      OR (${table.releasedAt} IS NOT NULL AND ${table.releaseReason} IS NOT NULL))
+    AND (${table.committedAt} IS NULL OR ${table.releasedAt} IS NULL)
+  `),
+]);
+
+export const giftCardLedgerEntries = sqliteTable("gift_card_ledger_entries", {
+  id: text("id").primaryKey(),
+  giftCardId: text("gift_card_id").notNull(),
+  currencyCode: text("currency_code").notNull(),
+  entryType: text("entry_type", {
+    enum: ["issuance", "redemption", "restoration", "adjustment"],
+  }).notNull(),
+  amountDeltaMinor: integer("amount_delta_minor").notNull(),
+  businessKey: text("business_key").notNull().unique(),
+  orderId: text("order_id").references(() => orders.id, { onDelete: "restrict" }),
+  reservationId: text("reservation_id")
+    .references(() => giftCardReservations.id, { onDelete: "restrict" }),
+  relatedEntryId: text("related_entry_id"),
+  createdAt: integer("created_at").notNull(),
+}, (table) => [
+  foreignKey({
+    columns: [table.giftCardId, table.currencyCode],
+    foreignColumns: [giftCardAccounts.id, giftCardAccounts.currencyCode],
+  }).onDelete("restrict"),
+  foreignKey({
+    columns: [table.relatedEntryId],
+    foreignColumns: [table.id],
+  }).onDelete("restrict"),
+  uniqueIndex("gift_card_ledger_issuance_unique")
+    .on(table.giftCardId).where(sql`${table.entryType} = 'issuance'`),
+  uniqueIndex("gift_card_ledger_reservation_unique")
+    .on(table.reservationId).where(sql`${table.reservationId} IS NOT NULL`),
+  index("gift_card_ledger_account_idx").on(table.giftCardId, table.createdAt, table.id),
+  index("gift_card_ledger_order_idx").on(table.orderId, table.entryType),
+  check("gift_card_ledger_id_check", sql`length(${table.id}) BETWEEN 1 AND 128`),
+  check("gift_card_ledger_amount_check", sql`
+    ${table.amountDeltaMinor} BETWEEN -${safeInteger} AND ${safeInteger}
+    AND ${table.amountDeltaMinor} <> 0
+  `),
+  check("gift_card_ledger_business_key_check", sql`
+    length(${table.businessKey}) BETWEEN 1 AND 256
+  `),
+  check("gift_card_ledger_sign_check", sql`
+    (${table.entryType} IN ('issuance', 'restoration') AND ${table.amountDeltaMinor} > 0)
+    OR (${table.entryType} = 'redemption' AND ${table.amountDeltaMinor} < 0)
+    OR ${table.entryType} = 'adjustment'
+  `),
+  check("gift_card_ledger_reservation_check", sql`
+    (${table.entryType} = 'redemption'
+      AND ${table.reservationId} IS NOT NULL AND ${table.orderId} IS NOT NULL)
+    OR (${table.entryType} <> 'redemption' AND ${table.reservationId} IS NULL)
+  `),
+]);
+
+export const giftCardDeliveries = sqliteTable("gift_card_deliveries", {
+  id: text("id").primaryKey(),
+  giftCardId: text("gift_card_id").notNull().unique()
+    .references(() => giftCardAccounts.id, { onDelete: "restrict" }),
+  orderId: text("order_id").references(() => orders.id, { onDelete: "restrict" }),
+  orderLineId: text("order_line_id"),
+  recipientEmail: text("recipient_email").notNull(),
+  recipientName: text("recipient_name"),
+  emailIdempotencyKey: text("email_idempotency_key").notNull().unique(),
+  status: text("status", {
+    enum: ["pending", "processing", "sent", "needs_review"],
+  }).notNull().default("pending"),
+  attemptCount: integer("attempt_count").notNull().default(0),
+  claimToken: text("claim_token"),
+  leaseExpiresAt: integer("lease_expires_at"),
+  codeCiphertext: text("code_ciphertext"),
+  codeNonce: text("code_nonce"),
+  codeKeyVersion: integer("code_key_version"),
+  createdAt: integer("created_at").notNull(),
+  updatedAt: integer("updated_at").notNull(),
+  completedAt: integer("completed_at"),
+}, (table) => [
+  index("gift_card_deliveries_retry_idx")
+    .on(table.status, table.leaseExpiresAt, table.updatedAt),
+  check("gift_card_deliveries_id_check", sql`length(${table.id}) BETWEEN 1 AND 128`),
+  check("gift_card_deliveries_recipient_check", sql`
+    length(${table.recipientEmail}) BETWEEN 3 AND 320
+    AND (${table.recipientName} IS NULL OR length(${table.recipientName}) BETWEEN 1 AND 200)
+  `),
+  check("gift_card_deliveries_ciphertext_check", sql`
+    (${table.codeCiphertext} IS NULL AND ${table.codeNonce} IS NULL AND ${table.codeKeyVersion} IS NULL)
+    OR (${table.codeCiphertext} IS NOT NULL
+      AND ${table.codeNonce} IS NOT NULL
+      AND ${table.codeKeyVersion} BETWEEN 1 AND ${safeInteger})
+  `),
+  check("gift_card_deliveries_lease_check", sql`
+    (${table.status} = 'processing'
+      AND ${table.claimToken} IS NOT NULL AND ${table.leaseExpiresAt} IS NOT NULL)
+    OR (${table.status} <> 'processing'
+      AND ${table.claimToken} IS NULL AND ${table.leaseExpiresAt} IS NULL)
+  `),
+  check("gift_card_deliveries_completion_check", sql`
+    (${table.status} IN ('sent', 'needs_review') AND ${table.completedAt} IS NOT NULL)
+    OR (${table.status} IN ('pending', 'processing') AND ${table.completedAt} IS NULL)
+  `),
+]);
+
+export type GiftCardAccountRow = typeof giftCardAccounts.$inferSelect;
+export type GiftCardReservationRow = typeof giftCardReservations.$inferSelect;
+export type GiftCardLedgerEntryRow = typeof giftCardLedgerEntries.$inferSelect;
+export type GiftCardDeliveryRow = typeof giftCardDeliveries.$inferSelect;

--- a/lib/db/schema/gift-cards.ts
+++ b/lib/db/schema/gift-cards.ts
@@ -173,6 +173,11 @@ export const giftCardLedgerEntries = sqliteTable("gift_card_ledger_entries", {
       AND ${table.reservationId} IS NOT NULL AND ${table.orderId} IS NOT NULL)
     OR (${table.entryType} <> 'redemption' AND ${table.reservationId} IS NULL)
   `),
+  check("gift_card_ledger_restoration_check", sql`
+    (${table.entryType} = 'restoration'
+      AND ${table.orderId} IS NOT NULL AND ${table.relatedEntryId} IS NOT NULL)
+    OR ${table.entryType} <> 'restoration'
+  `),
 ]);
 
 export const giftCardDeliveries = sqliteTable("gift_card_deliveries", {

--- a/lib/db/schema/index.ts
+++ b/lib/db/schema/index.ts
@@ -136,3 +136,6 @@ export * from "./redirect-map";
 
 // Optional, default-off Stripe subscription foundation
 export * from "./subscriptions";
+
+// Optional, default-off gift-card ledger and delivery foundation
+export * from "./gift-cards";

--- a/lib/gift-cards/capability.ts
+++ b/lib/gift-cards/capability.ts
@@ -1,0 +1,277 @@
+import { Money } from "@/lib/money";
+import type {
+  GiftCardCheckoutCapability,
+  GiftCardTenderRequestIdentity,
+} from "@/lib/commerce/capabilities";
+import type { Order } from "@/lib/types/order";
+import {
+  GiftCardCodeConfigurationError,
+  giftCardLookupCandidates,
+  type GiftCardKeyRing,
+} from "./code";
+import {
+  assertGiftCardMoney,
+  assertReserveGiftCardInput,
+  type GiftCardAccount,
+} from "./domain";
+import { createGiftCardRepository } from "./repository";
+import { GiftCardRuntimeConfigurationError } from "./config";
+
+type GiftCardRepository = Pick<ReturnType<typeof createGiftCardRepository>,
+  | "findAccountByCodeHash"
+  | "reserve"
+  | "commitReservation"
+  | "settleReservation"
+  | "releaseReservation"
+>;
+
+export interface ResolveGiftCardTenderInput {
+  token: string;
+  currency: string;
+  amountDue: Money;
+  requestIdentity: GiftCardTenderRequestIdentity;
+}
+
+export interface GiftCardCapabilityDependencies {
+  resolveLookupRuntime(): Promise<{
+    repository: GiftCardRepository;
+    keyRing: GiftCardKeyRing;
+  }>;
+  resolveRepository(): Promise<GiftCardRepository>;
+  now?: () => number;
+}
+
+export class GiftCardTenderRequestError extends Error {
+  constructor() {
+    super("Gift-card tender request is invalid");
+    this.name = "GiftCardTenderRequestError";
+  }
+}
+
+export class GiftCardTenderUnavailableError extends Error {
+  constructor() {
+    super("Gift-card tender is unavailable");
+    this.name = "GiftCardTenderUnavailableError";
+  }
+}
+
+export class GiftCardTenderReconciliationError extends Error {
+  constructor() {
+    super("Gift-card tender reconciliation failed");
+    this.name = "GiftCardTenderReconciliationError";
+  }
+}
+
+interface GiftCardTenderStateV1 {
+  v: 1;
+  reservationId: string;
+}
+
+function hex(bytes: Uint8Array): string {
+  let result = "";
+  for (const byte of bytes) result += byte.toString(16).padStart(2, "0");
+  return result;
+}
+
+async function reservationId(requestKey: string): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(`mercora:gift-card:reservation\u0000v1\u0000${requestKey}`),
+  );
+  return `gift_reservation_${hex(new Uint8Array(digest))}`;
+}
+
+function exactState(value: unknown): GiftCardTenderStateV1 | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const raw = value as Record<string, unknown>;
+  if (
+    Object.keys(raw).length !== 2
+    || raw.v !== 1
+    || typeof raw.reservationId !== "string"
+    || raw.reservationId.length < 1
+    || raw.reservationId.length > 128
+    || raw.reservationId.trim() !== raw.reservationId
+  ) return null;
+  return { v: 1, reservationId: raw.reservationId };
+}
+
+function epochNow(dependencies: GiftCardCapabilityDependencies): number {
+  const value = dependencies.now?.() ?? Math.floor(Date.now() / 1_000);
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new GiftCardTenderReconciliationError();
+  }
+  return value;
+}
+
+function protectedTender(order: Order): Money {
+  try {
+    const amount = Money.fromStored(
+      order.extensions?.checkout_tender ?? 0,
+      order.currency_code,
+    );
+    assertGiftCardMoney(amount);
+    return amount;
+  } catch {
+    throw new GiftCardTenderReconciliationError();
+  }
+}
+
+function exactAccount(matches: Array<GiftCardAccount | undefined>): GiftCardAccount | null {
+  const accounts = new Map<string, GiftCardAccount>();
+  for (const account of matches) {
+    if (account) accounts.set(account.id, account);
+  }
+  return accounts.size === 1 ? [...accounts.values()][0] : null;
+}
+
+function assertResolutionRequest(input: ResolveGiftCardTenderInput): void {
+  const identity = input.requestIdentity;
+  try {
+    if (
+      typeof input.token !== "string"
+      || input.token.length === 0
+      || !(input.amountDue instanceof Money)
+      || input.currency !== input.amountDue.currency
+      || !identity
+      || typeof identity.requestKey !== "string"
+      || identity.requestKey.length < 8
+      || identity.requestKey.length > 256
+      || identity.requestKey.trim() !== identity.requestKey
+      || typeof identity.quoteFingerprint !== "string"
+      || !/^[0-9a-f]{64}$/.test(identity.quoteFingerprint)
+      || !Number.isSafeInteger(identity.reservedAt)
+      || identity.reservedAt < 0
+      || !Number.isSafeInteger(identity.expiresAt)
+      || identity.expiresAt <= identity.reservedAt
+    ) throw new GiftCardTenderRequestError();
+    assertGiftCardMoney(input.amountDue, { positive: true });
+  } catch (error) {
+    if (error instanceof GiftCardTenderRequestError) throw error;
+    throw new GiftCardTenderRequestError();
+  }
+}
+
+/** Required internal reservation seam used once orchestration has durable identity. */
+export async function resolveGiftCardTender(
+  input: ResolveGiftCardTenderInput,
+  dependencies: GiftCardCapabilityDependencies,
+): Promise<{ amount: Money; state: GiftCardTenderStateV1 }> {
+  assertResolutionRequest(input);
+
+  try {
+    const runtime = await dependencies.resolveLookupRuntime();
+    // The codec computes every bounded rotation candidate before any lookup.
+    const candidates = await giftCardLookupCandidates(input.token, runtime.keyRing);
+    if (candidates.length === 0) throw new GiftCardTenderUnavailableError();
+    const account = exactAccount(await Promise.all(
+      candidates.map((candidate) => runtime.repository.findAccountByCodeHash(candidate)),
+    ));
+    if (
+      !account
+      || account.status !== "active"
+      || account.currency !== input.currency
+    ) throw new GiftCardTenderUnavailableError();
+
+    const id = await reservationId(input.requestIdentity.requestKey);
+    const reservationInput = {
+      id,
+      giftCardId: account.id,
+      requestKey: input.requestIdentity.requestKey,
+      quoteFingerprint: input.requestIdentity.quoteFingerprint,
+      requestedAmount: input.amountDue,
+      reservedAt: input.requestIdentity.reservedAt,
+      expiresAt: input.requestIdentity.expiresAt,
+    };
+    assertReserveGiftCardInput(reservationInput);
+    const result = await runtime.repository.reserve(reservationInput);
+    if (!result.available) throw new GiftCardTenderUnavailableError();
+    return {
+      amount: result.reservation.amount,
+      state: Object.freeze({ v: 1, reservationId: result.reservation.id }),
+    };
+  } catch (error) {
+    if (error instanceof GiftCardTenderRequestError) throw error;
+    if (error instanceof GiftCardRuntimeConfigurationError) throw error;
+    if (error instanceof GiftCardCodeConfigurationError) {
+      throw new GiftCardRuntimeConfigurationError();
+    }
+    if (error instanceof GiftCardTenderUnavailableError) throw error;
+    throw new GiftCardTenderUnavailableError();
+  }
+}
+
+export function createRepositoryBackedGiftCardCapability(
+  dependencies: GiftCardCapabilityDependencies,
+): Required<GiftCardCheckoutCapability> {
+  return {
+    async resolveTender({ token, currency, amountDue, requestIdentity }) {
+      if (token === undefined || token === "") {
+        return { amount: Money.zero(currency) };
+      }
+      if (typeof token !== "string") throw new GiftCardTenderUnavailableError();
+      if (!requestIdentity) throw new GiftCardTenderRequestError();
+      return resolveGiftCardTender({ token, currency, amountDue, requestIdentity }, dependencies);
+    },
+
+    async verifyReservedTender({ order, state, expectedTender }) {
+      if (!(expectedTender instanceof Money)) {
+        throw new GiftCardTenderReconciliationError();
+      }
+      if (expectedTender.isZero() && state === undefined) return;
+      const parsed = exactState(state);
+      if (!parsed || expectedTender.isZero() || !order.id) {
+        throw new GiftCardTenderReconciliationError();
+      }
+      try {
+        assertGiftCardMoney(expectedTender, { positive: true });
+        const repository = await dependencies.resolveRepository();
+        await repository.commitReservation({
+          reservationId: parsed.reservationId,
+          orderId: order.id,
+          expectedAmount: expectedTender,
+          committedAt: epochNow(dependencies),
+        });
+      } catch (error) {
+        if (error instanceof GiftCardRuntimeConfigurationError) throw error;
+        throw new GiftCardTenderReconciliationError();
+      }
+    },
+
+    async applyTender({ order, state }) {
+      const expectedTender = protectedTender(order);
+      if (expectedTender.isZero() && state === undefined) return;
+      const parsed = exactState(state);
+      if (!parsed || expectedTender.isZero() || !order.id) {
+        throw new GiftCardTenderReconciliationError();
+      }
+      try {
+        const repository = await dependencies.resolveRepository();
+        await repository.settleReservation({
+          reservationId: parsed.reservationId,
+          orderId: order.id,
+          settledAt: epochNow(dependencies),
+        });
+      } catch (error) {
+        if (error instanceof GiftCardRuntimeConfigurationError) throw error;
+        throw new GiftCardTenderReconciliationError();
+      }
+    },
+
+    async releaseTender({ state, reason }) {
+      if (state === undefined) return;
+      const parsed = exactState(state);
+      if (!parsed) throw new GiftCardTenderReconciliationError();
+      try {
+        const repository = await dependencies.resolveRepository();
+        await repository.releaseReservation({
+          reservationId: parsed.reservationId,
+          reason: reason ?? "checkout abandoned",
+          releasedAt: epochNow(dependencies),
+        });
+      } catch (error) {
+        if (error instanceof GiftCardRuntimeConfigurationError) throw error;
+        throw new GiftCardTenderReconciliationError();
+      }
+    },
+  };
+}

--- a/lib/gift-cards/capability.ts
+++ b/lib/gift-cards/capability.ts
@@ -22,6 +22,8 @@ type GiftCardRepository = Pick<ReturnType<typeof createGiftCardRepository>,
   | "reserve"
   | "commitReservation"
   | "settleReservation"
+  | "findSettledRedemption"
+  | "restoreRedemption"
   | "releaseReservation"
 >;
 
@@ -270,6 +272,33 @@ export function createRepositoryBackedGiftCardCapability(
         });
       } catch (error) {
         if (error instanceof GiftCardRuntimeConfigurationError) throw error;
+        throw new GiftCardTenderReconciliationError();
+      }
+    },
+
+    async restoreTender({ order, state, refundKey, amount }) {
+      if (!(amount instanceof Money)) throw new GiftCardTenderReconciliationError();
+      if (amount.isZero()) return;
+      const parsed = exactState(state);
+      if (!parsed || !order.id) throw new GiftCardTenderReconciliationError();
+      try {
+        assertGiftCardMoney(amount, { positive: true });
+        const repository = await dependencies.resolveRepository();
+        const redemption = await repository.findSettledRedemption({
+          reservationId: parsed.reservationId,
+          orderId: order.id,
+        });
+        if (!redemption) throw new GiftCardTenderReconciliationError();
+        await repository.restoreRedemption({
+          redemptionEntryId: redemption.id,
+          orderId: order.id,
+          refundKey,
+          amount,
+          restoredAt: epochNow(dependencies),
+        });
+      } catch (error) {
+        if (error instanceof GiftCardRuntimeConfigurationError) throw error;
+        if (error instanceof GiftCardTenderReconciliationError) throw error;
         throw new GiftCardTenderReconciliationError();
       }
     },

--- a/lib/gift-cards/checkout.ts
+++ b/lib/gift-cards/checkout.ts
@@ -1,0 +1,41 @@
+import { Money } from '@/lib/money';
+import { parseGiftCardCustomization } from '@/lib/gift-cards/customization';
+import type { GiftCardCustomization } from '@/lib/types/cartitem';
+import type { OrderItem } from '@/lib/types/order';
+
+export interface GiftCardOrderLineSnapshot {
+  lineId: string;
+  recipientEmail: string;
+  recipientName?: string;
+  message?: string;
+  deliveryDate?: string;
+  /** The catalog face value captured before discounts/tender. */
+  faceValue: ReturnType<Money['toJSON']>;
+}
+
+export function checkoutGiftCardCustomization(value: unknown): GiftCardCustomization | undefined {
+  return value === undefined ? undefined : parseGiftCardCustomization(value);
+}
+
+/** A gift-card line is explicit, digital, and carries only bounded recipient metadata. */
+export function isGiftCardOrderLine(item: OrderItem): boolean {
+  return item.fulfillment_type === 'digital' && item.gift_card !== undefined;
+}
+
+export function hasPhysicalCheckoutLines(items: OrderItem[]): boolean {
+  return items.some((item) => item.fulfillment_type !== 'digital');
+}
+
+export function giftCardLineSnapshots(items: OrderItem[]): GiftCardOrderLineSnapshot[] {
+  return items.flatMap((item) => {
+    if (!isGiftCardOrderLine(item) || !item.id || !item.gift_card) return [];
+    return [{
+      lineId: item.id,
+      recipientEmail: item.gift_card.recipientEmail,
+      ...(item.gift_card.recipientName ? { recipientName: item.gift_card.recipientName } : {}),
+      ...(item.gift_card.message ? { message: item.gift_card.message } : {}),
+      ...(item.gift_card.deliveryDate ? { deliveryDate: item.gift_card.deliveryDate } : {}),
+      faceValue: item.unit_price,
+    }];
+  });
+}

--- a/lib/gift-cards/code.ts
+++ b/lib/gift-cards/code.ts
@@ -1,0 +1,255 @@
+/**
+ * Gift-card bearer-code generation and one-way lookup identities.
+ *
+ * This module intentionally uses Web Crypto only so the same contract runs in
+ * Cloudflare Workers and the Node test environment. Raw bearer codes leave
+ * this module only when they are generated or explicitly normalized; lookup
+ * results contain only a key version and HMAC digest.
+ */
+
+const CODE_PREFIX = "GC";
+const CODE_GROUPS = 7;
+const CODE_GROUP_LENGTH = 4;
+const CODE_SYMBOL_COUNT = CODE_GROUPS * CODE_GROUP_LENGTH;
+
+// Uppercase symbols with the most common lookalike pairs removed: 0/O and 1/I.
+// Thirty-two symbols preserve exactly five bits of entropy per output symbol.
+const CODE_ALPHABET = "23456789ABCDEFGHJKLMNPQRSTUVWXYZ";
+const CODE_ALPHABET_PATTERN = "23456789A-HJ-NP-Z";
+
+const RANDOM_BATCH_BYTES = 64;
+const MAX_RANDOM_BATCHES = 128;
+// Seven complete 32-symbol buckets. Values 224..255 are deliberately rejected,
+// making the absence of modulo bias explicit and adversarially testable.
+const RANDOM_ACCEPTANCE_LIMIT = CODE_ALPHABET.length * 7;
+
+const HMAC_PURPOSE = "mercora:gift-card:bearer-code";
+const DIGEST_CONTRACT_VERSION = 1;
+const MIN_KEY_BYTES = 32;
+const MAX_KEY_BYTES = 4_096;
+const MAX_KEY_VERSIONS = 4;
+
+const encoder = new TextEncoder();
+
+export const GIFT_CARD_CODE_ENTROPY_BITS = CODE_SYMBOL_COUNT * Math.log2(CODE_ALPHABET.length);
+export const GIFT_CARD_CODE_LENGTH = CODE_PREFIX.length + CODE_GROUPS + CODE_SYMBOL_COUNT;
+export const GIFT_CARD_CODE_DIGEST_CONTRACT_VERSION = DIGEST_CONTRACT_VERSION;
+export const MAX_GIFT_CARD_CODE_KEY_VERSIONS = MAX_KEY_VERSIONS;
+
+export interface GiftCardKeyRing {
+  currentVersion: number;
+  keys: Readonly<Record<number, string | Uint8Array>>;
+}
+
+export interface GiftCardCodeLookup {
+  keyVersion: number;
+  digest: string;
+}
+
+export interface GenerateGiftCardCodeOptions {
+  /** Test seam. Production callers must omit this and use crypto.getRandomValues. */
+  randomFill?: (target: Uint8Array) => void;
+}
+
+export class GiftCardCodeConfigurationError extends Error {
+  constructor() {
+    super("Gift-card code key ring is invalid or unavailable");
+    this.name = "GiftCardCodeConfigurationError";
+  }
+}
+
+export class GiftCardCodeGenerationError extends Error {
+  constructor() {
+    super("Gift-card code generation failed");
+    this.name = "GiftCardCodeGenerationError";
+  }
+}
+
+export class GiftCardCodeCryptoError extends Error {
+  constructor() {
+    super("Gift-card code digest could not be computed");
+    this.name = "GiftCardCodeCryptoError";
+  }
+}
+
+interface ResolvedKey {
+  version: number;
+  bytes: Uint8Array<ArrayBuffer>;
+}
+
+interface ResolvedKeyRing {
+  current: ResolvedKey;
+  verification: ResolvedKey[];
+}
+
+function validKeyVersion(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
+}
+
+function canonicalVersionKey(value: string): number | null {
+  if (!/^[1-9][0-9]*$/.test(value)) return null;
+  const version = Number(value);
+  return validKeyVersion(version) && String(version) === value ? version : null;
+}
+
+function keyBytes(value: unknown): Uint8Array<ArrayBuffer> | null {
+  let bytes: Uint8Array<ArrayBuffer>;
+  if (typeof value === "string") {
+    bytes = encoder.encode(value);
+  } else if (value instanceof Uint8Array) {
+    // Uint8Array.from always creates an ordinary ArrayBuffer-backed copy, even
+    // when the caller provides a SharedArrayBuffer-backed view.
+    bytes = Uint8Array.from(value);
+  } else {
+    return null;
+  }
+  return bytes.length >= MIN_KEY_BYTES && bytes.length <= MAX_KEY_BYTES ? bytes : null;
+}
+
+function resolveKeyRingUnsafe(value: GiftCardKeyRing): ResolvedKeyRing | null {
+  if (!value || typeof value !== "object" || Array.isArray(value) || !validKeyVersion(value.currentVersion)) {
+    return null;
+  }
+  const keys = value.keys as unknown;
+  if (!keys || typeof keys !== "object" || Array.isArray(keys)) return null;
+  const prototype = Object.getPrototypeOf(keys);
+  if (prototype !== Object.prototype && prototype !== null) return null;
+
+  const entries = Object.entries(keys);
+  if (entries.length === 0 || entries.length > MAX_KEY_VERSIONS) return null;
+  const resolved: ResolvedKey[] = [];
+  for (const [rawVersion, rawKey] of entries) {
+    const version = canonicalVersionKey(rawVersion);
+    const bytes = keyBytes(rawKey);
+    if (version === null || !bytes) return null;
+    resolved.push({ version, bytes });
+  }
+  const current = resolved.find((entry) => entry.version === value.currentVersion);
+  if (!current) return null;
+
+  // Current first keeps creation and the common lookup path aligned. Remaining
+  // versions are newest-first so key rotation order is deterministic.
+  const verification = [
+    current,
+    ...resolved
+      .filter((entry) => entry.version !== current.version)
+      .sort((left, right) => right.version - left.version),
+  ];
+  return { current, verification };
+}
+
+function resolveKeyRing(value: GiftCardKeyRing): ResolvedKeyRing {
+  try {
+    const resolved = resolveKeyRingUnsafe(value);
+    if (resolved) return resolved;
+  } catch {
+    // Proxies/getters are configuration input too. Never preserve their errors,
+    // which could contain key material or other operator secrets.
+  }
+  throw new GiftCardCodeConfigurationError();
+}
+
+function formatCode(symbols: string): string {
+  const groups = Array.from({ length: CODE_GROUPS }, (_, index) =>
+    symbols.slice(index * CODE_GROUP_LENGTH, (index + 1) * CODE_GROUP_LENGTH)
+  );
+  return `${CODE_PREFIX}-${groups.join("-")}`;
+}
+
+/** Generate one neutral, 140-bit bearer code with rejection-sampled CSPRNG bytes. */
+export function generateGiftCardCode(options: GenerateGiftCardCodeOptions = {}): string {
+  const randomFill = options.randomFill ?? ((target: Uint8Array) => {
+    crypto.getRandomValues(target);
+  });
+  let symbols = "";
+  try {
+    for (let batch = 0; batch < MAX_RANDOM_BATCHES && symbols.length < CODE_SYMBOL_COUNT; batch += 1) {
+      const bytes = new Uint8Array(RANDOM_BATCH_BYTES);
+      randomFill(bytes);
+      for (const byte of bytes) {
+        if (byte >= RANDOM_ACCEPTANCE_LIMIT) continue;
+        symbols += CODE_ALPHABET[byte % CODE_ALPHABET.length];
+        if (symbols.length === CODE_SYMBOL_COUNT) break;
+      }
+    }
+  } catch {
+    throw new GiftCardCodeGenerationError();
+  }
+  if (symbols.length !== CODE_SYMBOL_COUNT) throw new GiftCardCodeGenerationError();
+  return formatCode(symbols);
+}
+
+/**
+ * Normalize only the exact public format. Lowercase ASCII is accepted for
+ * human entry, but separator positions, length, prefix, and alphabet are fixed.
+ */
+export function normalizeGiftCardCode(value: unknown): string | null {
+  if (typeof value !== "string" || value.length !== GIFT_CARD_CODE_LENGTH) return null;
+  if (!/^[A-Za-z0-9-]+$/.test(value)) return null;
+  const normalized = value.toUpperCase();
+  const pattern = new RegExp(
+    `^${CODE_PREFIX}(?:-[${CODE_ALPHABET_PATTERN}]{${CODE_GROUP_LENGTH}}){${CODE_GROUPS}}$`,
+  );
+  return pattern.test(normalized) ? normalized : null;
+}
+
+function digestMessage(code: string, keyVersion: number): Uint8Array<ArrayBuffer> {
+  return encoder.encode([
+    HMAC_PURPOSE,
+    `digest:v${DIGEST_CONTRACT_VERSION}`,
+    `key:${keyVersion}`,
+    code,
+  ].join("\u0000"));
+}
+
+function hex(bytes: Uint8Array): string {
+  let result = "";
+  for (const byte of bytes) result += byte.toString(16).padStart(2, "0");
+  return result;
+}
+
+async function lookupFor(code: string, key: ResolvedKey): Promise<GiftCardCodeLookup> {
+  try {
+    const cryptoKey = await crypto.subtle.importKey(
+      "raw",
+      key.bytes,
+      { name: "HMAC", hash: "SHA-256" },
+      false,
+      ["sign"],
+    );
+    const signature = await crypto.subtle.sign(
+      "HMAC",
+      cryptoKey,
+      digestMessage(code, key.version),
+    );
+    return Object.freeze({ keyVersion: key.version, digest: hex(new Uint8Array(signature)) });
+  } catch {
+    throw new GiftCardCodeCryptoError();
+  }
+}
+
+/** Build the current-version identity stored when a new gift card is issued. */
+export async function digestGiftCardCode(
+  value: unknown,
+  keyRing: GiftCardKeyRing,
+): Promise<GiftCardCodeLookup | null> {
+  const resolved = resolveKeyRing(keyRing);
+  const code = normalizeGiftCardCode(value);
+  return code ? lookupFor(code, resolved.current) : null;
+}
+
+/**
+ * Build fixed-shape lookup identities for current and bounded rotation keys.
+ * The raw bearer code is never included in a returned object.
+ */
+export async function giftCardLookupCandidates(
+  value: unknown,
+  keyRing: GiftCardKeyRing,
+): Promise<readonly GiftCardCodeLookup[]> {
+  const resolved = resolveKeyRing(keyRing);
+  const code = normalizeGiftCardCode(value);
+  if (!code) return Object.freeze([]);
+  return Object.freeze(await Promise.all(
+    resolved.verification.map((key) => lookupFor(code, key)),
+  ));
+}

--- a/lib/gift-cards/config.ts
+++ b/lib/gift-cards/config.ts
@@ -2,9 +2,15 @@ import {
   MAX_GIFT_CARD_CODE_KEY_VERSIONS,
   type GiftCardKeyRing,
 } from "./code";
+import {
+  MAX_GIFT_CARD_DELIVERY_KEY_VERSIONS,
+  type GiftCardEncryptionKeyRing,
+} from './encryption';
 
 export const GIFT_CARD_HMAC_CURRENT_VERSION_ENV = "GIFT_CARD_CODE_HMAC_CURRENT_VERSION";
 export const GIFT_CARD_HMAC_KEYS_ENV = "GIFT_CARD_CODE_HMAC_KEYS_JSON";
+export const GIFT_CARD_DELIVERY_CURRENT_VERSION_ENV = 'GIFT_CARD_DELIVERY_CURRENT_VERSION';
+export const GIFT_CARD_DELIVERY_KEYS_ENV = 'GIFT_CARD_DELIVERY_KEYS_JSON';
 
 const MIN_KEY_BYTES = 32;
 const MAX_KEY_BYTES = 4_096;
@@ -83,6 +89,44 @@ export function parseGiftCardCodeKeyRing(
       currentVersion,
       keys: Object.freeze(resolved),
     });
+  } catch (error) {
+    if (error instanceof GiftCardRuntimeConfigurationError) throw error;
+    throw new GiftCardRuntimeConfigurationError();
+  }
+}
+
+/** Parse the server-only AES-GCM delivery retry key ring. */
+export function parseGiftCardDeliveryKeyRing(
+  environment: GiftCardSecretEnvironment,
+): GiftCardEncryptionKeyRing {
+  try {
+    const currentVersion = positiveSafeInteger(
+      typeof environment[GIFT_CARD_DELIVERY_CURRENT_VERSION_ENV] === 'string'
+        ? environment[GIFT_CARD_DELIVERY_CURRENT_VERSION_ENV].trim() : undefined,
+    );
+    const serialized = environment[GIFT_CARD_DELIVERY_KEYS_ENV];
+    if (currentVersion === null || typeof serialized !== 'string' || serialized.length < 2 ||
+        serialized.length > MAX_KEY_RING_JSON_LENGTH) throw new GiftCardRuntimeConfigurationError();
+    const parsed: unknown = JSON.parse(serialized);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new GiftCardRuntimeConfigurationError();
+    }
+    const keys = parsed as Record<string, unknown>;
+    const versions = Object.keys(keys);
+    if (versions.length < 1 || versions.length > MAX_GIFT_CARD_DELIVERY_KEY_VERSIONS) {
+      throw new GiftCardRuntimeConfigurationError();
+    }
+    const resolved: Record<number, string> = {};
+    for (const rawVersion of versions) {
+      const version = positiveSafeInteger(rawVersion);
+      const key = keys[rawVersion];
+      if (version === null || typeof key !== 'string' || !/^base64:[A-Za-z0-9+/]+={0,2}$/.test(key)) {
+        throw new GiftCardRuntimeConfigurationError();
+      }
+      resolved[version] = key;
+    }
+    if (!Object.hasOwn(resolved, currentVersion)) throw new GiftCardRuntimeConfigurationError();
+    return Object.freeze({ currentVersion, keys: Object.freeze(resolved) });
   } catch (error) {
     if (error instanceof GiftCardRuntimeConfigurationError) throw error;
     throw new GiftCardRuntimeConfigurationError();

--- a/lib/gift-cards/config.ts
+++ b/lib/gift-cards/config.ts
@@ -1,0 +1,90 @@
+import {
+  MAX_GIFT_CARD_CODE_KEY_VERSIONS,
+  type GiftCardKeyRing,
+} from "./code";
+
+export const GIFT_CARD_HMAC_CURRENT_VERSION_ENV = "GIFT_CARD_CODE_HMAC_CURRENT_VERSION";
+export const GIFT_CARD_HMAC_KEYS_ENV = "GIFT_CARD_CODE_HMAC_KEYS_JSON";
+
+const MIN_KEY_BYTES = 32;
+const MAX_KEY_BYTES = 4_096;
+const MAX_KEY_RING_JSON_LENGTH = 20_000;
+const encoder = new TextEncoder();
+
+export type GiftCardSecretEnvironment = Record<string, unknown>;
+
+export class GiftCardRuntimeConfigurationError extends Error {
+  constructor() {
+    super("Gift-card runtime configuration is unavailable");
+    this.name = "GiftCardRuntimeConfigurationError";
+  }
+}
+
+function positiveSafeInteger(value: string | undefined): number | null {
+  if (!value || !/^[1-9][0-9]*$/.test(value)) return null;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && String(parsed) === value ? parsed : null;
+}
+
+/**
+ * Parse the server-only HMAC rotation ring from the current request's runtime
+ * environment. These values must never travel through StoreConfig or a public
+ * `NEXT_PUBLIC_*` variable.
+ */
+export function parseGiftCardCodeKeyRing(
+  environment: GiftCardSecretEnvironment,
+): GiftCardKeyRing {
+  try {
+    const currentVersion = positiveSafeInteger(
+      typeof environment[GIFT_CARD_HMAC_CURRENT_VERSION_ENV] === "string"
+        ? environment[GIFT_CARD_HMAC_CURRENT_VERSION_ENV].trim()
+        : undefined,
+    );
+    const serialized = environment[GIFT_CARD_HMAC_KEYS_ENV];
+    if (
+      currentVersion === null
+      || typeof serialized !== "string"
+      || serialized.length < 2
+      || serialized.length > MAX_KEY_RING_JSON_LENGTH
+    ) {
+      throw new GiftCardRuntimeConfigurationError();
+    }
+
+    const parsed: unknown = JSON.parse(serialized);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new GiftCardRuntimeConfigurationError();
+    }
+    const keys = parsed as Record<string, unknown>;
+    const versions = Object.keys(keys);
+    if (versions.length < 1 || versions.length > MAX_GIFT_CARD_CODE_KEY_VERSIONS) {
+      throw new GiftCardRuntimeConfigurationError();
+    }
+
+    const resolved: Record<number, string> = {};
+    for (const rawVersion of versions) {
+      const version = positiveSafeInteger(rawVersion);
+      const key = keys[rawVersion];
+      const byteLength = typeof key === "string" ? encoder.encode(key).length : 0;
+      if (
+        version === null
+        || typeof key !== "string"
+        || byteLength < MIN_KEY_BYTES
+        || byteLength > MAX_KEY_BYTES
+      ) {
+        throw new GiftCardRuntimeConfigurationError();
+      }
+      resolved[version] = key;
+    }
+    if (!Object.hasOwn(resolved, currentVersion)) {
+      throw new GiftCardRuntimeConfigurationError();
+    }
+
+    return Object.freeze({
+      currentVersion,
+      keys: Object.freeze(resolved),
+    });
+  } catch (error) {
+    if (error instanceof GiftCardRuntimeConfigurationError) throw error;
+    throw new GiftCardRuntimeConfigurationError();
+  }
+}

--- a/lib/gift-cards/config.ts
+++ b/lib/gift-cards/config.ts
@@ -3,6 +3,7 @@ import {
   type GiftCardKeyRing,
 } from "./code";
 import {
+  GIFT_CARD_DELIVERY_KEY_BYTES,
   MAX_GIFT_CARD_DELIVERY_KEY_VERSIONS,
   type GiftCardEncryptionKeyRing,
 } from './encryption';
@@ -23,6 +24,16 @@ export class GiftCardRuntimeConfigurationError extends Error {
   constructor() {
     super("Gift-card runtime configuration is unavailable");
     this.name = "GiftCardRuntimeConfigurationError";
+  }
+}
+
+/** Decoded byte length of a standard-base64 payload, or -1 if it is not decodable. */
+function decodedByteLength(payload: string): number {
+  if (payload.length === 0 || payload.length % 4 !== 0) return -1;
+  try {
+    return atob(payload).length;
+  } catch {
+    return -1;
   }
 }
 
@@ -121,6 +132,11 @@ export function parseGiftCardDeliveryKeyRing(
       const version = positiveSafeInteger(rawVersion);
       const key = keys[rawVersion];
       if (version === null || typeof key !== 'string' || !/^base64:[A-Za-z0-9+/]+={0,2}$/.test(key)) {
+        throw new GiftCardRuntimeConfigurationError();
+      }
+      // AES-256-GCM needs an exactly 32-byte key. Reject a wrong-length key at
+      // configuration load rather than deep inside the first encrypt/decrypt.
+      if (decodedByteLength(key.slice('base64:'.length)) !== GIFT_CARD_DELIVERY_KEY_BYTES) {
         throw new GiftCardRuntimeConfigurationError();
       }
       resolved[version] = key;

--- a/lib/gift-cards/customization.ts
+++ b/lib/gift-cards/customization.ts
@@ -1,0 +1,125 @@
+import type { GiftCardCustomization } from '@/lib/types/cartitem';
+
+export const GIFT_CARD_RECIPIENT_EMAIL_MAX_LENGTH = 254;
+export const GIFT_CARD_RECIPIENT_NAME_MAX_LENGTH = 100;
+export const GIFT_CARD_MESSAGE_MAX_LENGTH = 500;
+
+const ALLOWED_KEYS = new Set([
+  'recipientEmail',
+  'recipientName',
+  'message',
+  'deliveryDate',
+]);
+const EMAIL_PATTERN = /^[A-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?(?:\.[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?)+$/i;
+const CONTROL_CHARACTERS = /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/u;
+
+export class GiftCardCustomizationValidationError extends Error {
+  constructor() {
+    super('Invalid gift-card customization');
+    this.name = 'GiftCardCustomizationValidationError';
+  }
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function normalizedOptionalText(value: unknown, maxLength: number): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== 'string' || CONTROL_CHARACTERS.test(value)) {
+    throw new GiftCardCustomizationValidationError();
+  }
+  const normalized = value.normalize('NFC').trim().replace(/[\t ]+/gu, ' ');
+  if (normalized.length === 0 || normalized.length > maxLength) {
+    throw new GiftCardCustomizationValidationError();
+  }
+  return normalized;
+}
+
+function normalizedMessage(value: unknown): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== 'string' || CONTROL_CHARACTERS.test(value)) {
+    throw new GiftCardCustomizationValidationError();
+  }
+  const normalized = value
+    .normalize('NFC')
+    .replace(/\r\n?/gu, '\n')
+    .split('\n')
+    .map((line) => line.trim().replace(/[\t ]+/gu, ' '))
+    .join('\n')
+    .trim();
+  if (normalized.length === 0 || normalized.length > GIFT_CARD_MESSAGE_MAX_LENGTH) {
+    throw new GiftCardCustomizationValidationError();
+  }
+  return normalized;
+}
+
+function normalizedEmail(value: unknown): string {
+  if (typeof value !== 'string') throw new GiftCardCustomizationValidationError();
+  const normalized = value.normalize('NFC').trim().toLowerCase();
+  const [local = '', domain = '', ...rest] = normalized.split('@');
+  if (
+    normalized.length === 0 ||
+    normalized.length > GIFT_CARD_RECIPIENT_EMAIL_MAX_LENGTH ||
+    local.length > 64 ||
+    domain.length > 253 ||
+    rest.length > 0 ||
+    !EMAIL_PATTERN.test(normalized)
+  ) {
+    throw new GiftCardCustomizationValidationError();
+  }
+  return normalized;
+}
+
+function normalizedDeliveryDate(value: unknown): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== 'string' || !/^\d{4}-\d{2}-\d{2}$/u.test(value)) {
+    throw new GiftCardCustomizationValidationError();
+  }
+  const [year, month, day] = value.split('-').map(Number);
+  const date = new Date(Date.UTC(year, month - 1, day));
+  if (
+    date.getUTCFullYear() !== year ||
+    date.getUTCMonth() !== month - 1 ||
+    date.getUTCDate() !== day
+  ) {
+    throw new GiftCardCustomizationValidationError();
+  }
+  return value;
+}
+
+/**
+ * Parse the only gift-card details that may cross cart/client boundaries.
+ * Bearer codes, redemption tokens, and unknown fields are rejected.
+ */
+export function parseGiftCardCustomization(value: unknown): GiftCardCustomization {
+  if (!isPlainRecord(value) || Object.keys(value).some((key) => !ALLOWED_KEYS.has(key))) {
+    throw new GiftCardCustomizationValidationError();
+  }
+
+  const customization: GiftCardCustomization = {
+    recipientEmail: normalizedEmail(value.recipientEmail),
+  };
+  const recipientName = normalizedOptionalText(
+    value.recipientName,
+    GIFT_CARD_RECIPIENT_NAME_MAX_LENGTH,
+  );
+  const message = normalizedMessage(value.message);
+  const deliveryDate = normalizedDeliveryDate(value.deliveryDate);
+  if (recipientName !== undefined) customization.recipientName = recipientName;
+  if (message !== undefined) customization.message = message;
+  if (deliveryDate !== undefined) customization.deliveryDate = deliveryDate;
+  return customization;
+}
+
+export function canonicalGiftCardCustomization(value: GiftCardCustomization): string {
+  const parsed = parseGiftCardCustomization(value);
+  return JSON.stringify([
+    parsed.recipientEmail,
+    parsed.recipientName ?? null,
+    parsed.message ?? null,
+    parsed.deliveryDate ?? null,
+  ]);
+}

--- a/lib/gift-cards/domain.ts
+++ b/lib/gift-cards/domain.ts
@@ -90,6 +90,15 @@ export interface IssueGiftCardInput {
   issuedLineId?: string;
   purchaserCustomerId?: string;
   createdAt: number;
+  delivery?: {
+    id: string;
+    recipientEmail: string;
+    recipientName?: string;
+    emailIdempotencyKey: string;
+    codeCiphertext: string;
+    codeNonce: string;
+    codeKeyVersion: number;
+  };
 }
 
 export interface ReserveGiftCardInput {
@@ -167,6 +176,14 @@ export function giftCardRedemptionBusinessKey(reservationId: string): string {
   return `gift-card/redemption/${reservationId}/v1`;
 }
 
+export function giftCardRestorationBusinessKey(redemptionEntryId: string, refundKey: string): string {
+  assertGiftCardId(redemptionEntryId, 'gift-card redemption entry id');
+  assertBoundedText(refundKey, 'gift-card refund key', 1, 128);
+  const key = `gift-card/restoration/${redemptionEntryId}/${refundKey}/v1`;
+  assertGiftCardBusinessKey(key);
+  return key;
+}
+
 export function assertIssueGiftCardInput(input: IssueGiftCardInput): void {
   assertGiftCardId(input.id);
   assertGiftCardCodeHash(input.codeHash);
@@ -181,6 +198,19 @@ export function assertIssueGiftCardInput(input: IssueGiftCardInput): void {
   }
   if (input.purchaserCustomerId !== undefined) {
     assertGiftCardId(input.purchaserCustomerId, "gift-card purchaser customer id");
+  }
+  if (input.delivery !== undefined) {
+    assertGiftCardId(input.delivery.id, 'gift-card delivery id');
+    assertBoundedText(input.delivery.recipientEmail, 'gift-card delivery recipient', 3, 320);
+    if (input.delivery.recipientName !== undefined) {
+      assertBoundedText(input.delivery.recipientName, 'gift-card delivery recipient name', 1, 200);
+    }
+    assertBoundedText(input.delivery.emailIdempotencyKey, 'gift-card delivery idempotency key', 1, 256);
+    if (
+      !Number.isSafeInteger(input.delivery.codeKeyVersion) || input.delivery.codeKeyVersion < 1 ||
+      typeof input.delivery.codeCiphertext !== 'string' || input.delivery.codeCiphertext.length > 128 ||
+      typeof input.delivery.codeNonce !== 'string' || input.delivery.codeNonce.length > 32
+    ) throw new TypeError('gift-card delivery encryption state is invalid');
   }
 }
 

--- a/lib/gift-cards/domain.ts
+++ b/lib/gift-cards/domain.ts
@@ -1,0 +1,204 @@
+import { Money } from "@/lib/money";
+import type { GiftCardCodeLookup } from "./code";
+
+export const MAX_GIFT_CARD_INTEGER = Number.MAX_SAFE_INTEGER;
+export const GIFT_CARD_HASH_PATTERN = /^[0-9a-f]{64}$/;
+export const GIFT_CARD_CURRENCY_PATTERN = /^[A-Z]{3}$/;
+
+export type GiftCardAccountStatus = "active" | "disabled";
+export type GiftCardLedgerEntryType =
+  | "issuance"
+  | "redemption"
+  | "restoration"
+  | "adjustment";
+export type GiftCardDeliveryStatus =
+  | "pending"
+  | "processing"
+  | "sent"
+  | "needs_review";
+
+export type GiftCardCodeHash = GiftCardCodeLookup;
+
+export interface GiftCardAccount {
+  id: string;
+  codeHash: GiftCardCodeHash;
+  currency: string;
+  status: GiftCardAccountStatus;
+  issuanceEntryId: string;
+  issuanceBusinessKey: string;
+  issuedAmount: Money;
+  issuedOrderId?: string;
+  issuedLineId?: string;
+  purchaserCustomerId?: string;
+  createdAt: number;
+  disabledAt?: number;
+}
+
+export interface GiftCardReservation {
+  id: string;
+  giftCardId: string;
+  requestKey: string;
+  quoteFingerprint: string;
+  requestedAmount: Money;
+  amount: Money;
+  reservedAt: number;
+  expiresAt: number;
+  committedOrderId?: string;
+  committedAt?: number;
+  releasedAt?: number;
+  releaseReason?: string;
+}
+
+export interface GiftCardLedgerEntry {
+  id: string;
+  giftCardId: string;
+  entryType: GiftCardLedgerEntryType;
+  amountDelta: Money;
+  businessKey: string;
+  orderId?: string;
+  reservationId?: string;
+  relatedEntryId?: string;
+  createdAt: number;
+}
+
+export interface GiftCardDelivery {
+  id: string;
+  giftCardId: string;
+  orderId?: string;
+  orderLineId?: string;
+  recipientEmail: string;
+  recipientName?: string;
+  emailIdempotencyKey: string;
+  status: GiftCardDeliveryStatus;
+  attemptCount: number;
+  claimToken?: string;
+  leaseExpiresAt?: number;
+  /** AEAD fields only. A plaintext bearer code is never a domain field. */
+  codeCiphertext?: string;
+  codeNonce?: string;
+  codeKeyVersion?: number;
+  createdAt: number;
+  updatedAt: number;
+  completedAt?: number;
+}
+
+export interface IssueGiftCardInput {
+  id: string;
+  codeHash: GiftCardCodeHash;
+  amount: Money;
+  issuedOrderId?: string;
+  issuedLineId?: string;
+  purchaserCustomerId?: string;
+  createdAt: number;
+}
+
+export interface ReserveGiftCardInput {
+  id: string;
+  giftCardId: string;
+  requestKey: string;
+  quoteFingerprint: string;
+  requestedAmount: Money;
+  reservedAt: number;
+  expiresAt: number;
+}
+
+function assertBoundedText(
+  value: unknown,
+  label: string,
+  minimum: number,
+  maximum: number,
+): asserts value is string {
+  if (
+    typeof value !== "string"
+    || value.length < minimum
+    || value.length > maximum
+    || value.trim() !== value
+  ) {
+    throw new TypeError(`${label} must be a bounded non-whitespace string`);
+  }
+}
+
+export function assertGiftCardId(value: unknown, label = "gift-card id"): asserts value is string {
+  assertBoundedText(value, label, 1, 128);
+}
+
+export function assertGiftCardBusinessKey(value: unknown): asserts value is string {
+  assertBoundedText(value, "gift-card business key", 1, 256);
+}
+
+export function assertGiftCardEpoch(value: unknown, label: string): asserts value is number {
+  if (!Number.isSafeInteger(value) || Number(value) < 0) {
+    throw new TypeError(`${label} must be nonnegative integer epoch seconds`);
+  }
+}
+
+export function assertGiftCardCurrency(value: unknown): asserts value is string {
+  if (typeof value !== "string" || !GIFT_CARD_CURRENCY_PATTERN.test(value)) {
+    throw new TypeError("gift-card currency must be an uppercase ISO 4217 code");
+  }
+}
+
+export function assertGiftCardCodeHash(value: GiftCardCodeHash): void {
+  if (!Number.isSafeInteger(value.keyVersion) || value.keyVersion < 1) {
+    throw new TypeError("gift-card code hash key version must be a positive safe integer");
+  }
+  if (!GIFT_CARD_HASH_PATTERN.test(value.digest)) {
+    throw new TypeError("gift-card code hash must be 64 lowercase hexadecimal characters");
+  }
+}
+
+export function assertGiftCardMoney(value: Money, options: { positive?: boolean } = {}): void {
+  if (!(value instanceof Money)) throw new TypeError("gift-card amount must be Money");
+  assertGiftCardCurrency(value.currency);
+  if (value.isNegative() || (options.positive && value.isZero())) {
+    throw new TypeError(options.positive
+      ? "gift-card amount must be positive"
+      : "gift-card amount must be nonnegative");
+  }
+}
+
+export function giftCardIssuanceBusinessKey(giftCardId: string): string {
+  assertGiftCardId(giftCardId);
+  return `gift-card/issuance/${giftCardId}/v1`;
+}
+
+export function giftCardRedemptionBusinessKey(reservationId: string): string {
+  assertGiftCardId(reservationId, "gift-card reservation id");
+  return `gift-card/redemption/${reservationId}/v1`;
+}
+
+export function assertIssueGiftCardInput(input: IssueGiftCardInput): void {
+  assertGiftCardId(input.id);
+  assertGiftCardCodeHash(input.codeHash);
+  assertGiftCardMoney(input.amount, { positive: true });
+  assertGiftCardEpoch(input.createdAt, "gift-card issuance time");
+  if ((input.issuedOrderId === undefined) !== (input.issuedLineId === undefined)) {
+    throw new TypeError("gift-card issuance order and line attribution must appear together");
+  }
+  if (input.issuedOrderId !== undefined) {
+    assertBoundedText(input.issuedOrderId, "gift-card issuance order id", 1, 200);
+    assertGiftCardId(input.issuedLineId, "gift-card issuance line id");
+  }
+  if (input.purchaserCustomerId !== undefined) {
+    assertGiftCardId(input.purchaserCustomerId, "gift-card purchaser customer id");
+  }
+}
+
+export function assertReserveGiftCardInput(input: ReserveGiftCardInput): void {
+  assertGiftCardId(input.id, "gift-card reservation id");
+  assertGiftCardId(input.giftCardId);
+  assertBoundedText(input.requestKey, "gift-card reservation request key", 8, 256);
+  if (!GIFT_CARD_HASH_PATTERN.test(input.quoteFingerprint)) {
+    throw new TypeError("gift-card quote fingerprint must be 64 lowercase hexadecimal characters");
+  }
+  assertGiftCardMoney(input.requestedAmount, { positive: true });
+  assertGiftCardEpoch(input.reservedAt, "gift-card reservation time");
+  assertGiftCardEpoch(input.expiresAt, "gift-card reservation expiry");
+  if (input.expiresAt <= input.reservedAt) {
+    throw new TypeError("gift-card reservation expiry must follow its reservation time");
+  }
+}
+
+export function assertGiftCardReleaseReason(value: unknown): asserts value is string {
+  assertBoundedText(value, "gift-card release reason", 1, 200);
+}

--- a/lib/gift-cards/domain.ts
+++ b/lib/gift-cards/domain.ts
@@ -98,6 +98,8 @@ export interface IssueGiftCardInput {
     codeCiphertext: string;
     codeNonce: string;
     codeKeyVersion: number;
+    /** Earliest epoch second the recipient may be emailed; 0 means immediately. */
+    deliverAfter?: number;
   };
 }
 
@@ -211,6 +213,9 @@ export function assertIssueGiftCardInput(input: IssueGiftCardInput): void {
       typeof input.delivery.codeCiphertext !== 'string' || input.delivery.codeCiphertext.length > 128 ||
       typeof input.delivery.codeNonce !== 'string' || input.delivery.codeNonce.length > 32
     ) throw new TypeError('gift-card delivery encryption state is invalid');
+    if (input.delivery.deliverAfter !== undefined) {
+      assertGiftCardEpoch(input.delivery.deliverAfter, 'gift-card delivery schedule');
+    }
   }
 }
 

--- a/lib/gift-cards/encryption.ts
+++ b/lib/gift-cards/encryption.ts
@@ -1,0 +1,362 @@
+import { normalizeGiftCardCode } from "./code";
+
+const AEAD_PURPOSE = "mercora:gift-card:delivery-code";
+const AEAD_CONTRACT_VERSION = 1;
+const AES_KEY_BYTES = 32;
+const NONCE_BYTES = 12;
+const GCM_TAG_BITS = 128;
+const GCM_TAG_BYTES = GCM_TAG_BITS / 8;
+const MAX_KEY_VERSIONS = 4;
+const MAX_ID_LENGTH = 128;
+const KEY_STRING_PREFIX = "base64:";
+
+const STANDARD_BASE64_PATTERN = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
+const BOUNDED_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/;
+const encoder = new TextEncoder();
+const decoder = new TextDecoder("utf-8", { fatal: true });
+
+export const GIFT_CARD_DELIVERY_ENCRYPTION_CONTRACT_VERSION = AEAD_CONTRACT_VERSION;
+export const GIFT_CARD_DELIVERY_KEY_BYTES = AES_KEY_BYTES;
+export const GIFT_CARD_DELIVERY_NONCE_BYTES = NONCE_BYTES;
+export const MAX_GIFT_CARD_DELIVERY_KEY_VERSIONS = MAX_KEY_VERSIONS;
+
+export interface GiftCardEncryptionKeyRing {
+  currentVersion: number;
+  /**
+   * String keys use the exact `base64:<canonical padded standard-base64>`
+   * contract. Uint8Array keys are copied before use. Both must be 32 bytes.
+   */
+  keys: Readonly<Record<number, string | Uint8Array>>;
+}
+
+export interface EncryptedGiftCardDeliveryCode {
+  keyVersion: number;
+  nonce: string;
+  ciphertext: string;
+}
+
+export interface GiftCardDeliveryAad {
+  giftCardId: string;
+  deliveryId: string;
+}
+
+export interface EncryptGiftCardDeliveryCodeInput extends GiftCardDeliveryAad {
+  code: string;
+  keyRing: GiftCardEncryptionKeyRing;
+  /** Test seam. Production callers must omit this and use crypto.getRandomValues. */
+  randomFill?: (target: Uint8Array) => void;
+}
+
+export interface DecryptGiftCardDeliveryCodeInput extends GiftCardDeliveryAad {
+  encrypted: unknown;
+  keyRing: GiftCardEncryptionKeyRing;
+}
+
+export class GiftCardEncryptionConfigurationError extends Error {
+  constructor() {
+    super("Gift-card delivery encryption key ring is invalid or unavailable");
+    this.name = "GiftCardEncryptionConfigurationError";
+  }
+}
+
+export class GiftCardEncryptionInputError extends Error {
+  constructor() {
+    super("Gift-card delivery encryption input is invalid");
+    this.name = "GiftCardEncryptionInputError";
+  }
+}
+
+export class GiftCardEncryptionError extends Error {
+  constructor() {
+    super("Gift-card delivery code could not be encrypted");
+    this.name = "GiftCardEncryptionError";
+  }
+}
+
+export class GiftCardDecryptionError extends Error {
+  constructor() {
+    super("Gift-card delivery code could not be decrypted");
+    this.name = "GiftCardDecryptionError";
+  }
+}
+
+interface ResolvedKey {
+  version: number;
+  bytes: Uint8Array<ArrayBuffer>;
+}
+
+interface ResolvedKeyRing {
+  current: ResolvedKey;
+  byVersion: Map<number, ResolvedKey>;
+  all: ResolvedKey[];
+}
+
+function validKeyVersion(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
+}
+
+function canonicalVersionKey(value: string): number | null {
+  if (!/^[1-9][0-9]*$/.test(value)) return null;
+  const version = Number(value);
+  return validKeyVersion(version) && String(version) === value ? version : null;
+}
+
+function standardBase64Encode(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary);
+}
+
+function standardBase64Decode(value: unknown, maximumLength: number): Uint8Array<ArrayBuffer> | null {
+  if (
+    typeof value !== "string"
+    || value.length === 0
+    || value.length > maximumLength
+    || value.length % 4 !== 0
+    || !STANDARD_BASE64_PATTERN.test(value)
+  ) {
+    return null;
+  }
+  try {
+    const binary = atob(value);
+    const bytes = new Uint8Array(binary.length);
+    for (let index = 0; index < binary.length; index += 1) {
+      bytes[index] = binary.charCodeAt(index);
+    }
+    return standardBase64Encode(bytes) === value ? bytes : null;
+  } catch {
+    return null;
+  }
+}
+
+function keyBytes(value: unknown): Uint8Array<ArrayBuffer> | null {
+  if (value instanceof Uint8Array) {
+    const copied = Uint8Array.from(value);
+    if (copied.length === AES_KEY_BYTES) return copied;
+    copied.fill(0);
+    return null;
+  }
+  if (typeof value !== "string" || !value.startsWith(KEY_STRING_PREFIX)) return null;
+  const decoded = standardBase64Decode(value.slice(KEY_STRING_PREFIX.length), 44);
+  if (!decoded || decoded.length === AES_KEY_BYTES) return decoded;
+  decoded.fill(0);
+  return null;
+}
+
+function plainRecord(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function ownDataEntries(value: Record<string, unknown>): Array<[string, unknown]> | null {
+  const properties = Reflect.ownKeys(value);
+  if (properties.some((property) => typeof property !== "string")) return null;
+  const entries: Array<[string, unknown]> = [];
+  for (const property of properties as string[]) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, property);
+    if (!descriptor?.enumerable || !("value" in descriptor)) return null;
+    entries.push([property, descriptor.value]);
+  }
+  return entries;
+}
+
+function resolveKeyRingUnsafe(value: GiftCardEncryptionKeyRing): ResolvedKeyRing | null {
+  if (!plainRecord(value) || !validKeyVersion(value.currentVersion) || !plainRecord(value.keys)) {
+    return null;
+  }
+  const entries = ownDataEntries(value.keys);
+  if (!entries || entries.length === 0 || entries.length > MAX_KEY_VERSIONS) return null;
+
+  const all: ResolvedKey[] = [];
+  const byVersion = new Map<number, ResolvedKey>();
+  let valid = false;
+  try {
+    for (const [rawVersion, rawKey] of entries) {
+      const version = canonicalVersionKey(rawVersion);
+      const bytes = keyBytes(rawKey);
+      if (version === null || !bytes || byVersion.has(version)) {
+        bytes?.fill(0);
+        return null;
+      }
+      const resolved = { version, bytes };
+      all.push(resolved);
+      byVersion.set(version, resolved);
+    }
+    const current = byVersion.get(value.currentVersion);
+    if (!current) return null;
+    valid = true;
+    return { current, byVersion, all };
+  } finally {
+    if (!valid) {
+      for (const key of all) key.bytes.fill(0);
+    }
+  }
+}
+
+function resolveKeyRing(value: GiftCardEncryptionKeyRing): ResolvedKeyRing {
+  try {
+    const resolved = resolveKeyRingUnsafe(value);
+    if (resolved) return resolved;
+  } catch {
+    // Hostile proxies and getters are configuration too. Their original errors
+    // may contain key material and must never escape this boundary.
+  }
+  throw new GiftCardEncryptionConfigurationError();
+}
+
+function zeroizeKeyRing(keyRing: ResolvedKeyRing): void {
+  for (const key of keyRing.all) key.bytes.fill(0);
+}
+
+function validAadId(value: unknown): value is string {
+  return typeof value === "string"
+    && value.length >= 1
+    && value.length <= MAX_ID_LENGTH
+    && BOUNDED_ID_PATTERN.test(value);
+}
+
+function additionalData(
+  giftCardId: string,
+  deliveryId: string,
+  keyVersion: number,
+): Uint8Array<ArrayBuffer> {
+  return encoder.encode([
+    AEAD_PURPOSE,
+    `aead:v${AEAD_CONTRACT_VERSION}`,
+    `key:${keyVersion}`,
+    `gift-card:${giftCardId}`,
+    `delivery:${deliveryId}`,
+  ].join("\u0000"));
+}
+
+async function importEncryptionKey(
+  bytes: Uint8Array<ArrayBuffer>,
+  usage: "encrypt" | "decrypt",
+): Promise<CryptoKey> {
+  return crypto.subtle.importKey("raw", bytes, { name: "AES-GCM" }, false, [usage]);
+}
+
+function exactEncryptedPayload(value: unknown): EncryptedGiftCardDeliveryCode | null {
+  try {
+    if (!plainRecord(value)) return null;
+    const entries = ownDataEntries(value);
+    if (!entries || entries.map(([key]) => key).sort().join(",") !== "ciphertext,keyVersion,nonce") {
+      return null;
+    }
+    const keyVersion = value.keyVersion;
+    const nonce = standardBase64Decode(value.nonce, 16);
+    // A canonical 37-byte gift code plus the 16-byte GCM tag is exactly 53
+    // encrypted bytes and therefore 72 padded standard-base64 characters.
+    const ciphertext = standardBase64Decode(value.ciphertext, 72);
+    if (
+      !validKeyVersion(keyVersion)
+      || nonce?.length !== NONCE_BYTES
+      || ciphertext?.length !== 37 + GCM_TAG_BYTES
+    ) {
+      nonce?.fill(0);
+      ciphertext?.fill(0);
+      return null;
+    }
+    nonce.fill(0);
+    ciphertext.fill(0);
+    return {
+      keyVersion,
+      nonce: value.nonce as string,
+      ciphertext: value.ciphertext as string,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** Encrypt one canonical bearer code for durable, retryable delivery. */
+export async function encryptGiftCardDeliveryCode(
+  input: EncryptGiftCardDeliveryCodeInput,
+): Promise<EncryptedGiftCardDeliveryCode> {
+  const keyRing = resolveKeyRing(input.keyRing);
+  let plaintext: Uint8Array<ArrayBuffer> | undefined;
+  let nonce: Uint8Array<ArrayBuffer> | undefined;
+  try {
+    if (
+      normalizeGiftCardCode(input.code) !== input.code
+      || !validAadId(input.giftCardId)
+      || !validAadId(input.deliveryId)
+    ) {
+      throw new GiftCardEncryptionInputError();
+    }
+    plaintext = encoder.encode(input.code);
+    nonce = new Uint8Array(NONCE_BYTES);
+    const randomFill = input.randomFill ?? ((target: Uint8Array) => {
+      crypto.getRandomValues(target);
+    });
+    try {
+      randomFill(nonce);
+    } catch {
+      throw new GiftCardEncryptionError();
+    }
+
+    const cryptoKey = await importEncryptionKey(keyRing.current.bytes, "encrypt");
+    const encrypted = await crypto.subtle.encrypt({
+      name: "AES-GCM",
+      iv: nonce,
+      additionalData: additionalData(input.giftCardId, input.deliveryId, keyRing.current.version),
+      tagLength: GCM_TAG_BITS,
+    }, cryptoKey, plaintext);
+    return Object.freeze({
+      keyVersion: keyRing.current.version,
+      nonce: standardBase64Encode(nonce),
+      ciphertext: standardBase64Encode(new Uint8Array(encrypted)),
+    });
+  } catch (error) {
+    if (error instanceof GiftCardEncryptionInputError || error instanceof GiftCardEncryptionError) {
+      throw error;
+    }
+    throw new GiftCardEncryptionError();
+  } finally {
+    plaintext?.fill(0);
+    nonce?.fill(0);
+    zeroizeKeyRing(keyRing);
+  }
+}
+
+/** Decrypt only for immediate delivery, binding ciphertext to both stored IDs. */
+export async function decryptGiftCardDeliveryCode(
+  input: DecryptGiftCardDeliveryCodeInput,
+): Promise<string> {
+  const keyRing = resolveKeyRing(input.keyRing);
+  let nonce: Uint8Array<ArrayBuffer> | undefined;
+  let ciphertext: Uint8Array<ArrayBuffer> | undefined;
+  let plaintext: Uint8Array<ArrayBuffer> | undefined;
+  try {
+    if (!validAadId(input.giftCardId) || !validAadId(input.deliveryId)) {
+      throw new GiftCardDecryptionError();
+    }
+    const encrypted = exactEncryptedPayload(input.encrypted);
+    if (!encrypted) throw new GiftCardDecryptionError();
+    const key = keyRing.byVersion.get(encrypted.keyVersion);
+    if (!key) throw new GiftCardDecryptionError();
+    nonce = standardBase64Decode(encrypted.nonce, 16) ?? undefined;
+    ciphertext = standardBase64Decode(encrypted.ciphertext, 72) ?? undefined;
+    if (!nonce || !ciphertext) throw new GiftCardDecryptionError();
+
+    const cryptoKey = await importEncryptionKey(key.bytes, "decrypt");
+    const decrypted = await crypto.subtle.decrypt({
+      name: "AES-GCM",
+      iv: nonce,
+      additionalData: additionalData(input.giftCardId, input.deliveryId, encrypted.keyVersion),
+      tagLength: GCM_TAG_BITS,
+    }, cryptoKey, ciphertext);
+    plaintext = new Uint8Array(decrypted);
+    const code = decoder.decode(plaintext);
+    if (normalizeGiftCardCode(code) !== code) throw new GiftCardDecryptionError();
+    return code;
+  } catch {
+    throw new GiftCardDecryptionError();
+  } finally {
+    nonce?.fill(0);
+    ciphertext?.fill(0);
+    plaintext?.fill(0);
+    zeroizeKeyRing(keyRing);
+  }
+}

--- a/lib/gift-cards/line-identity.ts
+++ b/lib/gift-cards/line-identity.ts
@@ -1,0 +1,131 @@
+import {
+  canonicalGiftCardCustomization,
+  parseGiftCardCustomization,
+} from '@/lib/gift-cards/customization';
+import { Money } from '@/lib/money';
+import type {
+  CartItem,
+  GiftCardCustomization,
+  StableCartItem,
+} from '@/lib/types/cartitem';
+
+export const MAX_CART_LINE_QUANTITY = 1_000;
+
+export interface CheckoutCartLineProjection {
+  lineId: string;
+  productId: string;
+  variantId: string;
+  quantity: number;
+  giftCardCustomization?: GiftCardCustomization;
+}
+
+interface CartLineFacts {
+  productId: string;
+  variantId: string;
+  giftCardCustomization?: GiftCardCustomization;
+}
+
+function boundedText(value: unknown, maxLength: number, allowEmpty = false): value is string {
+  return typeof value === 'string'
+    && value.length <= maxLength
+    && (allowEmpty || value.trim().length > 0);
+}
+
+function canonicalLineFacts(facts: CartLineFacts): string {
+  return JSON.stringify([
+    facts.productId,
+    facts.variantId,
+    facts.giftCardCustomization
+      ? canonicalGiftCardCustomization(facts.giftCardCustomization)
+      : null,
+  ]);
+}
+
+function fnv1a(value: string, seed: number): number {
+  let hash = seed >>> 0;
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    hash ^= code & 0xff;
+    hash = Math.imul(hash, 0x01000193);
+    hash ^= code >>> 8;
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash >>> 0;
+}
+
+function hex32(value: number): string {
+  return value.toString(16).padStart(8, '0');
+}
+
+export function createCartLineId(facts: CartLineFacts): string {
+  const canonical = canonicalLineFacts(facts);
+  return `line_${hex32(fnv1a(canonical, 0x811c9dc5))}${hex32(fnv1a(canonical, 0x9e3779b9))}`;
+}
+
+export function sameCartLineFacts(left: CartLineFacts, right: CartLineFacts): boolean {
+  return canonicalLineFacts(left) === canonicalLineFacts(right);
+}
+
+/** Project an untrusted or legacy item into the exact persisted cart shape. */
+export function normalizeCartItemForStore(value: unknown): StableCartItem | null {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return null;
+  const candidate = value as Partial<CartItem>;
+  if (
+    !boundedText(candidate.productId, 128) ||
+    !boundedText(candidate.variantId, 128) ||
+    !boundedText(candidate.name, 256) ||
+    !boundedText(candidate.primaryImageUrl, 2_048, true) ||
+    !Number.isSafeInteger(candidate.quantity) ||
+    Number(candidate.quantity) < 1 ||
+    Number(candidate.quantity) > MAX_CART_LINE_QUANTITY
+  ) {
+    return null;
+  }
+
+  let price;
+  let giftCardCustomization: GiftCardCustomization | undefined;
+  try {
+    price = Money.fromStored(candidate.price).toJSON();
+    if (candidate.giftCardCustomization !== undefined) {
+      giftCardCustomization = parseGiftCardCustomization(candidate.giftCardCustomization);
+    }
+  } catch {
+    return null;
+  }
+
+  const facts: CartLineFacts = {
+    productId: candidate.productId,
+    variantId: candidate.variantId,
+    ...(giftCardCustomization ? { giftCardCustomization } : {}),
+  };
+  return {
+    lineId: createCartLineId(facts),
+    productId: candidate.productId,
+    variantId: candidate.variantId,
+    name: candidate.name,
+    price,
+    quantity: Number(candidate.quantity),
+    primaryImageUrl: candidate.primaryImageUrl,
+    ...(giftCardCustomization ? { giftCardCustomization } : {}),
+  };
+}
+
+export function projectCartLineForCheckout(item: StableCartItem): CheckoutCartLineProjection {
+  const normalized = normalizeCartItemForStore(item);
+  if (
+    !normalized ||
+    !/^line_[0-9a-f]{16}(?:_[2-9]\d*)?$/u.test(item.lineId)
+  ) {
+    throw new Error('Cart contains an invalid line');
+  }
+  return {
+    // Preserve a deterministic collision suffix assigned by the store.
+    lineId: item.lineId,
+    productId: normalized.productId,
+    variantId: normalized.variantId,
+    quantity: normalized.quantity,
+    ...(normalized.giftCardCustomization
+      ? { giftCardCustomization: normalized.giftCardCustomization }
+      : {}),
+  };
+}

--- a/lib/gift-cards/presentations.ts
+++ b/lib/gift-cards/presentations.ts
@@ -1,0 +1,102 @@
+import { Money, type MachMoney } from '@/lib/money';
+
+export interface GiftCardPresentation {
+  issuedAmount: MachMoney;
+  availableBalance: MachMoney;
+  status: 'active' | 'disabled';
+  createdAt: number;
+  delivery: { status: 'pending' | 'processing' | 'sent' | 'needs_review'; attempts: number } | undefined;
+}
+
+export interface AdminGiftCardPresentation extends GiftCardPresentation {
+  issuedOrderId: string | undefined;
+  issuedLineId: string | undefined;
+}
+
+interface PresentationRow {
+  currency_code: string;
+  issued_amount_minor: number;
+  available_balance_minor: number;
+  status: 'active' | 'disabled';
+  created_at: number;
+  issued_order_id: string | null;
+  issued_line_id: string | null;
+  delivery_status: 'pending' | 'processing' | 'sent' | 'needs_review' | null;
+  delivery_attempt_count: number | null;
+}
+
+const PRESENTATION_SELECT = `SELECT account.currency_code, account.issued_amount_minor,
+  (COALESCE((SELECT SUM(entry.amount_delta_minor)
+    FROM gift_card_ledger_entries entry WHERE entry.gift_card_id = account.id), 0) -
+    COALESCE((SELECT SUM(reservation.amount_minor) FROM gift_card_reservations reservation
+      WHERE reservation.gift_card_id = account.id AND reservation.released_at IS NULL
+        AND (reservation.committed_at IS NOT NULL OR reservation.expires_at > ?)
+        AND NOT EXISTS (SELECT 1 FROM gift_card_ledger_entries settlement
+          WHERE settlement.reservation_id = reservation.id AND settlement.entry_type = 'redemption')), 0)
+  ) AS available_balance_minor,
+  account.status, account.created_at, account.issued_order_id, account.issued_line_id,
+  delivery.status AS delivery_status, delivery.attempt_count AS delivery_attempt_count
+  FROM gift_card_accounts account
+  LEFT JOIN gift_card_deliveries delivery ON delivery.gift_card_id = account.id`;
+
+function mapRow(row: PresentationRow, admin: boolean): GiftCardPresentation | AdminGiftCardPresentation {
+  const issuedAmount = Money.fromMinor(row.issued_amount_minor, row.currency_code).toMach();
+  const availableBalance = Money.fromMinor(row.available_balance_minor, row.currency_code).toMach();
+  const base: GiftCardPresentation = {
+    issuedAmount,
+    availableBalance,
+    status: row.status,
+    createdAt: row.created_at,
+    delivery: row.delivery_status === null || row.delivery_attempt_count === null ? undefined : {
+      status: row.delivery_status,
+      attempts: row.delivery_attempt_count,
+    },
+  };
+  return admin ? {
+    ...base,
+    issuedOrderId: row.issued_order_id ?? undefined,
+    issuedLineId: row.issued_line_id ?? undefined,
+  } : base;
+}
+
+/**
+ * Both customer and operational projections deliberately omit bearer-code
+ * hashes, encrypted delivery material, account ids, recipient details, and
+ * ledger business keys. The database remains the source of the balance.
+ */
+export async function listCustomerGiftCardPresentations(args: {
+  database: D1Database;
+  customerId: string;
+  now: number;
+  limit: number;
+}): Promise<GiftCardPresentation[]> {
+  const result = await args.database.prepare(`${PRESENTATION_SELECT}
+    WHERE account.purchaser_customer_id = ? ORDER BY account.created_at DESC LIMIT ?`)
+    .bind(args.now, args.customerId, args.limit).all<PresentationRow>();
+  return (result.results ?? []).map((row) => mapRow(row, false) as GiftCardPresentation);
+}
+
+export async function listAdminGiftCardPresentations(args: {
+  database: D1Database;
+  now: number;
+  limit: number;
+  offset: number;
+  status?: 'active' | 'disabled';
+}): Promise<{ cards: AdminGiftCardPresentation[]; total: number }> {
+  const where = args.status ? 'WHERE account.status = ?' : '';
+  const bindings = args.status
+    ? [args.now, args.status, args.limit, args.offset]
+    : [args.now, args.limit, args.offset];
+  const [cards, count] = await args.database.batch([
+    args.database.prepare(`${PRESENTATION_SELECT} ${where}
+      ORDER BY account.created_at DESC LIMIT ? OFFSET ?`).bind(...bindings),
+    args.database.prepare(`SELECT COUNT(*) AS total FROM gift_card_accounts account ${where}`)
+      .bind(...(args.status ? [args.status] : [])),
+  ]);
+  const total = (count.results?.[0] as { total?: number } | undefined)?.total ?? 0;
+  return {
+    cards: (cards.results as PresentationRow[] | undefined ?? [])
+      .map((row) => mapRow(row, true) as AdminGiftCardPresentation),
+    total,
+  };
+}

--- a/lib/gift-cards/repository.ts
+++ b/lib/gift-cards/repository.ts
@@ -277,9 +277,9 @@ export function createGiftCardRepository(database: D1Database) {
         ),
         ...(input.delivery ? [database.prepare(`INSERT INTO gift_card_deliveries (
           id, gift_card_id, order_id, order_line_id, recipient_email, recipient_name,
-          email_idempotency_key, status, attempt_count, claim_token, lease_expires_at,
+          email_idempotency_key, status, attempt_count, deliver_after, claim_token, lease_expires_at,
           code_ciphertext, code_nonce, code_key_version, created_at, updated_at, completed_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', 0, NULL, NULL, ?, ?, ?, ?, ?, NULL)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', 0, ?, NULL, NULL, ?, ?, ?, ?, ?, NULL)
         ON CONFLICT(gift_card_id) DO NOTHING`).bind(
           input.delivery.id,
           input.id,
@@ -288,6 +288,7 @@ export function createGiftCardRepository(database: D1Database) {
           input.delivery.recipientEmail,
           input.delivery.recipientName ?? null,
           input.delivery.emailIdempotencyKey,
+          input.delivery.deliverAfter ?? 0,
           input.delivery.codeCiphertext,
           input.delivery.codeNonce,
           input.delivery.codeKeyVersion,

--- a/lib/gift-cards/repository.ts
+++ b/lib/gift-cards/repository.ts
@@ -10,6 +10,7 @@ import {
   assertIssueGiftCardInput,
   assertReserveGiftCardInput,
   giftCardIssuanceBusinessKey,
+  giftCardRestorationBusinessKey,
   giftCardRedemptionBusinessKey,
   type GiftCardAccount,
   type GiftCardCodeHash,
@@ -274,6 +275,25 @@ export function createGiftCardRepository(database: D1Database) {
           input.purchaserCustomerId ?? null,
           input.createdAt,
         ),
+        ...(input.delivery ? [database.prepare(`INSERT INTO gift_card_deliveries (
+          id, gift_card_id, order_id, order_line_id, recipient_email, recipient_name,
+          email_idempotency_key, status, attempt_count, claim_token, lease_expires_at,
+          code_ciphertext, code_nonce, code_key_version, created_at, updated_at, completed_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', 0, NULL, NULL, ?, ?, ?, ?, ?, NULL)
+        ON CONFLICT(gift_card_id) DO NOTHING`).bind(
+          input.delivery.id,
+          input.id,
+          input.issuedOrderId ?? null,
+          input.issuedLineId ?? null,
+          input.delivery.recipientEmail,
+          input.delivery.recipientName ?? null,
+          input.delivery.emailIdempotencyKey,
+          input.delivery.codeCiphertext,
+          input.delivery.codeNonce,
+          input.delivery.codeKeyVersion,
+          input.createdAt,
+          input.createdAt,
+        )] : []),
       ]);
       const account = await findAccountById(input.id);
       const issuanceRow = await database.prepare(
@@ -291,6 +311,24 @@ export function createGiftCardRepository(database: D1Database) {
         || issuance.orderId !== input.issuedOrderId
       ) {
         throw new GiftCardConflictError("Gift-card issuance ledger conflicts with durable state");
+      }
+      if (input.delivery) {
+        const delivery = await database.prepare(`SELECT id, gift_card_id, recipient_email,
+          recipient_name, email_idempotency_key, code_ciphertext, code_nonce, code_key_version
+          FROM gift_card_deliveries WHERE gift_card_id = ? LIMIT 1`).bind(input.id).first<{
+            id: string; gift_card_id: string; recipient_email: string; recipient_name: string | null;
+            email_idempotency_key: string; code_ciphertext: string | null; code_nonce: string | null;
+            code_key_version: number | null;
+          }>();
+        if (!delivery || delivery.id !== input.delivery.id || delivery.gift_card_id !== input.id ||
+          delivery.recipient_email !== input.delivery.recipientEmail ||
+          delivery.recipient_name !== (input.delivery.recipientName ?? null) ||
+          delivery.email_idempotency_key !== input.delivery.emailIdempotencyKey ||
+          delivery.code_ciphertext !== input.delivery.codeCiphertext ||
+          delivery.code_nonce !== input.delivery.codeNonce ||
+          delivery.code_key_version !== input.delivery.codeKeyVersion) {
+          throw new GiftCardConflictError('Gift-card delivery conflicts with durable state');
+        }
       }
       return { created: (result[0]?.meta.changes ?? 0) === 1, account, issuance };
     },
@@ -475,6 +513,66 @@ export function createGiftCardRepository(database: D1Database) {
         throw new GiftCardConflictError("Gift-card settlement conflicts with durable state");
       }
       return { created: inserted?.id === entryId, entry };
+    },
+
+    /** Restore a bounded amount of one settled redemption exactly once per refund key. */
+    async restoreRedemption(args: {
+      redemptionEntryId: string;
+      orderId: string;
+      refundKey: string;
+      amount: Money;
+      restoredAt: number;
+      entryId?: string;
+    }): Promise<{ created: boolean; entry: GiftCardLedgerEntry }> {
+      assertGiftCardId(args.redemptionEntryId, 'gift-card redemption entry id');
+      assertOrderId(args.orderId);
+      assertGiftCardMoney(args.amount, { positive: true });
+      assertGiftCardEpoch(args.restoredAt, 'gift-card restoration time');
+      const businessKey = giftCardRestorationBusinessKey(args.redemptionEntryId, args.refundKey);
+      const entryId = args.entryId ?? `gift_ledger_${crypto.randomUUID()}`;
+      assertGiftCardId(entryId, 'gift-card ledger entry id');
+      const existing = async (): Promise<GiftCardLedgerEntry | undefined> => {
+        const row = await database.prepare(`${LEDGER_SELECT} WHERE business_key = ? LIMIT 1`)
+          .bind(businessKey).first<LedgerRow>();
+        return row ? mapLedger(row) : undefined;
+      };
+      const validate = (entry: GiftCardLedgerEntry): GiftCardLedgerEntry => {
+        if (
+          entry.entryType !== 'restoration' || entry.orderId !== args.orderId ||
+          entry.relatedEntryId !== args.redemptionEntryId || !entry.amountDelta.equals(args.amount)
+        ) throw new GiftCardConflictError('Gift-card restoration conflicts with durable state');
+        return entry;
+      };
+      const prior = await existing();
+      if (prior) return { created: false, entry: validate(prior) };
+
+      let inserted: { id: string } | null;
+      try {
+        inserted = await database.prepare(`INSERT INTO gift_card_ledger_entries (
+        id, gift_card_id, currency_code, entry_type, amount_delta_minor,
+        business_key, order_id, reservation_id, related_entry_id, created_at
+      ) SELECT ?, redemption.gift_card_id, redemption.currency_code, 'restoration', ?,
+        ?, redemption.order_id, NULL, redemption.id, ?
+      FROM gift_card_ledger_entries redemption
+      WHERE redemption.id = ? AND redemption.entry_type = 'redemption'
+        AND redemption.order_id = ? AND redemption.currency_code = ?
+      ON CONFLICT DO NOTHING RETURNING id`).bind(
+        entryId,
+        args.amount.toMinorUnits(),
+        businessKey,
+        args.restoredAt,
+        args.redemptionEntryId,
+        args.orderId,
+        args.amount.currency,
+      ).first<{ id: string }>();
+      } catch {
+        const raced = await existing();
+        if (raced) return { created: false, entry: validate(raced) };
+        throw new GiftCardConflictError('Gift-card redemption cannot be restored');
+      }
+      const entry = await existing();
+      if (!entry) throw new GiftCardConflictError('Gift-card redemption cannot be restored');
+      return { created: inserted?.id === entryId, entry: validate(entry) };
     },
 
     async releaseReservation(args: {

--- a/lib/gift-cards/repository.ts
+++ b/lib/gift-cards/repository.ts
@@ -1,0 +1,508 @@
+import { Money } from "@/lib/money";
+import {
+  assertGiftCardBusinessKey,
+  assertGiftCardCodeHash,
+  assertGiftCardCurrency,
+  assertGiftCardEpoch,
+  assertGiftCardId,
+  assertGiftCardMoney,
+  assertGiftCardReleaseReason,
+  assertIssueGiftCardInput,
+  assertReserveGiftCardInput,
+  giftCardIssuanceBusinessKey,
+  giftCardRedemptionBusinessKey,
+  type GiftCardAccount,
+  type GiftCardCodeHash,
+  type GiftCardLedgerEntry,
+  type GiftCardReservation,
+  type IssueGiftCardInput,
+  type ReserveGiftCardInput,
+} from "./domain";
+
+interface AccountRow {
+  id: string;
+  code_hash: string;
+  code_hash_version: number;
+  currency_code: string;
+  status: "active" | "disabled";
+  issuance_entry_id: string;
+  issuance_business_key: string;
+  issued_amount_minor: number;
+  issued_order_id: string | null;
+  issued_line_id: string | null;
+  purchaser_customer_id: string | null;
+  created_at: number;
+  disabled_at: number | null;
+}
+
+interface ReservationRow {
+  id: string;
+  gift_card_id: string;
+  currency_code: string;
+  request_key: string;
+  quote_fingerprint: string;
+  requested_amount_minor: number;
+  amount_minor: number;
+  reserved_at: number;
+  expires_at: number;
+  committed_order_id: string | null;
+  committed_at: number | null;
+  released_at: number | null;
+  release_reason: string | null;
+}
+
+interface LedgerRow {
+  id: string;
+  gift_card_id: string;
+  currency_code: string;
+  entry_type: "issuance" | "redemption" | "restoration" | "adjustment";
+  amount_delta_minor: number;
+  business_key: string;
+  order_id: string | null;
+  reservation_id: string | null;
+  related_entry_id: string | null;
+  created_at: number;
+}
+
+interface BalanceRow {
+  currency_code: string;
+  ledger_balance_minor: number;
+  held_amount_minor: number;
+}
+
+export class GiftCardConflictError extends Error {}
+export class GiftCardUnavailableError extends Error {}
+
+export interface GiftCardBalance {
+  ledgerBalance: Money;
+  heldAmount: Money;
+  availableBalance: Money;
+}
+
+export type GiftCardReservationResult =
+  | { available: true; created: boolean; reservation: GiftCardReservation }
+  | { available: false };
+
+const ACCOUNT_SELECT = `SELECT id, code_hash, code_hash_version, currency_code,
+  status, issuance_entry_id, issuance_business_key, issued_amount_minor,
+  issued_order_id, issued_line_id, purchaser_customer_id, created_at, disabled_at
+  FROM gift_card_accounts`;
+
+const RESERVATION_SELECT = `SELECT id, gift_card_id, currency_code, request_key,
+  quote_fingerprint, requested_amount_minor, amount_minor, reserved_at, expires_at,
+  committed_order_id, committed_at, released_at, release_reason
+  FROM gift_card_reservations`;
+
+const LEDGER_SELECT = `SELECT id, gift_card_id, currency_code, entry_type,
+  amount_delta_minor, business_key, order_id, reservation_id, related_entry_id,
+  created_at FROM gift_card_ledger_entries`;
+
+function mapAccount(row: AccountRow): GiftCardAccount {
+  const account: GiftCardAccount = {
+    id: row.id,
+    codeHash: { keyVersion: row.code_hash_version, digest: row.code_hash },
+    currency: row.currency_code,
+    status: row.status,
+    issuanceEntryId: row.issuance_entry_id,
+    issuanceBusinessKey: row.issuance_business_key,
+    issuedAmount: Money.fromMinor(row.issued_amount_minor, row.currency_code),
+    issuedOrderId: row.issued_order_id ?? undefined,
+    issuedLineId: row.issued_line_id ?? undefined,
+    purchaserCustomerId: row.purchaser_customer_id ?? undefined,
+    createdAt: row.created_at,
+    disabledAt: row.disabled_at ?? undefined,
+  };
+  assertGiftCardCodeHash(account.codeHash);
+  assertGiftCardCurrency(account.currency);
+  assertGiftCardMoney(account.issuedAmount, { positive: true });
+  return account;
+}
+
+function mapReservation(row: ReservationRow): GiftCardReservation {
+  return {
+    id: row.id,
+    giftCardId: row.gift_card_id,
+    requestKey: row.request_key,
+    quoteFingerprint: row.quote_fingerprint,
+    requestedAmount: Money.fromMinor(row.requested_amount_minor, row.currency_code),
+    amount: Money.fromMinor(row.amount_minor, row.currency_code),
+    reservedAt: row.reserved_at,
+    expiresAt: row.expires_at,
+    committedOrderId: row.committed_order_id ?? undefined,
+    committedAt: row.committed_at ?? undefined,
+    releasedAt: row.released_at ?? undefined,
+    releaseReason: row.release_reason ?? undefined,
+  };
+}
+
+function mapLedger(row: LedgerRow): GiftCardLedgerEntry {
+  return {
+    id: row.id,
+    giftCardId: row.gift_card_id,
+    entryType: row.entry_type,
+    amountDelta: Money.fromMinor(row.amount_delta_minor, row.currency_code),
+    businessKey: row.business_key,
+    orderId: row.order_id ?? undefined,
+    reservationId: row.reservation_id ?? undefined,
+    relatedEntryId: row.related_entry_id ?? undefined,
+    createdAt: row.created_at,
+  };
+}
+
+function sameAccount(account: GiftCardAccount, input: IssueGiftCardInput): boolean {
+  return account.id === input.id
+    && account.codeHash.keyVersion === input.codeHash.keyVersion
+    && account.codeHash.digest === input.codeHash.digest
+    && account.issuedAmount.equals(input.amount)
+    && account.issuanceEntryId === input.id
+    && account.issuanceBusinessKey === giftCardIssuanceBusinessKey(input.id)
+    && account.issuedOrderId === input.issuedOrderId
+    && account.issuedLineId === input.issuedLineId
+    && account.purchaserCustomerId === input.purchaserCustomerId
+    && account.createdAt === input.createdAt;
+}
+
+function sameReservation(reservation: GiftCardReservation, input: ReserveGiftCardInput): boolean {
+  return reservation.id === input.id
+    && reservation.giftCardId === input.giftCardId
+    && reservation.requestKey === input.requestKey
+    && reservation.quoteFingerprint === input.quoteFingerprint
+    && reservation.requestedAmount.equals(input.requestedAmount);
+}
+
+function assertOrderId(value: unknown): asserts value is string {
+  if (typeof value !== "string" || value.length < 1 || value.length > 200 || value.trim() !== value) {
+    throw new TypeError("gift-card order id must be a bounded identifier");
+  }
+}
+
+function availableBalanceExpression(accountAlias: string, nowPlaceholder = "?"): string {
+  return `(COALESCE((
+    SELECT SUM(entry.amount_delta_minor)
+    FROM gift_card_ledger_entries entry
+    WHERE entry.gift_card_id = ${accountAlias}.id
+  ), 0) - COALESCE((
+    SELECT SUM(reservation.amount_minor)
+    FROM gift_card_reservations reservation
+    WHERE reservation.gift_card_id = ${accountAlias}.id
+      AND reservation.released_at IS NULL
+      AND (
+        reservation.committed_at IS NOT NULL
+        OR reservation.expires_at > ${nowPlaceholder}
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM gift_card_ledger_entries settlement
+        WHERE settlement.reservation_id = reservation.id
+          AND settlement.entry_type = 'redemption'
+      )
+  ), 0))`;
+}
+
+export function createGiftCardRepository(database: D1Database) {
+  const findAccountById = async (id: string): Promise<GiftCardAccount | undefined> => {
+    assertGiftCardId(id);
+    const row = await database.prepare(`${ACCOUNT_SELECT} WHERE id = ? LIMIT 1`)
+      .bind(id).first<AccountRow>();
+    return row ? mapAccount(row) : undefined;
+  };
+
+  const findReservationById = async (id: string): Promise<GiftCardReservation | undefined> => {
+    assertGiftCardId(id, "gift-card reservation id");
+    const row = await database.prepare(`${RESERVATION_SELECT} WHERE id = ? LIMIT 1`)
+      .bind(id).first<ReservationRow>();
+    return row ? mapReservation(row) : undefined;
+  };
+
+  return {
+    findAccountById,
+
+    async findAccountByCodeHash(codeHash: GiftCardCodeHash): Promise<GiftCardAccount | undefined> {
+      assertGiftCardCodeHash(codeHash);
+      const row = await database.prepare(
+        `${ACCOUNT_SELECT} WHERE code_hash_version = ? AND code_hash = ? LIMIT 1`,
+      ).bind(codeHash.keyVersion, codeHash.digest).first<AccountRow>();
+      return row ? mapAccount(row) : undefined;
+    },
+
+    async issueAccount(input: IssueGiftCardInput): Promise<{
+      created: boolean;
+      account: GiftCardAccount;
+      issuance: GiftCardLedgerEntry;
+    }> {
+      assertIssueGiftCardInput(input);
+      const businessKey = giftCardIssuanceBusinessKey(input.id);
+      const result = await database.batch([
+        database.prepare(`INSERT INTO gift_card_accounts (
+          id, code_hash, code_hash_version, currency_code, status,
+          issuance_entry_id, issuance_business_key, issued_amount_minor,
+          issued_order_id, issued_line_id, purchaser_customer_id, created_at, disabled_at
+        ) VALUES (?, ?, ?, ?, 'active', ?, ?, ?, ?, ?, ?, ?, NULL)
+        ON CONFLICT DO NOTHING`).bind(
+          input.id,
+          input.codeHash.digest,
+          input.codeHash.keyVersion,
+          input.amount.currency,
+          input.id,
+          businessKey,
+          input.amount.toMinorUnits(),
+          input.issuedOrderId ?? null,
+          input.issuedLineId ?? null,
+          input.purchaserCustomerId ?? null,
+          input.createdAt,
+        ),
+        database.prepare(`INSERT INTO gift_card_ledger_entries (
+          id, gift_card_id, currency_code, entry_type, amount_delta_minor,
+          business_key, order_id, reservation_id, related_entry_id, created_at
+        ) SELECT issuance_entry_id, id, currency_code, 'issuance', issued_amount_minor,
+          issuance_business_key, issued_order_id, NULL, NULL, created_at
+        FROM gift_card_accounts
+        WHERE id = ? AND code_hash = ? AND code_hash_version = ?
+          AND currency_code = ? AND issuance_entry_id = ?
+          AND issuance_business_key = ? AND issued_amount_minor = ?
+          AND issued_order_id IS ? AND issued_line_id IS ?
+          AND purchaser_customer_id IS ? AND created_at = ?
+        ON CONFLICT DO NOTHING`).bind(
+          input.id,
+          input.codeHash.digest,
+          input.codeHash.keyVersion,
+          input.amount.currency,
+          input.id,
+          businessKey,
+          input.amount.toMinorUnits(),
+          input.issuedOrderId ?? null,
+          input.issuedLineId ?? null,
+          input.purchaserCustomerId ?? null,
+          input.createdAt,
+        ),
+      ]);
+      const account = await findAccountById(input.id);
+      const issuanceRow = await database.prepare(
+        `${LEDGER_SELECT} WHERE business_key = ? LIMIT 1`,
+      ).bind(businessKey).first<LedgerRow>();
+      if (!account || !issuanceRow || !sameAccount(account, input)) {
+        throw new GiftCardConflictError("Gift-card issuance identity conflicts with durable state");
+      }
+      const issuance = mapLedger(issuanceRow);
+      if (
+        issuance.id !== input.id
+        || issuance.giftCardId !== input.id
+        || issuance.entryType !== "issuance"
+        || !issuance.amountDelta.equals(input.amount)
+        || issuance.orderId !== input.issuedOrderId
+      ) {
+        throw new GiftCardConflictError("Gift-card issuance ledger conflicts with durable state");
+      }
+      return { created: (result[0]?.meta.changes ?? 0) === 1, account, issuance };
+    },
+
+    async readBalance(giftCardId: string, now: number): Promise<GiftCardBalance | undefined> {
+      assertGiftCardId(giftCardId);
+      assertGiftCardEpoch(now, "gift-card balance time");
+      const row = await database.prepare(`SELECT account.currency_code,
+        COALESCE((SELECT SUM(entry.amount_delta_minor)
+          FROM gift_card_ledger_entries entry
+          WHERE entry.gift_card_id = account.id), 0) AS ledger_balance_minor,
+        COALESCE((SELECT SUM(reservation.amount_minor)
+          FROM gift_card_reservations reservation
+          WHERE reservation.gift_card_id = account.id
+            AND reservation.released_at IS NULL
+            AND (reservation.committed_at IS NOT NULL OR reservation.expires_at > ?)
+            AND NOT EXISTS (
+              SELECT 1 FROM gift_card_ledger_entries settlement
+              WHERE settlement.reservation_id = reservation.id
+                AND settlement.entry_type = 'redemption'
+            )), 0) AS held_amount_minor
+        FROM gift_card_accounts account WHERE account.id = ? LIMIT 1`)
+        .bind(now, giftCardId).first<BalanceRow>();
+      if (!row) return undefined;
+      const ledgerBalance = Money.fromMinor(row.ledger_balance_minor, row.currency_code);
+      const heldAmount = Money.fromMinor(row.held_amount_minor, row.currency_code);
+      return {
+        ledgerBalance,
+        heldAmount,
+        availableBalance: ledgerBalance.subtract(heldAmount),
+      };
+    },
+
+    async reserve(input: ReserveGiftCardInput): Promise<GiftCardReservationResult> {
+      assertReserveGiftCardInput(input);
+      const availableForCase = availableBalanceExpression("account");
+      const availableForWhere = availableBalanceExpression("account");
+      const inserted = await database.prepare(`INSERT INTO gift_card_reservations (
+        id, gift_card_id, currency_code, request_key, quote_fingerprint,
+        requested_amount_minor, amount_minor, reserved_at, expires_at,
+        committed_order_id, committed_at, released_at, release_reason
+      ) SELECT ?, account.id, account.currency_code, ?, ?, ?,
+        CASE WHEN ${availableForCase} < ? THEN ${availableForCase} ELSE ? END,
+        ?, ?, NULL, NULL, NULL, NULL
+      FROM gift_card_accounts account
+      WHERE account.id = ? AND account.currency_code = ? AND account.status = 'active'
+        AND ${availableForWhere} > 0
+      ON CONFLICT DO NOTHING
+      RETURNING id`).bind(
+        input.id,
+        input.requestKey,
+        input.quoteFingerprint,
+        input.requestedAmount.toMinorUnits(),
+        input.reservedAt,
+        input.requestedAmount.toMinorUnits(),
+        input.reservedAt,
+        input.requestedAmount.toMinorUnits(),
+        input.reservedAt,
+        input.expiresAt,
+        input.giftCardId,
+        input.requestedAmount.currency,
+        input.reservedAt,
+      ).first<{ id: string }>();
+      const row = await database.prepare(`${RESERVATION_SELECT} WHERE request_key = ? LIMIT 1`)
+        .bind(input.requestKey).first<ReservationRow>();
+      if (!row) {
+        const identityCollision = await findReservationById(input.id);
+        if (identityCollision) {
+          throw new GiftCardConflictError("Gift-card reservation identity conflicts with durable state");
+        }
+        return { available: false };
+      }
+      const reservation = mapReservation(row);
+      if (!sameReservation(reservation, input)) {
+        throw new GiftCardConflictError("Gift-card reservation request conflicts with durable state");
+      }
+      return { available: true, created: inserted?.id === input.id, reservation };
+    },
+
+    findReservationById,
+
+    async commitReservation(args: {
+      reservationId: string;
+      orderId: string;
+      expectedAmount: Money;
+      committedAt: number;
+    }): Promise<GiftCardReservation> {
+      assertGiftCardId(args.reservationId, "gift-card reservation id");
+      assertOrderId(args.orderId);
+      assertGiftCardMoney(args.expectedAmount, { positive: true });
+      assertGiftCardEpoch(args.committedAt, "gift-card commitment time");
+      const row = await database.prepare(`UPDATE gift_card_reservations
+        SET committed_order_id = ?, committed_at = COALESCE(committed_at, ?)
+        WHERE id = ? AND currency_code = ? AND amount_minor = ?
+          AND released_at IS NULL
+          AND NOT EXISTS (
+            SELECT 1 FROM gift_card_ledger_entries
+            WHERE reservation_id = gift_card_reservations.id
+              AND entry_type = 'redemption'
+          )
+          AND (
+            (committed_order_id IS NULL AND committed_at IS NULL AND expires_at > ?)
+            OR committed_order_id = ?
+          )
+        RETURNING id, gift_card_id, currency_code, request_key,
+          quote_fingerprint, requested_amount_minor, amount_minor, reserved_at,
+          expires_at, committed_order_id, committed_at, released_at, release_reason`)
+        .bind(
+          args.orderId,
+          args.committedAt,
+          args.reservationId,
+          args.expectedAmount.currency,
+          args.expectedAmount.toMinorUnits(),
+          args.committedAt,
+          args.orderId,
+        ).first<ReservationRow>();
+      if (row) return mapReservation(row);
+      const existing = await findReservationById(args.reservationId);
+      if (
+        existing
+        && existing.committedOrderId === args.orderId
+        && existing.amount.equals(args.expectedAmount)
+        && existing.releasedAt === undefined
+      ) return existing;
+      if (existing?.committedOrderId !== undefined) {
+        throw new GiftCardConflictError("Gift-card reservation is committed to a different order");
+      }
+      if (existing?.releasedAt !== undefined || (existing && existing.expiresAt <= args.committedAt)) {
+        throw new GiftCardUnavailableError("Gift-card reservation is no longer available");
+      }
+      throw new GiftCardConflictError("Gift-card reservation cannot be committed to this order");
+    },
+
+    async settleReservation(args: {
+      reservationId: string;
+      orderId: string;
+      settledAt: number;
+      entryId?: string;
+    }): Promise<{ created: boolean; entry: GiftCardLedgerEntry }> {
+      assertGiftCardId(args.reservationId, "gift-card reservation id");
+      assertOrderId(args.orderId);
+      assertGiftCardEpoch(args.settledAt, "gift-card settlement time");
+      const entryId = args.entryId ?? `gift_ledger_${crypto.randomUUID()}`;
+      assertGiftCardId(entryId, "gift-card ledger entry id");
+      const businessKey = giftCardRedemptionBusinessKey(args.reservationId);
+      assertGiftCardBusinessKey(businessKey);
+      const inserted = await database.prepare(`INSERT INTO gift_card_ledger_entries (
+        id, gift_card_id, currency_code, entry_type, amount_delta_minor,
+        business_key, order_id, reservation_id, related_entry_id, created_at
+      ) SELECT ?, reservation.gift_card_id, reservation.currency_code,
+        'redemption', -reservation.amount_minor, ?, ?, reservation.id, NULL, ?
+      FROM gift_card_reservations reservation
+      WHERE reservation.id = ? AND reservation.committed_order_id = ?
+        AND reservation.committed_at IS NOT NULL AND reservation.released_at IS NULL
+        AND NOT EXISTS (
+          SELECT 1 FROM gift_card_ledger_entries existing
+          WHERE existing.reservation_id = reservation.id
+        )
+      ON CONFLICT DO NOTHING RETURNING id`).bind(
+        entryId,
+        businessKey,
+        args.orderId,
+        args.settledAt,
+        args.reservationId,
+        args.orderId,
+      ).first<{ id: string }>();
+      const row = await database.prepare(`${LEDGER_SELECT} WHERE business_key = ? LIMIT 1`)
+        .bind(businessKey).first<LedgerRow>();
+      if (!row) {
+        throw new GiftCardConflictError("Gift-card reservation is not committed for settlement");
+      }
+      const entry = mapLedger(row);
+      const reservation = await findReservationById(args.reservationId);
+      if (
+        !reservation
+        || entry.giftCardId !== reservation.giftCardId
+        || entry.entryType !== "redemption"
+        || entry.orderId !== args.orderId
+        || entry.reservationId !== args.reservationId
+        || !entry.amountDelta.equals(reservation.amount.negate())
+      ) {
+        throw new GiftCardConflictError("Gift-card settlement conflicts with durable state");
+      }
+      return { created: inserted?.id === entryId, entry };
+    },
+
+    async releaseReservation(args: {
+      reservationId: string;
+      reason: string;
+      releasedAt: number;
+    }): Promise<{ released: boolean; reservation: GiftCardReservation }> {
+      assertGiftCardId(args.reservationId, "gift-card reservation id");
+      assertGiftCardReleaseReason(args.reason);
+      assertGiftCardEpoch(args.releasedAt, "gift-card release time");
+      const row = await database.prepare(`UPDATE gift_card_reservations
+        SET released_at = ?, release_reason = ?
+        WHERE id = ? AND committed_at IS NULL AND committed_order_id IS NULL
+          AND released_at IS NULL
+          AND NOT EXISTS (
+            SELECT 1 FROM gift_card_ledger_entries
+            WHERE reservation_id = gift_card_reservations.id
+          )
+        RETURNING id, gift_card_id, currency_code, request_key,
+          quote_fingerprint, requested_amount_minor, amount_minor, reserved_at,
+          expires_at, committed_order_id, committed_at, released_at, release_reason`)
+        .bind(args.releasedAt, args.reason, args.reservationId).first<ReservationRow>();
+      if (row) return { released: true, reservation: mapReservation(row) };
+      const existing = await findReservationById(args.reservationId);
+      if (existing?.releasedAt !== undefined && existing.releaseReason === args.reason) {
+        return { released: false, reservation: existing };
+      }
+      throw new GiftCardConflictError("Gift-card reservation cannot be released");
+    },
+  };
+}

--- a/lib/gift-cards/repository.ts
+++ b/lib/gift-cards/repository.ts
@@ -515,6 +515,24 @@ export function createGiftCardRepository(database: D1Database) {
       return { created: inserted?.id === entryId, entry };
     },
 
+    async findSettledRedemption(args: {
+      reservationId: string;
+      orderId: string;
+    }): Promise<GiftCardLedgerEntry | undefined> {
+      assertGiftCardId(args.reservationId, 'gift-card reservation id');
+      assertOrderId(args.orderId);
+      const businessKey = giftCardRedemptionBusinessKey(args.reservationId);
+      const row = await database.prepare(`${LEDGER_SELECT} WHERE business_key = ? LIMIT 1`)
+        .bind(businessKey).first<LedgerRow>();
+      if (!row) return undefined;
+      const entry = mapLedger(row);
+      if (
+        entry.entryType !== 'redemption' || entry.reservationId !== args.reservationId ||
+        entry.orderId !== args.orderId || entry.amountDelta.isNegative() === false
+      ) throw new GiftCardConflictError('Gift-card redemption conflicts with durable state');
+      return entry;
+    },
+
     /** Restore a bounded amount of one settled redemption exactly once per refund key. */
     async restoreRedemption(args: {
       redemptionEntryId: string;

--- a/lib/gift-cards/runtime.ts
+++ b/lib/gift-cards/runtime.ts
@@ -1,0 +1,65 @@
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import type { GiftCardCheckoutCapability } from "@/lib/commerce/capabilities";
+import { createRepositoryBackedGiftCardCapability } from "./capability";
+import {
+  GiftCardRuntimeConfigurationError,
+  parseGiftCardCodeKeyRing,
+  type GiftCardSecretEnvironment,
+} from "./config";
+import { createGiftCardRepository } from "./repository";
+
+interface GiftCardWorkerEnvironment extends GiftCardSecretEnvironment {
+  DB?: D1Database;
+}
+
+export interface GiftCardRuntimeDependencies {
+  getEnvironment?: () => Promise<GiftCardWorkerEnvironment>;
+  repositoryFactory?: typeof createGiftCardRepository;
+  now?: () => number;
+}
+
+async function defaultEnvironment(): Promise<GiftCardWorkerEnvironment> {
+  const { env } = await getCloudflareContext({ async: true });
+  return env as unknown as GiftCardWorkerEnvironment;
+}
+
+function repository(
+  environment: GiftCardWorkerEnvironment,
+  factory: typeof createGiftCardRepository,
+) {
+  if (!environment.DB) throw new GiftCardRuntimeConfigurationError();
+  return factory(environment.DB);
+}
+
+/**
+ * Build a capability whose methods resolve request-scoped bindings lazily.
+ * Reconciliation-only operation needs D1 but intentionally does not require
+ * bearer-code HMAC keys after acquisition has been disabled.
+ */
+export function createRuntimeGiftCardCapability(
+  dependencies: GiftCardRuntimeDependencies = {},
+): Required<GiftCardCheckoutCapability> {
+  const getEnvironment = dependencies.getEnvironment ?? defaultEnvironment;
+  const repositoryFactory = dependencies.repositoryFactory ?? createGiftCardRepository;
+  return createRepositoryBackedGiftCardCapability({
+    async resolveLookupRuntime() {
+      const environment = await getEnvironment();
+      const keyRing = parseGiftCardCodeKeyRing(environment);
+      return {
+        repository: repository(environment, repositoryFactory),
+        keyRing,
+      };
+    },
+    async resolveRepository() {
+      return repository(await getEnvironment(), repositoryFactory);
+    },
+    now: dependencies.now,
+  });
+}
+
+/** Pass this factory to resolveCommerceCapabilities; disabled flags never call it. */
+export function createRuntimeGiftCardCapabilityFactory(
+  dependencies: GiftCardRuntimeDependencies = {},
+): () => Required<GiftCardCheckoutCapability> {
+  return () => createRuntimeGiftCardCapability(dependencies);
+}

--- a/lib/mcp/checkout.ts
+++ b/lib/mcp/checkout.ts
@@ -15,6 +15,11 @@ import {
 import { cancelPaymentIntent, createPaymentIntent } from '@/lib/stripe';
 import type { Address, Order } from '@/lib/types';
 import type { AgentSession } from './types';
+import { resolveRuntimeCommerceCapabilities } from '@/lib/commerce/runtime';
+import { createCartLineId } from '@/lib/gift-cards/line-identity';
+import { hasPhysicalCheckoutLines } from '@/lib/gift-cards/checkout';
+import { finalizeZeroCashGiftOrder } from '@/lib/services/order-finalization';
+import { noOpCommerceCapabilities } from '@/lib/commerce/capabilities';
 
 export interface McpCheckoutRequest {
   shippingAddress: unknown;
@@ -22,14 +27,17 @@ export interface McpCheckoutRequest {
   shippingOption?: string;
   discountCodes?: string[];
   giftCardToken?: string;
+  giftCardRequestKey?: string;
 }
 
 export interface McpCheckoutResult {
-  clientSecret: string;
-  paymentIntentId: string;
+  clientSecret?: string;
+  paymentIntentId?: string;
   orderId: string;
   amount: ReturnType<typeof toWireMoney>;
   quote: CheckoutQuote;
+  /** The order was paid and finalized without a Stripe PaymentIntent. */
+  noCash: boolean;
 }
 
 export function normalizeMcpAddress(value: unknown): Address {
@@ -87,8 +95,13 @@ export async function createMcpCheckout(args: {
   const shippingMethodId = args.input.shippingMethodId ?? args.input.shippingOption;
   if (!isBoundedString(shippingMethodId, 128)) throw new Error('Shipping method is required');
 
-  const quote = await priceCheckout({
+  const requiresGiftCardRuntime = typeof args.input.giftCardToken === 'string' && args.input.giftCardToken !== '';
+  const capabilities = requiresGiftCardRuntime
+    ? await resolveRuntimeCommerceCapabilities()
+    : noOpCommerceCapabilities;
+  const pricingInput = {
     items: args.session.cart.map((item) => ({
+      lineId: createCartLineId({ productId: item.productId, variantId: item.variantId }),
       productId: item.productId,
       variantId: item.variantId,
       quantity: item.quantity,
@@ -97,16 +110,18 @@ export async function createMcpCheckout(args: {
     shippingMethodId,
     discountCodes: args.input.discountCodes,
     giftCardToken: args.input.giftCardToken,
-  });
+    giftCardRequestKey: args.input.giftCardRequestKey,
+  };
+  const quote = requiresGiftCardRuntime
+    ? await priceCheckout(pricingInput, { capabilities })
+    : await priceCheckout(pricingInput);
   await assertCheckoutInventoryAvailable(quote.items);
 
   const total = Money.fromStored(quote.total);
-  if (!total.gt(Money.zero(total.currency))) {
-    throw new Error('Checkout requires a positive payment amount');
-  }
-
   const orderId = newMcpOrderId(args.agentId);
-  const paymentIntent = await createPaymentIntent({
+  let paymentIntent: Awaited<ReturnType<typeof createPaymentIntent>> | undefined;
+  try {
+    paymentIntent = total.gt(Money.zero(total.currency)) ? await createPaymentIntent({
     amount: total.toMinorUnits(),
     currency: total.currency.toLowerCase(),
     automatic_payment_methods: { enabled: true },
@@ -129,19 +144,34 @@ export async function createMcpCheckout(args: {
       name: shippingAddress.recipient || 'Customer',
     },
     description: `Order ${orderId}`,
-  });
+    }) : undefined;
+  } catch (error) {
+    if (quote.tenderState !== undefined) {
+      await capabilities.giftCards.releaseTender?.({
+        state: quote.tenderState,
+        reason: 'cash payment initialization failed',
+      }).catch(() => undefined);
+    }
+    throw error;
+  }
 
-  const providerAmount = Number(paymentIntent.amount);
-  const providerCurrency = String(paymentIntent.currency || '').toUpperCase();
-  if (
+  const providerAmount = paymentIntent ? Number(paymentIntent.amount) : total.toMinorUnits();
+  const providerCurrency = paymentIntent ? String(paymentIntent.currency || '').toUpperCase() : total.currency;
+  if (paymentIntent && (
     !Number.isSafeInteger(providerAmount) ||
     providerAmount !== total.toMinorUnits() ||
     providerCurrency !== total.currency ||
     !paymentIntent.client_secret
-  ) {
+  )) {
     await cancelPaymentIntent(paymentIntent.id).catch((error) =>
       console.error(`[mcp] Failed to cancel invalid PaymentIntent ${paymentIntent.id}:`, error)
     );
+    if (quote.tenderState !== undefined) {
+      await capabilities.giftCards.releaseTender?.({
+        state: quote.tenderState,
+        reason: 'cash payment validation failed',
+      }).catch(() => undefined);
+    }
     throw new Error('Payment provider returned an invalid intent');
   }
 
@@ -153,7 +183,7 @@ export async function createMcpCheckout(args: {
     agent_id: args.agentId,
     mcp_session_id: args.session.sessionId,
     email: shippingAddress.email,
-    payment_intent_id: paymentIntent.id,
+    ...(paymentIntent ? { payment_intent_id: paymentIntent.id } : {}),
     checkout_catalog_subtotal: catalogSubtotal.toJSON(),
     checkout_subtotal: catalogSubtotal.subtract(merchandiseDiscount).toJSON(),
     checkout_discount: quote.discount,
@@ -179,30 +209,50 @@ export async function createMcpCheckout(args: {
       status: 'pending',
       total_amount: Money.fromMinor(providerAmount, providerCurrency).toJSON(),
       currency_code: providerCurrency,
-      shipping_address: shippingAddress,
+      shipping_address: hasPhysicalCheckoutLines(quote.items) ? shippingAddress : null,
       billing_address: shippingAddress,
       items: quote.items,
-      shipping_method: quote.shippingMethod.label,
-      payment_method: 'stripe',
+      shipping_method: hasPhysicalCheckoutLines(quote.items) ? quote.shippingMethod.label : null,
+      payment_method: paymentIntent ? 'stripe' : 'gift_card',
       payment_status: 'pending',
-      external_references: { payment_intent_id: paymentIntent.id },
+      external_references: paymentIntent ? { payment_intent_id: paymentIntent.id } : null,
       extensions,
       created_at: new Date().toISOString(),
       updated_at: new Date().toISOString(),
     });
   } catch (error) {
-    await cancelPaymentIntent(paymentIntent.id).catch((cancelError) =>
+    if (quote.tenderState !== undefined) {
+      await capabilities.giftCards.releaseTender?.({ state: quote.tenderState, reason: 'checkout persistence failed' })
+        .catch(() => undefined);
+    }
+    if (paymentIntent) await cancelPaymentIntent(paymentIntent.id).catch((cancelError) =>
       console.error(`[mcp] Failed to cancel orphaned PaymentIntent ${paymentIntent.id}:`, cancelError)
     );
     throw error;
   }
 
+  if (!paymentIntent) {
+    const finalized = await finalizeZeroCashGiftOrder({
+      orderId,
+      enforceOwnership: false,
+      sendEmail: true,
+      capabilities,
+    });
+    return {
+      orderId: finalized.order.id!,
+      amount: toWireMoney(total.toJSON()),
+      quote,
+      noCash: true,
+    };
+  }
+
   return {
-    clientSecret: paymentIntent.client_secret,
+    clientSecret: paymentIntent.client_secret!,
     paymentIntentId: paymentIntent.id,
     orderId,
     amount: toWireMoney(Money.fromMinor(providerAmount, providerCurrency).toJSON()),
     quote,
+    noCash: false,
   };
 }
 
@@ -242,6 +292,29 @@ export async function getOwnedMcpOrderBinding(args: {
     extensions.agent_id !== args.agentId ||
     extensions.mcp_session_id !== args.sessionId ||
     extensions.payment_intent_id !== args.paymentIntentId
+  ) return null;
+  return hydrateOrder(record);
+}
+
+/** Fetch an already-finalized gift-funded MCP order without accepting a PI substitute. */
+export async function getOwnedMcpZeroCashOrder(args: {
+  orderId: string;
+  agentId: string;
+  sessionId: string;
+}): Promise<Order | null> {
+  const db = await getDbAsync();
+  const [record] = await db.select().from(orders).where(and(
+    eq(orders.id, args.orderId),
+    eq(orders.payment_method, 'gift_card'),
+  )).limit(1);
+  if (!record) return null;
+  const extensions = asRecord(record.extensions);
+  const external = asRecord(record.external_references);
+  if (
+    extensions.agent_id !== args.agentId ||
+    extensions.mcp_session_id !== args.sessionId ||
+    typeof extensions.payment_intent_id === 'string' ||
+    typeof external.payment_intent_id === 'string'
   ) return null;
   return hydrateOrder(record);
 }

--- a/lib/mcp/tools/order.ts
+++ b/lib/mcp/tools/order.ts
@@ -1,16 +1,19 @@
 import { toWireMoney } from '../../money';
 import {
   finalizeOrderPayment,
+  finalizeZeroCashGiftOrder,
   PaymentVerificationError,
 } from '../../services/order-finalization';
 import type { MACHAddress as Address } from '../../types/mach/Address';
 import {
   getOwnedMcpOrder,
   getOwnedMcpOrderBinding,
+  getOwnedMcpZeroCashOrder,
 } from '../checkout';
 import { requireOwnedSession } from '../session';
 import { buildMcpOrderDelivery } from '../order-delivery';
 import type { MCPToolResponse, OrderRequest, OrderResponse } from '../types';
+import { resolveRuntimeCommerceCapabilities } from '@/lib/commerce/runtime';
 
 const ZERO_TOTAL = toWireMoney(0);
 
@@ -64,16 +67,62 @@ export async function placeOrder(
   const { orderId, paymentIntentId } = request;
   if (
     typeof orderId !== 'string' ||
-    !/^MCP-[A-Z0-9]+-\d+-[A-F0-9]{8}$/.test(orderId) ||
-    typeof paymentIntentId !== 'string' ||
-    !/^pi_[A-Za-z0-9_]+$/.test(paymentIntentId)
+    !/^MCP-[A-Z0-9]+-\d+-[A-F0-9]{8}$/.test(orderId)
   ) {
     return orderFailure(
       sessionId,
       agentId,
       startTime,
       'PAYMENT_REQUIRED',
-      'A valid orderId and paymentIntentId from create_payment_intent are required.',
+      'A valid orderId from create_payment_intent is required.',
+      ['Call create_payment_intent', 'Complete payment if required', 'Retry place_order'],
+    );
+  }
+
+  if (paymentIntentId === undefined || paymentIntentId === '') {
+    const pending = await getOwnedMcpZeroCashOrder({ orderId, agentId, sessionId });
+    if (!pending) {
+      return orderFailure(
+        sessionId, agentId, startTime, 'PAYMENT_NOT_BOUND',
+        'The gift-funded order is not bound to this agent and session.',
+        ['Create a new checkout for this session'],
+      );
+    }
+    try {
+      const result = await finalizeZeroCashGiftOrder({
+        orderId,
+        enforceOwnership: false,
+        sendEmail: true,
+        capabilities: await resolveRuntimeCommerceCapabilities(),
+      });
+      const order = result.order;
+      return {
+        success: true,
+        data: {
+          orderId: order.id!, status: order.status,
+          total: toWireMoney(order.total_amount, order.currency_code),
+          tracking_number: order.tracking_number,
+          estimated_delivery: calculateEstimatedDelivery(order.shipping_address, order.shipping_method || 'standard'),
+        },
+        context: { session_id: sessionId, agent_id: agentId, processing_time_ms: Date.now() - startTime },
+        metadata: {
+          can_fulfill_percentage: 100, estimated_satisfaction: 95,
+          next_actions: ['Save the order confirmation', 'Use get_order_status for updates'],
+        },
+      };
+    } catch (error) {
+      console.error(`[mcp] Failed to finalize gift-funded order ${orderId}:`, error);
+      return orderFailure(
+        sessionId, agentId, startTime, 'ORDER_FINALIZATION_FAILED',
+        'The gift-funded order could not be finalized.',
+        ['Retry place_order; finalization is idempotent'],
+      );
+    }
+  }
+  if (typeof paymentIntentId !== 'string' || !/^pi_[A-Za-z0-9_]+$/.test(paymentIntentId)) {
+    return orderFailure(
+      sessionId, agentId, startTime, 'PAYMENT_REQUIRED',
+      'A valid PaymentIntent from create_payment_intent is required.',
       ['Call create_payment_intent', 'Complete payment', 'Retry place_order'],
     );
   }

--- a/lib/mcp/tools/payment.ts
+++ b/lib/mcp/tools/payment.ts
@@ -13,6 +13,7 @@ export interface AgentPaymentIntentResponse {
   paymentIntentId: string;
   orderId: string;
   amount: MachMoney;
+  noCash?: boolean;
   quote: {
     items: Array<{
       productId: string;
@@ -57,10 +58,11 @@ export async function createAgentPaymentIntent(
     return {
       success: true,
       data: {
-        clientSecret: checkout.clientSecret,
-        paymentIntentId: checkout.paymentIntentId,
+        clientSecret: checkout.clientSecret ?? '',
+        paymentIntentId: checkout.paymentIntentId ?? '',
         orderId: checkout.orderId,
         amount: checkout.amount,
+        ...(checkout.noCash ? { noCash: true } : {}),
         quote: {
           items: checkout.quote.items.map((item) => ({
             productId: item.product_id,
@@ -78,7 +80,9 @@ export async function createAgentPaymentIntent(
       metadata: {
         can_fulfill_percentage: 100,
         estimated_satisfaction: 90,
-        next_actions: ['Complete the PaymentIntent', 'Call place_order with orderId and paymentIntentId'],
+        next_actions: checkout.noCash
+          ? ['Save the order confirmation']
+          : ['Complete the PaymentIntent', 'Call place_order with orderId and paymentIntentId'],
       },
     };
   } catch (error) {

--- a/lib/mcp/types.ts
+++ b/lib/mcp/types.ts
@@ -100,7 +100,8 @@ export interface CartRequest {
 
 export interface OrderRequest {
   orderId: string;
-  paymentIntentId: string;
+  /** Omitted only for a zero-cash, gift-funded order finalized by checkout. */
+  paymentIntentId?: string;
   shippingAddress?: Address;
   billingAddress?: Address;
   paymentMethod?: string;

--- a/lib/observability/scheduled.ts
+++ b/lib/observability/scheduled.ts
@@ -3,6 +3,22 @@ import { runRecommendationCron } from '@/lib/recommendations/cron';
 import { drainInventoryAdjustments } from '@/lib/services/inventory-adjustments';
 import { drainOrderEffects } from '@/lib/services/order-effects';
 import { recordTelemetry } from '@/lib/observability/telemetry';
+import { noOpCommerceCapabilities, resolveCommerceCapabilities } from '@/lib/commerce/capabilities';
+import { createRuntimeGiftCardCapabilityFactory } from '@/lib/gift-cards/runtime';
+import { drainGiftCardDeliveries } from '@/lib/services/gift-card-fulfillment';
+
+function runtimeCapabilities(env: CloudflareEnv) {
+  const enabled = (key: string) => String((env as unknown as Record<string, unknown>)[key] ?? '')
+    .trim().toLowerCase() === 'true';
+  return resolveCommerceCapabilities({
+    giftCardAcquisition: enabled('STORE_FEATURE_GIFT_CARD_ACQUISITION'),
+    giftCardReconciliation: enabled('STORE_FEATURE_GIFT_CARD_RECONCILIATION'),
+    subscriptionAcquisition: enabled('STORE_FEATURE_SUBSCRIPTION_ACQUISITION'),
+    subscriptionReconciliation: enabled('STORE_FEATURE_SUBSCRIPTION_RECONCILIATION'),
+  }, { giftCards: createRuntimeGiftCardCapabilityFactory({
+    getEnvironment: async () => env as unknown as Record<string, unknown> & { DB?: D1Database },
+  }), subscriptions: () => noOpCommerceCapabilities.subscriptions });
+}
 
 export function handleScheduled(
   controller: ScheduledController,
@@ -10,13 +26,24 @@ export function handleScheduled(
   ctx: ExecutionContext,
 ): void {
   if (controller.cron === '*/5 * * * *') {
+    const capabilities = runtimeCapabilities(env);
+    const giftCardsEnabled = String((env as unknown as Record<string, unknown>)
+      .STORE_FEATURE_GIFT_CARD_RECONCILIATION ?? '').trim().toLowerCase() === 'true';
     ctx.waitUntil(
       Promise.all([
-        drainOrderEffects({ database: env.DB, limit: 25 }),
+        drainOrderEffects({
+          database: env.DB,
+          capabilities,
+          giftCardEnvironment: env as unknown as Record<string, unknown> & { DB?: D1Database },
+          limit: 25,
+        }),
         drainInventoryAdjustments({ database: env.DB, limit: 25 }),
+        giftCardsEnabled
+          ? drainGiftCardDeliveries({ environment: env as unknown as Record<string, unknown> & { DB?: D1Database }, limit: 25 })
+          : Promise.resolve({ attempted: 0 }),
       ])
-        .then(([effects, inventory]) =>
-          console.log('[cron] recovery queues drained', { effects, inventory })
+        .then(([effects, inventory, giftCardDeliveries]) =>
+          console.log('[cron] recovery queues drained', { effects, inventory, giftCardDeliveries })
         )
         .catch((error) => recordTelemetry('cron.recovery_failed', {
           operation: 'process', outcome: 'failed', provider: 'd1',

--- a/lib/observability/telemetry.ts
+++ b/lib/observability/telemetry.ts
@@ -57,6 +57,7 @@ export const TELEMETRY_EVENTS = {
   'refund.request_rejected': { severity: 'warning', sampleRate: 0.05 },
   'refund.provider_unresolved': { severity: 'critical', sampleRate: 1 },
   'refund.provider_inconsistent': { severity: 'critical', sampleRate: 1 },
+  'refund.gift_restoration_unresolved': { severity: 'critical', sampleRate: 1 },
   'refund.settlement_failed': { severity: 'critical', sampleRate: 1 },
   'fulfillment.transition_failed': { severity: 'critical', sampleRate: 1 },
   'fulfillment.query_failed': { severity: 'error', sampleRate: 0.25 },
@@ -109,7 +110,7 @@ const ALLOWED_FIELD_ENUMS = {
     'rejected', 'retry_scheduled', 'unavailable', 'unresolved',
   ]),
   provider: new Set([
-    'analytics', 'carrier', 'cloudflare_email', 'd1', 'resend', 'stripe', 'workers_ai',
+    'analytics', 'carrier', 'cloudflare_email', 'd1', 'gift_card', 'resend', 'stripe', 'workers_ai',
   ]),
   trigger: new Set(['manual', 'recovery', 'request', 'scheduled', 'webhook']),
 } as const;

--- a/lib/payments/refund-ledger.ts
+++ b/lib/payments/refund-ledger.ts
@@ -30,7 +30,8 @@ export type RefundLedgerDecision =
       idempotencyKey: string;
       requestFingerprint: string;
       refundAmount: number;
-      stripeRefundId: string;
+      /** Present only when a cash-provider refund was required. */
+      stripeRefundId?: string;
       providerStatus: string;
     }
   | {
@@ -168,14 +169,21 @@ export async function decideRefundLedgerAction(
   if (matching.length === 1) {
     const match = matching[0];
     if (match.status === 'settled') {
-      if (!match.stripeRefundId) return reject('Settled refund is missing its Stripe id', 409);
+      const allocation = settledTenderAllocation(refunds[match.entryIndex]);
+      if (!allocation) return reject('Settled refund has an invalid tender allocation', 409);
+      if (allocation.cashAmount > 0 && !match.stripeRefundId) {
+        return reject('Settled cash refund is missing its Stripe id', 409);
+      }
+      if (allocation.giftAmount > 0 && refunds[match.entryIndex].gift_restoration_status !== 'succeeded') {
+        return reject('Settled gift refund is missing restoration confirmation', 409);
+      }
       return {
         action: 'completed',
         entryIndex: match.entryIndex,
         idempotencyKey: match.key,
         requestFingerprint: match.fingerprint,
         refundAmount: match.amount,
-        stripeRefundId: match.stripeRefundId,
+        ...(match.stripeRefundId ? { stripeRefundId: match.stripeRefundId } : {}),
         providerStatus: match.providerStatus ?? 'succeeded',
       };
     }
@@ -241,4 +249,23 @@ export async function decideRefundLedgerAction(
   } catch (error) {
     return reject(error instanceof Error ? error.message : 'Invalid refund request');
   }
+}
+
+/**
+ * Legacy refund records predate tender allocation and therefore imply cash.
+ * A zero-cash refund must write `cash_amount: 0` explicitly; that distinction
+ * prevents an absent provider id from being mistaken for a corrupt cash refund.
+ */
+function settledTenderAllocation(entry: RefundRecord): { cashAmount: number; giftAmount: number } | null {
+  if (!isPositiveSafeInteger(entry.amount)) return null;
+  if (entry.cash_amount === undefined && entry.gift_amount === undefined) {
+    return { cashAmount: entry.amount, giftAmount: 0 };
+  }
+  const cashAmount = typeof entry.cash_amount === 'number' && Number.isSafeInteger(entry.cash_amount)
+    && entry.cash_amount >= 0 ? entry.cash_amount : null;
+  const giftAmount = typeof entry.gift_amount === 'number' && Number.isSafeInteger(entry.gift_amount)
+    && entry.gift_amount >= 0 ? entry.gift_amount : null;
+  return cashAmount === null || giftAmount === null || cashAmount + giftAmount !== entry.amount
+    ? null
+    : { cashAmount, giftAmount };
 }

--- a/lib/payments/refund-tender.ts
+++ b/lib/payments/refund-tender.ts
@@ -1,0 +1,48 @@
+/**
+ * Deterministic allocation for a refund of a mixed cash/gift-card purchase.
+ *
+ * The checkout snapshot records the original cash charge and gift tender.
+ * Allocation is cumulative (rather than per-request proportional rounding),
+ * so independently retried partial refunds can never exceed either tender.
+ * Cash is allocated first; once its original charge is exhausted, the
+ * remaining refund is restored to the original gift-card redemption.
+ */
+export interface RefundTenderAllocationInput {
+  refundAmount: number;
+  cashPaid: number;
+  giftTender: number;
+  refundedCash: number;
+  restoredGift: number;
+}
+
+export interface RefundTenderAllocation {
+  cashAmount: number;
+  giftAmount: number;
+}
+
+function amount(value: unknown, label: string): number {
+  if (!Number.isSafeInteger(value) || Number(value) < 0) {
+    throw new TypeError(`${label} must be a nonnegative safe integer`);
+  }
+  return Number(value);
+}
+
+/** Split one new refund while preserving the original cash/gift tender caps. */
+export function allocateRefundTender(input: RefundTenderAllocationInput): RefundTenderAllocation {
+  const refundAmount = amount(input.refundAmount, 'refund amount');
+  const cashPaid = amount(input.cashPaid, 'cash paid');
+  const giftTender = amount(input.giftTender, 'gift tender');
+  const refundedCash = amount(input.refundedCash, 'refunded cash');
+  const restoredGift = amount(input.restoredGift, 'restored gift tender');
+  if (refundAmount === 0) throw new TypeError('refund amount must be positive');
+  if (refundedCash > cashPaid || restoredGift > giftTender) {
+    throw new RangeError('recorded refund allocation exceeds its original tender');
+  }
+  const remainingCash = cashPaid - refundedCash;
+  const remainingGift = giftTender - restoredGift;
+  if (refundAmount > remainingCash + remainingGift) {
+    throw new RangeError('refund exceeds remaining tender allocation');
+  }
+  const cashAmount = Math.min(refundAmount, remainingCash);
+  return { cashAmount, giftAmount: refundAmount - cashAmount };
+}

--- a/lib/services/checkout-pricing.ts
+++ b/lib/services/checkout-pricing.ts
@@ -182,7 +182,13 @@ function eligibleLineIndexes(
   context: EligibilityContext
 ): number[] | null {
   if (!eligibilityMatches(promotion, context)) return null;
-  let eligible = catalog.map((_, index) => index);
+  // Gift cards are stored value at face value. Discounting a gift-card line
+  // would let a buyer acquire a full-value card for less than face value
+  // (issuance always credits the catalog unit_price), so no promotion may ever
+  // target one. They still count toward cart-minimum thresholds via `subtotal`.
+  let eligible = catalog
+    .map((_, index) => index)
+    .filter((index) => catalog[index].product.type !== 'gift_card');
   for (const condition of promotion.rules.conditions ?? []) {
     if (condition.type === 'cart_minimum' || condition.type === 'cart_subtotal') {
       if (condition.operator !== 'gte') return null;
@@ -779,7 +785,7 @@ export async function priceCheckout(
       throw new Error('Optional tender capability returned non-serializable server state');
     }
   }
-  if (tender.currency !== currency || tender.isNegative() || tender.gt(beforeTender)) {
+  if (tender.currency !== currency || tender.isNegative() || tender.gt(tenderEligible)) {
     throw new Error('Optional tender capability returned an invalid amount');
   }
   const total = beforeTender.subtract(tender);

--- a/lib/services/checkout-pricing.ts
+++ b/lib/services/checkout-pricing.ts
@@ -8,6 +8,11 @@ import {
   noOpCommerceCapabilities,
   type CommerceCapabilities,
 } from '@/lib/commerce/capabilities';
+import {
+  checkoutGiftCardCustomization,
+  hasPhysicalCheckoutLines,
+  isGiftCardOrderLine,
+} from '@/lib/gift-cards/checkout';
 import type { Address, CheckoutLineAllocation, OrderItem, Promotion } from '@/lib/types';
 import {
   allowedShippingCountries,
@@ -20,9 +25,11 @@ export const MAX_CHECKOUT_LINES = 100;
 export const MAX_DISCOUNT_CODES = 25;
 
 export interface CheckoutLineInput {
+  lineId?: string;
   productId: string;
   variantId?: string;
   quantity: number;
+  giftCardCustomization?: unknown;
 }
 
 export interface CheckoutPricingInput {
@@ -31,6 +38,8 @@ export interface CheckoutPricingInput {
   shippingMethodId: string;
   discountCodes?: string[];
   giftCardToken?: string;
+  /** Server-generated request identity, stable across a checkout retry. */
+  giftCardRequestKey?: string;
   customerId?: string;
 }
 
@@ -464,6 +473,37 @@ function allocateLargestRemainder(total: number, weights: number[]): number[] {
   return shares.sort((a, b) => a.index - b.index).map((share) => share.amount);
 }
 
+function hex(bytes: Uint8Array): string {
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+async function tenderQuoteFingerprint(args: {
+  currency: string;
+  items: OrderItem[];
+  merchandiseDiscount: Money;
+  shipping: Money;
+  tax: Money;
+  eligible: Money;
+}): Promise<string> {
+  const canonical = JSON.stringify({
+    v: 1,
+    currency: args.currency,
+    items: args.items.map((item) => ({
+      id: item.id,
+      productId: item.product_id,
+      variantId: item.variant_id,
+      quantity: item.quantity,
+      total: item.total_price,
+      digitalGiftCard: isGiftCardOrderLine(item),
+    })),
+    merchandiseDiscount: args.merchandiseDiscount.toMinorUnits(),
+    shipping: args.shipping.toMinorUnits(),
+    tax: args.tax.toMinorUnits(),
+    eligible: args.eligible.toMinorUnits(),
+  });
+  return hex(new Uint8Array(await crypto.subtle.digest('SHA-256', new TextEncoder().encode(canonical))));
+}
+
 export async function priceCheckout(
   input: CheckoutPricingInput,
   options: {
@@ -477,6 +517,7 @@ export async function priceCheckout(
     throw new Error(`Checkout requires between 1 and ${MAX_CHECKOUT_LINES} line items`);
   }
 
+  const seenLineIds = new Set<string>();
   const catalog = await Promise.all(input.items.map(async (line, index) => {
     if (
       !line ||
@@ -488,7 +529,10 @@ export async function priceCheckout(
       )) ||
       !Number.isSafeInteger(line.quantity) ||
       line.quantity <= 0 ||
-      line.quantity > 1_000
+      line.quantity > 1_000 ||
+      (line.lineId !== undefined && (
+        typeof line.lineId !== 'string' || !/^line_[0-9a-f]{16}(?:_[2-9]\d*)?$/u.test(line.lineId)
+      ))
     ) {
       throw new Error(`Checkout line ${index} is invalid`);
     }
@@ -504,17 +548,33 @@ export async function priceCheckout(
     }
     const unitPrice = Money.fromStored(variant.price);
     if (unitPrice.isNegative()) throw new Error(`Variant ${variantId} has an invalid catalog price`);
-    return { line, product, variant, unitPrice };
+    const giftCardCustomization = checkoutGiftCardCustomization(line.giftCardCustomization);
+    if (product.type === 'gift_card' && !giftCardCustomization) {
+      throw new Error('Gift-card lines require recipient delivery details');
+    }
+    if (giftCardCustomization && (
+      product.type !== 'gift_card' || product.fulfillment_type !== 'digital' ||
+      variant.shipping_required !== false || line.quantity !== 1
+    )) {
+      throw new Error('Gift-card lines must be single digital gift-card catalog items');
+    }
+    if (line.lineId && seenLineIds.has(line.lineId)) {
+      throw new Error('Checkout contains duplicate line identifiers');
+    }
+    if (line.lineId) seenLineIds.add(line.lineId);
+    return { line, product, variant, unitPrice, giftCardCustomization };
   }));
 
   const currency = catalog[0].unitPrice.currency;
   let subtotal = Money.zero(currency);
-  const orderItems: OrderItem[] = catalog.map(({ line, product, variant, unitPrice }) => {
+  const orderItems: OrderItem[] = catalog.map(({
+    line, product, variant, unitPrice, giftCardCustomization,
+  }) => {
     if (unitPrice.currency !== currency) throw new Error('Checkout cannot mix currencies');
     const totalPrice = unitPrice.times(line.quantity);
     subtotal = subtotal.add(totalPrice);
     return {
-      id: `line_${crypto.randomUUID()}`,
+      id: line.lineId ?? `line_${crypto.randomUUID()}`,
       product_id: product.id,
       variant_id: variant.id,
       sku: variant.sku,
@@ -526,36 +586,42 @@ export async function priceCheckout(
         option_name: option.option_id,
         option_value: option.value,
       })),
+      fulfillment_type: variant.shipping_required === false ? 'digital' : 'physical',
+      ...(giftCardCustomization ? { gift_card: giftCardCustomization } : {}),
     };
   });
+
+  const hasPhysicalLines = hasPhysicalCheckoutLines(orderItems);
 
   const [shippingSettings, storeSettings] = await Promise.all([
     deps.getSettings('shipping'),
     deps.getSettings('store'),
   ]);
+  if (!input.shippingAddress) throw new Error('Checkout requires a billing or shipping address');
   const destinationCountry = input.shippingAddress.country.toUpperCase();
-  if (!allowedShippingCountries(shippingSettings).includes(destinationCountry)) {
-    throw new Error(`Checkout shipping is not available for ${destinationCountry}`);
-  }
-  const methods = enabledShippingMethods(shippingSettings);
-  const method = methods.find((entry) =>
-    entry.id === input.shippingMethodId
-  );
-  if (!method || typeof method.label !== 'string') {
-    throw new Error(`Shipping method ${input.shippingMethodId} is not configured`);
-  }
-  const configuredShippingCost = Number(method.cost);
-  if (!Number.isFinite(configuredShippingCost) || configuredShippingCost < 0) {
-    throw new Error(`Shipping method ${input.shippingMethodId} has an invalid configured cost`);
-  }
-  let shipping = Money.fromMajor(configuredShippingCost, currency);
-  const threshold = freeShippingThreshold(storeSettings);
-  const freeMethods = freeShippingMethodIds(shippingSettings);
-  if (
-    subtotal.gte(Money.fromMajor(threshold, currency)) &&
-    freeMethods.includes(input.shippingMethodId)
-  ) {
-    shipping = Money.zero(currency);
+  let shipping = Money.zero(currency);
+  let shippingMethod: CheckoutQuote['shippingMethod'] = { id: 'digital', label: 'Digital delivery' };
+  if (hasPhysicalLines) {
+    if (!input.shippingMethodId) throw new Error('Checkout shipping method is required');
+    if (!allowedShippingCountries(shippingSettings).includes(destinationCountry)) {
+      throw new Error(`Checkout shipping is not available for ${destinationCountry}`);
+    }
+    const methods = enabledShippingMethods(shippingSettings);
+    const method = methods.find((entry) => entry.id === input.shippingMethodId);
+    if (!method || typeof method.label !== 'string') {
+      throw new Error(`Shipping method ${input.shippingMethodId} is not configured`);
+    }
+    const configuredShippingCost = Number(method.cost);
+    if (!Number.isFinite(configuredShippingCost) || configuredShippingCost < 0) {
+      throw new Error(`Shipping method ${input.shippingMethodId} has an invalid configured cost`);
+    }
+    shipping = Money.fromMajor(configuredShippingCost, currency);
+    const threshold = freeShippingThreshold(storeSettings);
+    const freeMethods = freeShippingMethodIds(shippingSettings);
+    if (subtotal.gte(Money.fromMajor(threshold, currency)) && freeMethods.includes(input.shippingMethodId)) {
+      shipping = Money.zero(currency);
+    }
+    shippingMethod = { id: input.shippingMethodId, label: method.label };
   }
 
   const codes = normalizeCodes(input.discountCodes);
@@ -669,10 +735,40 @@ export async function priceCheckout(
   }));
 
   const beforeTender = discountedMerchandise.add(chargedShipping).add(tax);
+  // Stored value cannot fund stored value. A tender may pay only the other
+  // merchandise plus the shipping/tax attributable to the whole checkout.
+  const giftCardValue = orderItems.reduce((sum, item, index) => isGiftCardOrderLine(item)
+    ? sum.add(pricedCatalog[index].lineTotal.subtract(discounts.perLine[index]).add(lineTaxes[index]))
+    : sum, Money.zero(currency));
+  const tenderEligible = beforeTender.subtract(giftCardValue);
+  if (input.giftCardToken && (
+    typeof input.giftCardRequestKey !== 'string' ||
+    input.giftCardRequestKey.length < 8 ||
+    input.giftCardRequestKey.length > 256 ||
+    input.giftCardRequestKey.trim() !== input.giftCardRequestKey
+  )) {
+    throw new Error('Gift-card tender requires a stable checkout request identity');
+  }
+  const now = Math.floor(Date.now() / 1_000);
   const tenderResolution = await capabilities.giftCards.resolveTender({
     token: input.giftCardToken,
     currency,
-    amountDue: beforeTender,
+    amountDue: tenderEligible,
+    ...(input.giftCardToken ? {
+      requestIdentity: {
+        requestKey: input.giftCardRequestKey!,
+        quoteFingerprint: await tenderQuoteFingerprint({
+          currency,
+          items: orderItems,
+          merchandiseDiscount: discounts.merchandise,
+          shipping: chargedShipping,
+          tax,
+          eligible: tenderEligible,
+        }),
+        reservedAt: now,
+        expiresAt: now + (15 * 60),
+      },
+    } : {}),
   });
   const tender = tenderResolution.amount;
   if (tenderResolution.state !== undefined) {
@@ -702,7 +798,7 @@ export async function priceCheckout(
     tender: tender.toJSON(),
     total: total.toJSON(),
     discountCodes: discounts.appliedCodes,
-    shippingMethod: { id: input.shippingMethodId, label: method.label },
+    shippingMethod,
     taxSource,
     tenderState: tenderResolution.state,
   };

--- a/lib/services/gift-card-fulfillment.ts
+++ b/lib/services/gift-card-fulfillment.ts
@@ -1,0 +1,186 @@
+import { getCloudflareContext } from '@opennextjs/cloudflare';
+import { Money } from '@/lib/money';
+import { createGiftCardRepository } from '@/lib/gift-cards/repository';
+import { digestGiftCardCode, generateGiftCardCode, type GiftCardKeyRing } from '@/lib/gift-cards/code';
+import {
+  decryptGiftCardDeliveryCode,
+  encryptGiftCardDeliveryCode,
+  type GiftCardEncryptionKeyRing,
+} from '@/lib/gift-cards/encryption';
+import { parseGiftCardCodeKeyRing, parseGiftCardDeliveryKeyRing } from '@/lib/gift-cards/config';
+import { isGiftCardOrderLine } from '@/lib/gift-cards/checkout';
+import { sendEmail } from '@/lib/email/sender';
+import { getStoreConfig } from '@/lib/store-config';
+import type { Order } from '@/lib/types/order';
+import { escapeHtmlText } from '@/lib/utils/maintenance-html';
+
+const DELIVERY_LEASE_SECONDS = 10 * 60;
+
+interface GiftCardFulfillmentEnvironment extends Record<string, unknown> { DB?: D1Database }
+
+function epochSeconds(): number { return Math.floor(Date.now() / 1_000); }
+
+async function stableId(prefix: string, orderId: string, lineId: string): Promise<string> {
+  const bytes = new TextEncoder().encode(`${prefix}\u0000v1\u0000${orderId}\u0000${lineId}`);
+  const digest = new Uint8Array(await crypto.subtle.digest('SHA-256', bytes));
+  return `${prefix}_${Array.from(digest, (byte) => byte.toString(16).padStart(2, '0')).join('')}`;
+}
+
+function deliveryMessage(args: { code: string; amount: Money; recipientName?: string }) {
+  const store = getStoreConfig();
+  const greeting = args.recipientName ? `Hello ${args.recipientName},` : 'Hello,';
+  const subject = `${store.identity.name} gift card`;
+  return {
+    from: store.contact.senderEmail,
+    to: '',
+    subject,
+    text: `${greeting}\n\nYou received a ${args.amount.format()} gift card.\n\nCode: ${args.code}\n\nKeep this code private.`,
+    html: `<p>${escapeHtmlText(greeting)}</p><p>You received a ${escapeHtmlText(args.amount.format())} gift card.</p><p><strong>${escapeHtmlText(args.code)}</strong></p><p>Keep this code private.</p>`,
+  };
+}
+
+async function issueLine(args: {
+  repository: ReturnType<typeof createGiftCardRepository>;
+  order: Order;
+  line: Order['items'][number];
+  hmac: GiftCardKeyRing;
+  deliveryKeys: GiftCardEncryptionKeyRing;
+  now: number;
+}): Promise<string> {
+  const recipient = args.line.gift_card;
+  if (!args.order.id || !args.line.id || !recipient) throw new Error('Gift-card order snapshot is invalid');
+  const giftCardId = await stableId('gift_card', args.order.id, args.line.id);
+  const existing = await args.repository.findAccountById(giftCardId);
+  if (existing) return giftCardId;
+  const deliveryId = await stableId('gift_delivery', args.order.id, args.line.id);
+  const code = generateGiftCardCode();
+  try {
+    const codeHash = await digestGiftCardCode(code, args.hmac);
+    if (!codeHash) throw new Error('Generated gift-card code is invalid');
+    const encrypted = await encryptGiftCardDeliveryCode({
+      giftCardId, deliveryId, code, keyRing: args.deliveryKeys,
+    });
+    await args.repository.issueAccount({
+      id: giftCardId,
+      codeHash,
+      amount: Money.fromStored(args.line.unit_price, args.order.currency_code),
+      issuedOrderId: args.order.id,
+      issuedLineId: args.line.id,
+      purchaserCustomerId: args.order.customer_id,
+      createdAt: args.now,
+      delivery: {
+        id: deliveryId,
+        recipientEmail: recipient.recipientEmail,
+        ...(recipient.recipientName ? { recipientName: recipient.recipientName } : {}),
+        emailIdempotencyKey: `gift-card-delivery/${giftCardId}/v1`,
+        codeCiphertext: encrypted.ciphertext,
+        codeNonce: encrypted.nonce,
+        codeKeyVersion: encrypted.keyVersion,
+      },
+    });
+  } finally {
+    // Strings cannot be reliably zeroized in JS; keep this scope minimal and
+    // never return, store, log, or attach the bearer code to an error.
+  }
+  return giftCardId;
+}
+
+async function deliverOne(args: {
+  database: D1Database;
+  giftCardId: string;
+  keys: GiftCardEncryptionKeyRing;
+  now: number;
+}): Promise<void> {
+  const token = crypto.randomUUID();
+  const claimed = await args.database.prepare(`UPDATE gift_card_deliveries
+    SET status = 'processing', attempt_count = attempt_count + 1, claim_token = ?,
+        lease_expires_at = ?, updated_at = ?
+    WHERE gift_card_id = ? AND (status = 'pending' OR (status = 'processing' AND lease_expires_at <= ?))
+    RETURNING id, recipient_email, recipient_name, email_idempotency_key, code_ciphertext,
+      code_nonce, code_key_version`).bind(
+    token, args.now + DELIVERY_LEASE_SECONDS, args.now, args.giftCardId, args.now,
+  ).first<{
+    id: string; recipient_email: string; recipient_name: string | null; email_idempotency_key: string;
+    code_ciphertext: string | null; code_nonce: string | null; code_key_version: number | null;
+  }>();
+  if (!claimed) return;
+  if (!claimed.code_ciphertext || !claimed.code_nonce || !claimed.code_key_version) {
+    await args.database.prepare(`UPDATE gift_card_deliveries SET status = 'needs_review',
+      claim_token = NULL, lease_expires_at = NULL, completed_at = ?, updated_at = ?
+      WHERE id = ? AND claim_token = ?`).bind(args.now, args.now, claimed.id, token).run();
+    return;
+  }
+  let code: string | undefined;
+  try {
+    code = await decryptGiftCardDeliveryCode({
+      giftCardId: args.giftCardId,
+      deliveryId: claimed.id,
+      encrypted: { keyVersion: claimed.code_key_version, nonce: claimed.code_nonce, ciphertext: claimed.code_ciphertext },
+      keyRing: args.keys,
+    });
+    const account = await args.database.prepare(`SELECT issued_amount_minor, currency_code FROM gift_card_accounts WHERE id = ?`)
+      .bind(args.giftCardId).first<{ issued_amount_minor: number; currency_code: string }>();
+    if (!account) throw new Error('Gift-card account is missing');
+    const message = deliveryMessage({
+      code, amount: Money.fromMinor(account.issued_amount_minor, account.currency_code),
+      ...(claimed.recipient_name ? { recipientName: claimed.recipient_name } : {}),
+    });
+    const result = await sendEmail({ ...message, to: claimed.recipient_email }, { idempotencyKey: claimed.email_idempotency_key });
+    const status = result.success ? 'sent' : result.needsReview ? 'needs_review' : 'pending';
+    await args.database.prepare(`UPDATE gift_card_deliveries SET status = ?, claim_token = NULL,
+      lease_expires_at = NULL, completed_at = ?, updated_at = ? WHERE id = ? AND claim_token = ?`)
+      .bind(status, status === 'sent' || status === 'needs_review' ? args.now : null, args.now, claimed.id, token).run();
+  } catch {
+    await args.database.prepare(`UPDATE gift_card_deliveries SET status = 'pending', claim_token = NULL,
+      lease_expires_at = NULL, updated_at = ? WHERE id = ? AND claim_token = ?`)
+      .bind(args.now, claimed.id, token).run();
+  } finally {
+    code = undefined;
+  }
+}
+
+/** Idempotently issue every paid gift-card line and make delivery retryable. */
+export async function fulfillPaidGiftCards(order: Order, options: {
+  environment?: GiftCardFulfillmentEnvironment;
+  now?: number;
+} = {}): Promise<void> {
+  const lines = order.items.filter(isGiftCardOrderLine);
+  if (lines.length === 0) return;
+  if (!order.id || order.payment_status !== 'paid') throw new Error('Gift-card issuance requires a paid order');
+  const environment = options.environment ?? (await getCloudflareContext({ async: true })).env as unknown as GiftCardFulfillmentEnvironment;
+  if (!environment.DB) throw new Error('Gift-card database is unavailable');
+  const database = environment.DB;
+  const repository = createGiftCardRepository(database);
+  const now = options.now ?? epochSeconds();
+  const deliveryKeys = parseGiftCardDeliveryKeyRing(environment);
+  let hmac: GiftCardKeyRing | undefined;
+  const cards: string[] = [];
+  for (const line of lines) {
+    if (!order.id || !line.id) throw new Error('Gift-card line lacks immutable identity');
+    const id = await stableId('gift_card', order.id, line.id);
+    if (!await repository.findAccountById(id)) hmac ??= parseGiftCardCodeKeyRing(environment);
+    cards.push(await issueLine({ repository, order, line, hmac: hmac!, deliveryKeys, now }));
+  }
+  for (const giftCardId of cards) await deliverOne({ database, giftCardId, keys: deliveryKeys, now });
+}
+
+/** Retry durable pending/expired delivery claims without reissuing any card. */
+export async function drainGiftCardDeliveries(options: {
+  environment?: GiftCardFulfillmentEnvironment;
+  now?: number;
+  limit?: number;
+} = {}): Promise<{ attempted: number }> {
+  const environment = options.environment ?? (await getCloudflareContext({ async: true })).env as unknown as GiftCardFulfillmentEnvironment;
+  if (!environment.DB) throw new Error('Gift-card database is unavailable');
+  const limit = options.limit ?? 25;
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > 100) throw new Error('Gift-card delivery limit is invalid');
+  const now = options.now ?? epochSeconds();
+  const rows = await environment.DB.prepare(`SELECT gift_card_id FROM gift_card_deliveries
+    WHERE status = 'pending' OR (status = 'processing' AND lease_expires_at <= ?)
+    ORDER BY updated_at, id LIMIT ?`).bind(now, limit).all<{ gift_card_id: string }>();
+  const keys = parseGiftCardDeliveryKeyRing(environment);
+  for (const row of rows.results ?? []) {
+    await deliverOne({ database: environment.DB, giftCardId: row.gift_card_id, keys, now });
+  }
+  return { attempted: rows.results?.length ?? 0 };
+}

--- a/lib/services/gift-card-fulfillment.ts
+++ b/lib/services/gift-card-fulfillment.ts
@@ -15,10 +15,21 @@ import type { Order } from '@/lib/types/order';
 import { escapeHtmlText } from '@/lib/utils/maintenance-html';
 
 const DELIVERY_LEASE_SECONDS = 10 * 60;
+// A delivery that keeps failing without an explicit needs-review signal (e.g. a
+// permanently bouncing address) is escalated to needs_review after this many
+// attempts so it stops being reclaimed on every drain cycle forever.
+const MAX_DELIVERY_ATTEMPTS = 8;
 
 interface GiftCardFulfillmentEnvironment extends Record<string, unknown> { DB?: D1Database }
 
 function epochSeconds(): number { return Math.floor(Date.now() / 1_000); }
+
+/** Midnight-UTC epoch second of a validated YYYY-MM-DD scheduled delivery date. */
+function scheduledDeliverAfter(deliveryDate: string | undefined): number {
+  if (!deliveryDate) return 0;
+  const [year, month, day] = deliveryDate.split('-').map(Number);
+  return Math.floor(Date.UTC(year, month - 1, day) / 1_000);
+}
 
 async function stableId(prefix: string, orderId: string, lineId: string): Promise<string> {
   const bytes = new TextEncoder().encode(`${prefix}\u0000v1\u0000${orderId}\u0000${lineId}`);
@@ -43,7 +54,7 @@ async function issueLine(args: {
   repository: ReturnType<typeof createGiftCardRepository>;
   order: Order;
   line: Order['items'][number];
-  hmac: GiftCardKeyRing;
+  resolveHmac: () => GiftCardKeyRing;
   deliveryKeys: GiftCardEncryptionKeyRing;
   now: number;
 }): Promise<string> {
@@ -53,9 +64,10 @@ async function issueLine(args: {
   const existing = await args.repository.findAccountById(giftCardId);
   if (existing) return giftCardId;
   const deliveryId = await stableId('gift_delivery', args.order.id, args.line.id);
+  const deliverAfter = scheduledDeliverAfter(recipient.deliveryDate);
   const code = generateGiftCardCode();
   try {
-    const codeHash = await digestGiftCardCode(code, args.hmac);
+    const codeHash = await digestGiftCardCode(code, args.resolveHmac());
     if (!codeHash) throw new Error('Generated gift-card code is invalid');
     const encrypted = await encryptGiftCardDeliveryCode({
       giftCardId, deliveryId, code, keyRing: args.deliveryKeys,
@@ -76,6 +88,7 @@ async function issueLine(args: {
         codeCiphertext: encrypted.ciphertext,
         codeNonce: encrypted.nonce,
         codeKeyVersion: encrypted.keyVersion,
+        ...(deliverAfter > 0 ? { deliverAfter } : {}),
       },
     });
   } finally {
@@ -95,15 +108,20 @@ async function deliverOne(args: {
   const claimed = await args.database.prepare(`UPDATE gift_card_deliveries
     SET status = 'processing', attempt_count = attempt_count + 1, claim_token = ?,
         lease_expires_at = ?, updated_at = ?
-    WHERE gift_card_id = ? AND (status = 'pending' OR (status = 'processing' AND lease_expires_at <= ?))
+    WHERE gift_card_id = ? AND deliver_after <= ?
+      AND (status = 'pending' OR (status = 'processing' AND lease_expires_at <= ?))
     RETURNING id, recipient_email, recipient_name, email_idempotency_key, code_ciphertext,
-      code_nonce, code_key_version`).bind(
-    token, args.now + DELIVERY_LEASE_SECONDS, args.now, args.giftCardId, args.now,
+      code_nonce, code_key_version, attempt_count`).bind(
+    token, args.now + DELIVERY_LEASE_SECONDS, args.now, args.giftCardId, args.now, args.now,
   ).first<{
     id: string; recipient_email: string; recipient_name: string | null; email_idempotency_key: string;
     code_ciphertext: string | null; code_nonce: string | null; code_key_version: number | null;
+    attempt_count: number;
   }>();
   if (!claimed) return;
+  // attempt_count is post-increment (SQLite RETURNING sees the new row). Once a
+  // non-terminal failure has exhausted the retry budget, park for review.
+  const exhausted = claimed.attempt_count >= MAX_DELIVERY_ATTEMPTS;
   if (!claimed.code_ciphertext || !claimed.code_nonce || !claimed.code_key_version) {
     await args.database.prepare(`UPDATE gift_card_deliveries SET status = 'needs_review',
       claim_token = NULL, lease_expires_at = NULL, completed_at = ?, updated_at = ?
@@ -126,14 +144,15 @@ async function deliverOne(args: {
       ...(claimed.recipient_name ? { recipientName: claimed.recipient_name } : {}),
     });
     const result = await sendEmail({ ...message, to: claimed.recipient_email }, { idempotencyKey: claimed.email_idempotency_key });
-    const status = result.success ? 'sent' : result.needsReview ? 'needs_review' : 'pending';
+    const status = result.success ? 'sent' : (result.needsReview || exhausted) ? 'needs_review' : 'pending';
     await args.database.prepare(`UPDATE gift_card_deliveries SET status = ?, claim_token = NULL,
       lease_expires_at = NULL, completed_at = ?, updated_at = ? WHERE id = ? AND claim_token = ?`)
       .bind(status, status === 'sent' || status === 'needs_review' ? args.now : null, args.now, claimed.id, token).run();
   } catch {
-    await args.database.prepare(`UPDATE gift_card_deliveries SET status = 'pending', claim_token = NULL,
-      lease_expires_at = NULL, updated_at = ? WHERE id = ? AND claim_token = ?`)
-      .bind(args.now, claimed.id, token).run();
+    const status = exhausted ? 'needs_review' : 'pending';
+    await args.database.prepare(`UPDATE gift_card_deliveries SET status = ?, claim_token = NULL,
+      lease_expires_at = NULL, completed_at = ?, updated_at = ? WHERE id = ? AND claim_token = ?`)
+      .bind(status, exhausted ? args.now : null, args.now, claimed.id, token).run();
   } finally {
     code = undefined;
   }
@@ -153,14 +172,17 @@ export async function fulfillPaidGiftCards(order: Order, options: {
   const repository = createGiftCardRepository(database);
   const now = options.now ?? epochSeconds();
   const deliveryKeys = parseGiftCardDeliveryKeyRing(environment);
+  // Resolve the HMAC ring lazily: a fully re-run (all cards already issued)
+  // order effect never needs the code secret.
   let hmac: GiftCardKeyRing | undefined;
+  const resolveHmac = () => (hmac ??= parseGiftCardCodeKeyRing(environment));
   const cards: string[] = [];
   for (const line of lines) {
     if (!order.id || !line.id) throw new Error('Gift-card line lacks immutable identity');
-    const id = await stableId('gift_card', order.id, line.id);
-    if (!await repository.findAccountById(id)) hmac ??= parseGiftCardCodeKeyRing(environment);
-    cards.push(await issueLine({ repository, order, line, hmac: hmac!, deliveryKeys, now }));
+    cards.push(await issueLine({ repository, order, line, resolveHmac, deliveryKeys, now }));
   }
+  // Cards with a future scheduled date are claimed only once due; the scheduler
+  // drain picks them up. Immediate cards send here.
   for (const giftCardId of cards) await deliverOne({ database, giftCardId, keys: deliveryKeys, now });
 }
 
@@ -176,8 +198,9 @@ export async function drainGiftCardDeliveries(options: {
   if (!Number.isSafeInteger(limit) || limit < 1 || limit > 100) throw new Error('Gift-card delivery limit is invalid');
   const now = options.now ?? epochSeconds();
   const rows = await environment.DB.prepare(`SELECT gift_card_id FROM gift_card_deliveries
-    WHERE status = 'pending' OR (status = 'processing' AND lease_expires_at <= ?)
-    ORDER BY updated_at, id LIMIT ?`).bind(now, limit).all<{ gift_card_id: string }>();
+    WHERE deliver_after <= ?
+      AND (status = 'pending' OR (status = 'processing' AND lease_expires_at <= ?))
+    ORDER BY updated_at, id LIMIT ?`).bind(now, now, limit).all<{ gift_card_id: string }>();
   const keys = parseGiftCardDeliveryKeyRing(environment);
   for (const row of rows.results ?? []) {
     await deliverOne({ database: environment.DB, giftCardId: row.gift_card_id, keys, now });

--- a/lib/services/inventory-adjustments.ts
+++ b/lib/services/inventory-adjustments.ts
@@ -3,6 +3,7 @@ import type { Order, OrderItem } from '@/lib/types/order';
 import type { ProductInventory } from '@/lib/types';
 import { canFulfillInventory } from '@/lib/inventory/availability';
 import { recordTelemetry } from '@/lib/observability/telemetry';
+import { isGiftCardOrderLine } from '@/lib/gift-cards/checkout';
 
 const ADJUSTMENT_LEASE_MS = 5 * 60 * 1000;
 const MAX_ADJUSTMENT_ERROR = 2_000;
@@ -94,6 +95,9 @@ function validateAdjustment(input: InventoryAdjustmentInput): void {
 function aggregateOrderDemand(items: OrderItem[]): Map<string, number> {
   const demand = new Map<string, number>();
   for (const item of items) {
+    // Gift cards are stored value, not catalog stock. Their face value is
+    // issued by the paid-order effect and must never mutate variant inventory.
+    if (isGiftCardOrderLine(item)) continue;
     if (!item.variant_id || item.variant_id.length > 256) {
       throw new Error('Paid order item has no valid variant id');
     }

--- a/lib/services/order-effects.ts
+++ b/lib/services/order-effects.ts
@@ -18,6 +18,7 @@ import {
 import { runPaidOrderInventoryEffect } from '@/lib/services/inventory-adjustments';
 import { recordTelemetry } from '@/lib/observability/telemetry';
 import { subscriptionAcquisitionIdFromOrder } from '@/lib/commerce/capabilities';
+import { fulfillPaidGiftCards } from '@/lib/services/gift-card-fulfillment';
 
 const EFFECT_LEASE_MS = 5 * 60 * 1000;
 const MAX_EFFECT_ERROR = 2_000;
@@ -52,6 +53,8 @@ export interface OrderEffectRuntime {
   sendConfirmation?: typeof sendOrderConfirmation;
   sendMerchantNotification?: typeof sendMerchantOrderNotification;
   runInventory?: (order: Order, effect: ClaimedOrderEffect) => Promise<unknown>;
+  /** Full Worker environment for encrypted gift-card issuance/delivery. */
+  giftCardEnvironment?: Record<string, unknown> & { DB?: D1Database };
   now?: () => Date;
 }
 
@@ -268,6 +271,9 @@ async function executeEffect(
       await capabilities.giftCards.applyTender({
         order,
         state: extensions.checkout_tender_state,
+      });
+      await fulfillPaidGiftCards(order, {
+        environment: runtime.giftCardEnvironment ?? (runtime.database ? { DB: runtime.database } : undefined),
       });
       return { applied: true };
     case 'subscription':

--- a/lib/services/order-finalization.ts
+++ b/lib/services/order-finalization.ts
@@ -37,6 +37,57 @@ export interface FinalizeOrderResult {
 }
 
 /**
+ * Finalize an order wholly funded by a committed gift-card reservation. This
+ * is intentionally separate from PaymentIntent finalization: no Stripe object
+ * is created, retrieved, or simulated for a zero-cash transaction.
+ */
+export async function finalizeZeroCashGiftOrder(args: {
+  orderId: string;
+  customerId?: string;
+  enforceOwnership?: boolean;
+  sendEmail?: boolean;
+  capabilities: CommerceCapabilities;
+}): Promise<FinalizeOrderResult> {
+  const db = await getDbAsync();
+  const [record] = await db.select().from(orders).where(eq(orders.id, args.orderId)).limit(1);
+  if (!record) throw new PaymentVerificationError('Pending order not found');
+  const order = hydrateOrder(record);
+  if (args.enforceOwnership && order.customer_id && order.customer_id !== args.customerId) {
+    throw new PaymentVerificationError('Order does not belong to the authenticated customer');
+  }
+  const extensions = asObject(record.extensions);
+  const total = Money.fromStored(extensions.checkout_total ?? order.total_amount, order.currency_code);
+  const tender = Money.fromStored(extensions.checkout_tender ?? 0, order.currency_code);
+  if (!total.isZero() || tender.isZero() || !order.id) {
+    throw new PaymentVerificationError('Order is not eligible for zero-cash gift-card finalization');
+  }
+  if (order.payment_status !== 'paid') {
+    await args.capabilities.giftCards.verifyReservedTender({
+      order,
+      state: extensions.checkout_tender_state,
+      expectedTender: tender,
+    });
+  }
+  await stagePaidOrderEffects(order, { includeEmail: args.sendEmail !== false });
+  const promotion = await promoteOrderToPaid({
+    orderId: order.id,
+    amountReceived: Money.zero(order.currency_code),
+  });
+  if (!promotion.order || promotion.order.payment_status !== 'paid') {
+    throw new Error('Order payment promotion lost without a paid winner');
+  }
+  try {
+    await stagePaidOrderEffects(promotion.order, { includeEmail: args.sendEmail !== false });
+    await drainOrderEffects({ orderId: promotion.order.id!, capabilities: args.capabilities, limit: 25 });
+  } catch (error) {
+    recordTelemetry('paid_effect.drain_failed', {
+      operation: 'process', outcome: 'failed', provider: 'd1', retryable: true, trigger: 'request',
+    }, error);
+  }
+  return { paid: true, promoted: promotion.promoted, order: promotion.order };
+}
+
+/**
  * Verify a captured PaymentIntent and atomically promote exactly one pending
  * order. Client returns and signed webhooks both call this routine.
  */

--- a/lib/store-config.ts
+++ b/lib/store-config.ts
@@ -73,7 +73,8 @@ export type StoreConfig = {
     carriers: readonly StoreCarrierDefinition[];
     features: {
       recommendations: boolean;
-      giftCards: boolean;
+      giftCardAcquisition: boolean;
+      giftCardReconciliation: boolean;
       subscriptionAcquisition: boolean;
       subscriptionReconciliation: boolean;
     };
@@ -153,7 +154,8 @@ export const storeDefaults: StoreConfig = {
     ],
     features: {
       recommendations: true,
-      giftCards: false,
+      giftCardAcquisition: false,
+      giftCardReconciliation: false,
       subscriptionAcquisition: false,
       subscriptionReconciliation: false,
     },
@@ -438,7 +440,16 @@ export function resolveStoreConfig(env: Environment = {}): StoreConfig {
           "STORE_FEATURE_RECOMMENDATIONS",
           storeDefaults.commerce.features.recommendations,
         ),
-        giftCards: storeDefaults.commerce.features.giftCards,
+        giftCardAcquisition: bool(
+          env,
+          "STORE_FEATURE_GIFT_CARD_ACQUISITION",
+          storeDefaults.commerce.features.giftCardAcquisition,
+        ),
+        giftCardReconciliation: bool(
+          env,
+          "STORE_FEATURE_GIFT_CARD_RECONCILIATION",
+          storeDefaults.commerce.features.giftCardReconciliation,
+        ),
         subscriptionAcquisition: bool(
           env,
           "STORE_FEATURE_SUBSCRIPTION_ACQUISITION",

--- a/lib/stores/cart-store.ts
+++ b/lib/stores/cart-store.ts
@@ -39,11 +39,16 @@
 
 import { create } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";
-import type { CartItem } from "@/lib/types/cartitem";
+import type { CartItem, StableCartItem } from "@/lib/types/cartitem";
 import type { Address } from "@/lib/types";
 import type { BillingInfo } from "@/lib/types/billing";
 import type { ShippingOption } from "@/lib/types/shipping";
 import { Money, cartSubtotal, type StoredMoney } from "@/lib/money";
+import {
+  MAX_CART_LINE_QUANTITY,
+  normalizeCartItemForStore,
+  sameCartLineFacts,
+} from "@/lib/gift-cards/line-identity";
 
 /**
  * Interface for applied discount information
@@ -63,7 +68,7 @@ export interface AppliedDiscount {
 interface CartState {
   // === Cart Items ===
   /** Array of items currently in the shopping cart */
-  items: CartItem[];
+  items: StableCartItem[];
 
   // === Discount Information ===
   /** Array of applied discounts and their details */
@@ -87,9 +92,9 @@ interface CartState {
   /** Add an item to the cart (merges quantities if item exists) */
   addItem: (item: CartItem) => void;
   /** Remove an item completely from the cart */
-  removeItem: (variantId: string) => void;
+  removeItem: (lineId: string) => void;
   /** Update the quantity of a specific item */
-  updateQuantity: (variantId: string, quantity: number) => void;
+  updateQuantity: (lineId: string, quantity: number) => void;
   /** Clear all items from the cart */
   clearCart: () => void;
   /** Calculate total price of all items in cart */
@@ -151,43 +156,51 @@ export const useCartStore = create<CartState>()(
        * If item already exists, increases quantity; otherwise adds new item
        */
       addItem: (item) => {
+        const normalized = normalizeCartItemForStore(item);
+        if (!normalized) return;
         const items = get().items;
-        const existing = items.find((i) => i.variantId === item.variantId);
+        const existing = items.find((existingItem) => sameCartLineFacts(existingItem, normalized));
 
         if (existing) {
-          // Merge quantities for existing items
+          const quantity = existing.quantity + normalized.quantity;
+          if (quantity > MAX_CART_LINE_QUANTITY) return;
           set({
             items: items.map((i) =>
-              i.variantId === item.variantId
-                ? { ...i, quantity: i.quantity + item.quantity }
+              i.lineId === existing.lineId
+                ? { ...i, quantity }
                 : i
             ),
           });
         } else {
-          // Add new item to cart
-          set({ items: [...items, item] });
+          let lineId = normalized.lineId;
+          let suffix = 2;
+          while (items.some((existingItem) => existingItem.lineId === lineId)) {
+            lineId = `${normalized.lineId}_${suffix}`;
+            suffix += 1;
+          }
+          set({ items: [...items, { ...normalized, lineId }] });
         }
       },
 
       /**
-       * Remove item completely from cart by variant ID
+       * Remove item completely from cart by stable line ID
        */
-      removeItem: (variantId) => {
-        set({ items: get().items.filter((i) => i.variantId !== variantId) });
+      removeItem: (lineId) => {
+        set({ items: get().items.filter((i) => i.lineId !== lineId) });
       },
 
       /**
        * Update item quantity with validation (removes if quantity < 1)
        */
-      updateQuantity: (variantId, quantity) => {
+      updateQuantity: (lineId, quantity) => {
         if (quantity < 1) {
           // Remove item if quantity becomes invalid
-          get().removeItem(variantId);
-        } else {
+          get().removeItem(lineId);
+        } else if (Number.isSafeInteger(quantity) && quantity <= MAX_CART_LINE_QUANTITY) {
           // Update quantity for specified item
           set({
             items: get().items.map((i) =>
-              i.variantId === variantId ? { ...i, quantity } : i
+              i.lineId === lineId ? { ...i, quantity } : i
             ),
           });
         }
@@ -351,7 +364,7 @@ export const useCartStore = create<CartState>()(
     {
       name: 'cart-storage',
       skipHydration: true,
-      version: 1,
+      version: 2,
       migrate: (persistedState: unknown) => migrateCartState(persistedState),
     }
   )
@@ -361,17 +374,42 @@ function sumDiscounts(discounts: AppliedDiscount[], currency = 'USD'): Money {
   return discounts.reduce((total, discount) => total.add(Money.fromStored(discount.amount, currency)), Money.zero(currency));
 }
 
-function migrateCartState(persistedState: unknown): unknown {
+export function migrateCartState(persistedState: unknown): unknown {
   if (!persistedState || typeof persistedState !== 'object') return persistedState;
   const state = persistedState as { items?: unknown[]; taxAmount?: unknown; totalDiscount?: unknown; appliedDiscounts?: unknown[]; shippingOption?: { cost?: unknown } };
   const toStored = (value: unknown): StoredMoney => typeof value === 'number' ? Money.fromMajor(value).toJSON() : Money.fromStored(value).toJSON();
   return {
     ...state,
-    items: state.items?.map((item) => {
-      if (!item || typeof item !== 'object') return item;
+    items: state.items?.reduce<StableCartItem[]>((items, item) => {
+      if (!item || typeof item !== 'object') return items;
       const cartItem = item as { price?: unknown };
-      return { ...cartItem, ...(cartItem.price !== undefined && { price: toStored(cartItem.price) }) };
-    }),
+      let normalized: StableCartItem | null = null;
+      try {
+        normalized = normalizeCartItemForStore({
+          ...cartItem,
+          ...(cartItem.price !== undefined && { price: toStored(cartItem.price) }),
+        });
+      } catch {
+        return items;
+      }
+      if (!normalized) return items;
+      const existing = items.find((candidate) => sameCartLineFacts(candidate, normalized));
+      if (existing) {
+        existing.quantity = Math.min(
+          MAX_CART_LINE_QUANTITY,
+          existing.quantity + normalized.quantity,
+        );
+        return items;
+      }
+      let lineId = normalized.lineId;
+      let suffix = 2;
+      while (items.some((candidate) => candidate.lineId === lineId)) {
+        lineId = `${normalized.lineId}_${suffix}`;
+        suffix += 1;
+      }
+      items.push({ ...normalized, lineId });
+      return items;
+    }, []),
     taxAmount: state.taxAmount === undefined ? undefined : toStored(state.taxAmount),
     totalDiscount: state.totalDiscount === undefined ? Money.zero().toJSON() : toStored(state.totalDiscount),
     appliedDiscounts: state.appliedDiscounts?.map((discount) => {

--- a/lib/types/cartitem.ts
+++ b/lib/types/cartitem.ts
@@ -1,11 +1,24 @@
 import type { StoredMoney } from '@/lib/money';
 
+export interface GiftCardCustomization {
+  recipientEmail: string;
+  recipientName?: string;
+  message?: string;
+  /** Calendar date in canonical YYYY-MM-DD form. */
+  deliveryDate?: string;
+}
+
 export interface CartItem {
-  variantId: string; // Unique identifier for the variant in the cart
+  /** Assigned by the cart from immutable, canonical line facts. */
+  lineId?: string;
+  variantId: string;
   productId: string; // Parent product reference (string for MACH)
   name: string;
   /** Persisted minor-unit price, not a decimal display value. */
   price: StoredMoney;
   quantity: number;
   primaryImageUrl: string;
+  giftCardCustomization?: GiftCardCustomization;
 }
+
+export type StableCartItem = CartItem & { lineId: string };

--- a/lib/types/order.ts
+++ b/lib/types/order.ts
@@ -19,6 +19,10 @@ export interface OrderItem {
   total_price: Money;
   product_name: string;
   variant_options?: VariantOption[];
+  /** Immutable fulfillment snapshot; absent legacy items are physical. */
+  fulfillment_type?: 'physical' | 'digital';
+  /** Bounded delivery data for a digital gift-card purchase; never a bearer code. */
+  gift_card?: import('@/lib/types/cartitem').GiftCardCustomization;
   created_at?: string;
 }
 

--- a/migrations/0022_add_gift_cards.sql
+++ b/migrations/0022_add_gift_cards.sql
@@ -1,0 +1,285 @@
+-- Additive, default-empty gift-card account, ledger, reservation, and delivery state.
+--
+-- Deploy/rollback contract:
+-- - Apply this migration before deploying gift-card-aware application code.
+-- - Keep acquisition and reconciliation capabilities disabled until code-hash
+--   secrets and the production capability factory are configured.
+-- - Old code ignores these tables; new code with both capabilities disabled
+--   must not read them.
+-- - After the first accepted tender, rollback disables new acquisition but
+--   retains reconciliation until every committed hold and paid effect settles.
+-- - Never down-migrate balances, reservations, ledger entries, or delivery state.
+
+CREATE TABLE gift_card_accounts (
+  id TEXT PRIMARY KEY CHECK (length(id) BETWEEN 1 AND 128),
+  code_hash TEXT NOT NULL CHECK (
+    length(code_hash) = 64
+    AND code_hash = lower(code_hash)
+    AND code_hash NOT GLOB '*[^0-9a-f]*'
+  ),
+  code_hash_version INTEGER NOT NULL CHECK (
+    code_hash_version BETWEEN 1 AND 9007199254740991
+  ),
+  currency_code TEXT NOT NULL CHECK (
+    length(currency_code) = 3
+    AND currency_code = upper(currency_code)
+    AND currency_code NOT GLOB '*[^A-Z]*'
+  ),
+  status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'disabled')),
+  issuance_entry_id TEXT NOT NULL UNIQUE CHECK (length(issuance_entry_id) BETWEEN 1 AND 128),
+  issuance_business_key TEXT NOT NULL UNIQUE CHECK (
+    length(issuance_business_key) BETWEEN 1 AND 256
+  ),
+  issued_amount_minor INTEGER NOT NULL CHECK (
+    issued_amount_minor BETWEEN 1 AND 9007199254740991
+  ),
+  issued_order_id TEXT REFERENCES orders(id) ON DELETE RESTRICT,
+  issued_line_id TEXT CHECK (
+    issued_line_id IS NULL OR length(issued_line_id) BETWEEN 1 AND 128
+  ),
+  purchaser_customer_id TEXT REFERENCES customers(id) ON DELETE RESTRICT,
+  created_at INTEGER NOT NULL CHECK (created_at BETWEEN 0 AND 9007199254740991),
+  disabled_at INTEGER CHECK (disabled_at BETWEEN 0 AND 9007199254740991),
+  CHECK (
+    (status = 'active' AND disabled_at IS NULL)
+    OR (status = 'disabled' AND disabled_at IS NOT NULL)
+  ),
+  CHECK (
+    (issued_order_id IS NULL AND issued_line_id IS NULL)
+    OR (issued_order_id IS NOT NULL AND issued_line_id IS NOT NULL)
+  ),
+  UNIQUE (id, currency_code),
+  UNIQUE (code_hash_version, code_hash)
+);
+
+CREATE INDEX gift_card_accounts_status_idx
+  ON gift_card_accounts(status, currency_code);
+CREATE INDEX gift_card_accounts_order_idx
+  ON gift_card_accounts(issued_order_id, issued_line_id);
+
+CREATE TABLE gift_card_reservations (
+  id TEXT PRIMARY KEY CHECK (length(id) BETWEEN 1 AND 128),
+  gift_card_id TEXT NOT NULL,
+  currency_code TEXT NOT NULL,
+  request_key TEXT NOT NULL UNIQUE CHECK (length(request_key) BETWEEN 8 AND 256),
+  quote_fingerprint TEXT NOT NULL CHECK (
+    length(quote_fingerprint) = 64
+    AND quote_fingerprint = lower(quote_fingerprint)
+    AND quote_fingerprint NOT GLOB '*[^0-9a-f]*'
+  ),
+  requested_amount_minor INTEGER NOT NULL CHECK (
+    requested_amount_minor BETWEEN 1 AND 9007199254740991
+  ),
+  amount_minor INTEGER NOT NULL CHECK (
+    amount_minor BETWEEN 1 AND requested_amount_minor
+  ),
+  reserved_at INTEGER NOT NULL CHECK (reserved_at BETWEEN 0 AND 9007199254740991),
+  expires_at INTEGER NOT NULL CHECK (
+    expires_at BETWEEN 1 AND 9007199254740991
+    AND expires_at > reserved_at
+  ),
+  committed_order_id TEXT REFERENCES orders(id) ON DELETE RESTRICT,
+  committed_at INTEGER CHECK (committed_at BETWEEN 0 AND 9007199254740991),
+  released_at INTEGER CHECK (released_at BETWEEN 0 AND 9007199254740991),
+  release_reason TEXT CHECK (
+    release_reason IS NULL OR length(release_reason) BETWEEN 1 AND 200
+  ),
+  FOREIGN KEY (gift_card_id, currency_code)
+    REFERENCES gift_card_accounts(id, currency_code) ON DELETE RESTRICT,
+  CHECK (
+    (committed_order_id IS NULL AND committed_at IS NULL)
+    OR (committed_order_id IS NOT NULL AND committed_at IS NOT NULL)
+  ),
+  CHECK (
+    (released_at IS NULL AND release_reason IS NULL)
+    OR (released_at IS NOT NULL AND release_reason IS NOT NULL)
+  ),
+  CHECK (committed_at IS NULL OR released_at IS NULL)
+);
+
+CREATE INDEX gift_card_reservations_account_idx
+  ON gift_card_reservations(gift_card_id, released_at, committed_at, expires_at);
+CREATE INDEX gift_card_reservations_order_idx
+  ON gift_card_reservations(committed_order_id);
+
+CREATE TABLE gift_card_ledger_entries (
+  id TEXT PRIMARY KEY CHECK (length(id) BETWEEN 1 AND 128),
+  gift_card_id TEXT NOT NULL,
+  currency_code TEXT NOT NULL,
+  entry_type TEXT NOT NULL CHECK (
+    entry_type IN ('issuance', 'redemption', 'restoration', 'adjustment')
+  ),
+  amount_delta_minor INTEGER NOT NULL CHECK (
+    amount_delta_minor BETWEEN -9007199254740991 AND 9007199254740991
+    AND amount_delta_minor <> 0
+  ),
+  business_key TEXT NOT NULL UNIQUE CHECK (length(business_key) BETWEEN 1 AND 256),
+  order_id TEXT REFERENCES orders(id) ON DELETE RESTRICT,
+  reservation_id TEXT REFERENCES gift_card_reservations(id) ON DELETE RESTRICT,
+  related_entry_id TEXT REFERENCES gift_card_ledger_entries(id) ON DELETE RESTRICT,
+  created_at INTEGER NOT NULL CHECK (created_at BETWEEN 0 AND 9007199254740991),
+  FOREIGN KEY (gift_card_id, currency_code)
+    REFERENCES gift_card_accounts(id, currency_code) ON DELETE RESTRICT,
+  CHECK (
+    (entry_type IN ('issuance', 'restoration') AND amount_delta_minor > 0)
+    OR (entry_type = 'redemption' AND amount_delta_minor < 0)
+    OR entry_type = 'adjustment'
+  ),
+  CHECK (
+    (entry_type = 'redemption' AND reservation_id IS NOT NULL AND order_id IS NOT NULL)
+    OR (entry_type <> 'redemption' AND reservation_id IS NULL)
+  )
+);
+
+CREATE UNIQUE INDEX gift_card_ledger_issuance_unique
+  ON gift_card_ledger_entries(gift_card_id) WHERE entry_type = 'issuance';
+CREATE UNIQUE INDEX gift_card_ledger_reservation_unique
+  ON gift_card_ledger_entries(reservation_id) WHERE reservation_id IS NOT NULL;
+CREATE INDEX gift_card_ledger_account_idx
+  ON gift_card_ledger_entries(gift_card_id, created_at, id);
+CREATE INDEX gift_card_ledger_order_idx
+  ON gift_card_ledger_entries(order_id, entry_type);
+
+-- Defense in depth for every writer, including future admin/import tooling.
+-- A single SQLite INSERT sees and changes one serialized database snapshot.
+CREATE TRIGGER gift_card_ledger_balance_guard
+BEFORE INSERT ON gift_card_ledger_entries
+FOR EACH ROW
+WHEN (
+  COALESCE((
+    SELECT SUM(amount_delta_minor)
+    FROM gift_card_ledger_entries
+    WHERE gift_card_id = NEW.gift_card_id
+  ), 0) + NEW.amount_delta_minor
+) NOT BETWEEN 0 AND 9007199254740991
+BEGIN
+  SELECT RAISE(ABORT, 'gift-card ledger balance would be invalid');
+END;
+
+CREATE TRIGGER gift_card_ledger_issuance_guard
+BEFORE INSERT ON gift_card_ledger_entries
+FOR EACH ROW
+WHEN NEW.entry_type = 'issuance' AND NOT EXISTS (
+  SELECT 1
+  FROM gift_card_accounts account
+  WHERE account.id = NEW.gift_card_id
+    AND account.currency_code = NEW.currency_code
+    AND account.issuance_entry_id = NEW.id
+    AND account.issuance_business_key = NEW.business_key
+    AND account.issued_amount_minor = NEW.amount_delta_minor
+    AND account.issued_order_id IS NEW.order_id
+    AND account.created_at = NEW.created_at
+)
+BEGIN
+  SELECT RAISE(ABORT, 'gift-card issuance conflicts with its account snapshot');
+END;
+
+CREATE TRIGGER gift_card_ledger_redemption_guard
+BEFORE INSERT ON gift_card_ledger_entries
+FOR EACH ROW
+WHEN NEW.entry_type = 'redemption' AND NOT EXISTS (
+  SELECT 1
+  FROM gift_card_reservations reservation
+  WHERE reservation.id = NEW.reservation_id
+    AND reservation.gift_card_id = NEW.gift_card_id
+    AND reservation.currency_code = NEW.currency_code
+    AND reservation.committed_order_id = NEW.order_id
+    AND reservation.committed_at IS NOT NULL
+    AND reservation.released_at IS NULL
+    AND NEW.amount_delta_minor = -reservation.amount_minor
+)
+BEGIN
+  SELECT RAISE(ABORT, 'gift-card redemption conflicts with its committed reservation');
+END;
+
+-- Reservations are accepted only while the account is active and their exact
+-- amount fits the ledger-derived balance after all unresolved holds.
+CREATE TRIGGER gift_card_reservations_balance_guard
+BEFORE INSERT ON gift_card_reservations
+FOR EACH ROW
+WHEN NOT EXISTS (
+  SELECT 1
+  FROM gift_card_accounts account
+  WHERE account.id = NEW.gift_card_id
+    AND account.currency_code = NEW.currency_code
+    AND account.status = 'active'
+    AND NEW.amount_minor <= (
+      COALESCE((
+        SELECT SUM(entry.amount_delta_minor)
+        FROM gift_card_ledger_entries entry
+        WHERE entry.gift_card_id = account.id
+      ), 0)
+      - COALESCE((
+        SELECT SUM(reservation.amount_minor)
+        FROM gift_card_reservations reservation
+        WHERE reservation.gift_card_id = account.id
+          AND reservation.released_at IS NULL
+          AND (
+            reservation.committed_at IS NOT NULL
+            OR reservation.expires_at > NEW.reserved_at
+          )
+          AND NOT EXISTS (
+            SELECT 1
+            FROM gift_card_ledger_entries settlement
+            WHERE settlement.reservation_id = reservation.id
+              AND settlement.entry_type = 'redemption'
+          )
+      ), 0)
+    )
+)
+BEGIN
+  SELECT RAISE(ABORT, 'gift-card reservation exceeds available balance');
+END;
+
+CREATE TABLE gift_card_deliveries (
+  id TEXT PRIMARY KEY CHECK (length(id) BETWEEN 1 AND 128),
+  gift_card_id TEXT NOT NULL UNIQUE REFERENCES gift_card_accounts(id) ON DELETE RESTRICT,
+  order_id TEXT REFERENCES orders(id) ON DELETE RESTRICT,
+  order_line_id TEXT CHECK (
+    order_line_id IS NULL OR length(order_line_id) BETWEEN 1 AND 128
+  ),
+  recipient_email TEXT NOT NULL CHECK (length(recipient_email) BETWEEN 3 AND 320),
+  recipient_name TEXT CHECK (
+    recipient_name IS NULL OR length(recipient_name) BETWEEN 1 AND 200
+  ),
+  email_idempotency_key TEXT NOT NULL UNIQUE CHECK (
+    length(email_idempotency_key) BETWEEN 1 AND 256
+  ),
+  status TEXT NOT NULL DEFAULT 'pending' CHECK (
+    status IN ('pending', 'processing', 'sent', 'needs_review')
+  ),
+  attempt_count INTEGER NOT NULL DEFAULT 0 CHECK (
+    attempt_count BETWEEN 0 AND 9007199254740991
+  ),
+  claim_token TEXT,
+  lease_expires_at INTEGER CHECK (lease_expires_at BETWEEN 0 AND 9007199254740991),
+  code_ciphertext TEXT CHECK (
+    code_ciphertext IS NULL OR length(code_ciphertext) BETWEEN 1 AND 4096
+  ),
+  code_nonce TEXT CHECK (code_nonce IS NULL OR length(code_nonce) BETWEEN 1 AND 256),
+  code_key_version INTEGER CHECK (
+    code_key_version BETWEEN 1 AND 9007199254740991
+  ),
+  created_at INTEGER NOT NULL CHECK (created_at BETWEEN 0 AND 9007199254740991),
+  updated_at INTEGER NOT NULL CHECK (updated_at BETWEEN 0 AND 9007199254740991),
+  completed_at INTEGER CHECK (completed_at BETWEEN 0 AND 9007199254740991),
+  CHECK (
+    (order_id IS NULL AND order_line_id IS NULL)
+    OR (order_id IS NOT NULL AND order_line_id IS NOT NULL)
+  ),
+  CHECK (
+    (code_ciphertext IS NULL AND code_nonce IS NULL AND code_key_version IS NULL)
+    OR (code_ciphertext IS NOT NULL AND code_nonce IS NOT NULL AND code_key_version IS NOT NULL)
+  ),
+  CHECK (
+    (status = 'processing' AND claim_token IS NOT NULL AND lease_expires_at IS NOT NULL)
+    OR (status <> 'processing' AND claim_token IS NULL AND lease_expires_at IS NULL)
+  ),
+  CHECK (
+    (status IN ('sent', 'needs_review') AND completed_at IS NOT NULL)
+    OR (status IN ('pending', 'processing') AND completed_at IS NULL)
+  )
+);
+
+CREATE INDEX gift_card_deliveries_retry_idx
+  ON gift_card_deliveries(status, lease_expires_at, updated_at);

--- a/migrations/0022_add_gift_cards.sql
+++ b/migrations/0022_add_gift_cards.sql
@@ -403,6 +403,9 @@ CREATE TABLE gift_card_deliveries (
   attempt_count INTEGER NOT NULL DEFAULT 0 CHECK (
     attempt_count BETWEEN 0 AND 9007199254740991
   ),
+  deliver_after INTEGER NOT NULL DEFAULT 0 CHECK (
+    deliver_after BETWEEN 0 AND 9007199254740991
+  ),
   claim_token TEXT,
   lease_expires_at INTEGER CHECK (lease_expires_at BETWEEN 0 AND 9007199254740991),
   code_ciphertext TEXT CHECK (
@@ -434,4 +437,4 @@ CREATE TABLE gift_card_deliveries (
 );
 
 CREATE INDEX gift_card_deliveries_retry_idx
-  ON gift_card_deliveries(status, lease_expires_at, updated_at);
+  ON gift_card_deliveries(status, deliver_after, lease_expires_at, updated_at);

--- a/migrations/0022_add_gift_cards.sql
+++ b/migrations/0022_add_gift_cards.sql
@@ -57,6 +57,55 @@ CREATE INDEX gift_card_accounts_status_idx
 CREATE INDEX gift_card_accounts_order_idx
   ON gift_card_accounts(issued_order_id, issued_line_id);
 
+-- The bearer lookup, denomination, issuance provenance, and creation clock are
+-- an immutable financial snapshot. Only the one-way active -> disabled state
+-- transition is mutable after issuance.
+CREATE TRIGGER gift_card_accounts_identity_immutable
+BEFORE UPDATE ON gift_card_accounts
+FOR EACH ROW
+WHEN NOT (
+  NEW.id IS OLD.id
+  AND NEW.code_hash IS OLD.code_hash
+  AND NEW.code_hash_version IS OLD.code_hash_version
+  AND NEW.currency_code IS OLD.currency_code
+  AND NEW.issuance_entry_id IS OLD.issuance_entry_id
+  AND NEW.issuance_business_key IS OLD.issuance_business_key
+  AND NEW.issued_amount_minor IS OLD.issued_amount_minor
+  AND NEW.issued_order_id IS OLD.issued_order_id
+  AND NEW.issued_line_id IS OLD.issued_line_id
+  AND NEW.purchaser_customer_id IS OLD.purchaser_customer_id
+  AND NEW.created_at IS OLD.created_at
+)
+BEGIN
+  SELECT RAISE(ABORT, 'gift-card account identity is immutable');
+END;
+
+CREATE TRIGGER gift_card_accounts_status_transition_guard
+BEFORE UPDATE ON gift_card_accounts
+FOR EACH ROW
+WHEN NOT (
+  (
+    OLD.status = 'active'
+    AND OLD.disabled_at IS NULL
+    AND (
+      (NEW.status = 'active' AND NEW.disabled_at IS NULL)
+      OR (
+        NEW.status = 'disabled'
+        AND NEW.disabled_at IS NOT NULL
+        AND NEW.disabled_at >= OLD.created_at
+      )
+    )
+  )
+  OR (
+    OLD.status = 'disabled'
+    AND NEW.status = 'disabled'
+    AND NEW.disabled_at IS OLD.disabled_at
+  )
+)
+BEGIN
+  SELECT RAISE(ABORT, 'gift-card account status transition is invalid');
+END;
+
 CREATE TABLE gift_card_reservations (
   id TEXT PRIMARY KEY CHECK (length(id) BETWEEN 1 AND 128),
   gift_card_id TEXT NOT NULL,
@@ -102,6 +151,63 @@ CREATE INDEX gift_card_reservations_account_idx
 CREATE INDEX gift_card_reservations_order_idx
   ON gift_card_reservations(committed_order_id);
 
+-- Quote and hold facts are immutable. Mutations may only move an open hold to
+-- exactly one terminal state, or replay that already-durable transition.
+CREATE TRIGGER gift_card_reservations_identity_immutable
+BEFORE UPDATE ON gift_card_reservations
+FOR EACH ROW
+WHEN NOT (
+  NEW.id IS OLD.id
+  AND NEW.gift_card_id IS OLD.gift_card_id
+  AND NEW.currency_code IS OLD.currency_code
+  AND NEW.request_key IS OLD.request_key
+  AND NEW.quote_fingerprint IS OLD.quote_fingerprint
+  AND NEW.requested_amount_minor IS OLD.requested_amount_minor
+  AND NEW.amount_minor IS OLD.amount_minor
+  AND NEW.reserved_at IS OLD.reserved_at
+  AND NEW.expires_at IS OLD.expires_at
+)
+BEGIN
+  SELECT RAISE(ABORT, 'gift-card reservation identity is immutable');
+END;
+
+CREATE TRIGGER gift_card_reservations_transition_guard
+BEFORE UPDATE ON gift_card_reservations
+FOR EACH ROW
+WHEN NOT (
+  (
+    NEW.committed_order_id IS OLD.committed_order_id
+    AND NEW.committed_at IS OLD.committed_at
+    AND NEW.released_at IS OLD.released_at
+    AND NEW.release_reason IS OLD.release_reason
+  )
+  OR (
+    OLD.committed_order_id IS NULL
+    AND OLD.committed_at IS NULL
+    AND OLD.released_at IS NULL
+    AND OLD.release_reason IS NULL
+    AND NEW.committed_order_id IS NOT NULL
+    AND NEW.committed_at IS NOT NULL
+    AND NEW.committed_at >= OLD.reserved_at
+    AND NEW.released_at IS NULL
+    AND NEW.release_reason IS NULL
+  )
+  OR (
+    OLD.committed_order_id IS NULL
+    AND OLD.committed_at IS NULL
+    AND OLD.released_at IS NULL
+    AND OLD.release_reason IS NULL
+    AND NEW.committed_order_id IS NULL
+    AND NEW.committed_at IS NULL
+    AND NEW.released_at IS NOT NULL
+    AND NEW.released_at >= OLD.reserved_at
+    AND NEW.release_reason IS NOT NULL
+  )
+)
+BEGIN
+  SELECT RAISE(ABORT, 'gift-card reservation transition is invalid');
+END;
+
 CREATE TABLE gift_card_ledger_entries (
   id TEXT PRIMARY KEY CHECK (length(id) BETWEEN 1 AND 128),
   gift_card_id TEXT NOT NULL,
@@ -128,6 +234,10 @@ CREATE TABLE gift_card_ledger_entries (
   CHECK (
     (entry_type = 'redemption' AND reservation_id IS NOT NULL AND order_id IS NOT NULL)
     OR (entry_type <> 'redemption' AND reservation_id IS NULL)
+  ),
+  CHECK (
+    (entry_type = 'restoration' AND order_id IS NOT NULL AND related_entry_id IS NOT NULL)
+    OR entry_type <> 'restoration'
   )
 );
 
@@ -190,6 +300,48 @@ WHEN NEW.entry_type = 'redemption' AND NOT EXISTS (
 )
 BEGIN
   SELECT RAISE(ABORT, 'gift-card redemption conflicts with its committed reservation');
+END;
+
+-- A restoration is attributed to the original order and redemption. Its
+-- cumulative positive entries may never restore more than that redemption.
+-- Concurrent INSERTs serialize through SQLite and each sees prior winners.
+CREATE TRIGGER gift_card_ledger_restoration_guard
+BEFORE INSERT ON gift_card_ledger_entries
+FOR EACH ROW
+WHEN NEW.entry_type = 'restoration' AND NOT EXISTS (
+  SELECT 1
+  FROM gift_card_ledger_entries redemption
+  WHERE redemption.id = NEW.related_entry_id
+    AND redemption.entry_type = 'redemption'
+    AND redemption.gift_card_id = NEW.gift_card_id
+    AND redemption.currency_code = NEW.currency_code
+    AND redemption.order_id = NEW.order_id
+    AND NEW.amount_delta_minor <= (
+      -redemption.amount_delta_minor
+      - COALESCE((
+        SELECT SUM(restoration.amount_delta_minor)
+        FROM gift_card_ledger_entries restoration
+        WHERE restoration.entry_type = 'restoration'
+          AND restoration.related_entry_id = redemption.id
+      ), 0)
+    )
+)
+BEGIN
+  SELECT RAISE(ABORT, 'gift-card restoration conflicts with its redemption');
+END;
+
+CREATE TRIGGER gift_card_ledger_append_only_update
+BEFORE UPDATE ON gift_card_ledger_entries
+FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'gift-card ledger is append-only');
+END;
+
+CREATE TRIGGER gift_card_ledger_append_only_delete
+BEFORE DELETE ON gift_card_ledger_entries
+FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'gift-card ledger is append-only');
 END;
 
 -- Reservations are accepted only while the account is active and their exact

--- a/tests/integration/d1-harness.test.ts
+++ b/tests/integration/d1-harness.test.ts
@@ -34,6 +34,7 @@ describe('real D1 Workers harness', () => {
       '0019_add_content_publishing.sql',
       '0020_add_redirect_map.sql',
       '0021_add_subscriptions.sql',
+      '0022_add_gift_cards.sql',
     ]);
   });
 

--- a/tests/integration/gift-cards-migration.test.ts
+++ b/tests/integration/gift-cards-migration.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { env } from "cloudflare:workers";
+import { applyD1Migrations } from "cloudflare:test";
+
+describe("gift-card migration ordering", () => {
+  it("preserves a populated 0021 baseline before adding empty gift-card state", async () => {
+    const index = env.TEST_MIGRATIONS.findIndex(
+      ({ name }) => name === "0022_add_gift_cards.sql",
+    );
+    expect(index).toBeGreaterThan(0);
+    const throughSubscriptions = env.TEST_MIGRATIONS.slice(0, index);
+    const giftCards = env.TEST_MIGRATIONS.slice(index, index + 1);
+    expect(giftCards.map(({ name }) => name)).toEqual(["0022_add_gift_cards.sql"]);
+    await applyD1Migrations(env.DB, throughSubscriptions);
+
+    await env.DB.prepare(`INSERT INTO customers
+      (id, type, person, created_at, updated_at)
+      VALUES ('gift-baseline-customer', 'person', ?, ?, ?)`)
+      .bind(
+        JSON.stringify({ email: "baseline@example.test" }),
+        "2026-08-15T00:00:00.000Z",
+        "2026-08-15T00:00:00.000Z",
+      ).run();
+    await env.DB.prepare(`INSERT INTO orders
+      (id, customer_id, status, total_amount, currency_code, items,
+       payment_status, created_at, updated_at)
+      VALUES ('gift-baseline-order', 'gift-baseline-customer', 'processing', ?,
+       'USD', '[]', 'paid', ?, ?)`)
+      .bind(
+        JSON.stringify({ amount: 2_500, currency: "USD" }),
+        "2026-08-15T00:01:00.000Z",
+        "2026-08-15T00:01:00.000Z",
+      ).run();
+    await env.DB.prepare(`INSERT INTO subscription_provider_customers
+      (customer_id, stripe_customer_id) VALUES
+      ('gift-baseline-customer', 'cus_gift_baseline')`).run();
+
+    const snapshot = async () => JSON.stringify({
+      customer: await env.DB.prepare(
+        "SELECT * FROM customers WHERE id = 'gift-baseline-customer'",
+      ).first(),
+      order: await env.DB.prepare(
+        "SELECT * FROM orders WHERE id = 'gift-baseline-order'",
+      ).first(),
+      providerCustomer: await env.DB.prepare(
+        "SELECT * FROM subscription_provider_customers WHERE customer_id = 'gift-baseline-customer'",
+      ).first(),
+    });
+    const before = await snapshot();
+    await applyD1Migrations(env.DB, giftCards);
+    expect(await snapshot()).toBe(before);
+
+    for (const table of [
+      "gift_card_accounts",
+      "gift_card_reservations",
+      "gift_card_ledger_entries",
+      "gift_card_deliveries",
+    ]) {
+      const row = await env.DB.prepare(`SELECT count(*) AS count FROM ${table}`)
+        .first<{ count: number }>();
+      expect(row).toEqual({ count: 0 });
+    }
+  });
+});

--- a/tests/integration/lib/gift-cards/repository.test.ts
+++ b/tests/integration/lib/gift-cards/repository.test.ts
@@ -210,6 +210,50 @@ describe("gift-card repository on real D1", () => {
     });
   });
 
+  it('restores a settled redemption exactly once per refund key and never exceeds it', async () => {
+    const repository = createGiftCardRepository(env.DB);
+    await repository.issueAccount(issuance());
+    await repository.reserve(reservation('reservation_restore_repository', 600));
+    await insertPendingOrder('gift-order-restore-repository');
+    const committed = await repository.commitReservation({
+      reservationId: 'reservation_restore_repository',
+      orderId: 'gift-order-restore-repository',
+      expectedAmount: Money.fromMinor(600, 'USD'),
+      committedAt: now + 100,
+    });
+    const redemption = await repository.settleReservation({
+      reservationId: committed.id,
+      orderId: 'gift-order-restore-repository',
+      settledAt: now + 101,
+    });
+    const first = await repository.restoreRedemption({
+      redemptionEntryId: redemption.entry.id,
+      orderId: 'gift-order-restore-repository',
+      refundKey: 'refund-restore-1',
+      amount: Money.fromMinor(400, 'USD'),
+      restoredAt: now + 200,
+    });
+    const retry = await repository.restoreRedemption({
+      redemptionEntryId: redemption.entry.id,
+      orderId: 'gift-order-restore-repository',
+      refundKey: 'refund-restore-1',
+      amount: Money.fromMinor(400, 'USD'),
+      restoredAt: now + 201,
+    });
+    expect(first.created).toBe(true);
+    expect(retry.created).toBe(false);
+    await expect(repository.readBalance(giftCardId, now + 201)).resolves.toMatchObject({
+      ledgerBalance: Money.fromMinor(800, 'USD'),
+    });
+    await expect(repository.restoreRedemption({
+      redemptionEntryId: redemption.entry.id,
+      orderId: 'gift-order-restore-repository',
+      refundKey: 'refund-restore-overage',
+      amount: Money.fromMinor(201, 'USD'),
+      restoredAt: now + 202,
+    })).rejects.toBeInstanceOf(GiftCardConflictError);
+  });
+
   it("serializes commit against release with exactly one terminal winner", async () => {
     const repository = createGiftCardRepository(env.DB);
     await repository.issueAccount(issuance());

--- a/tests/integration/lib/gift-cards/repository.test.ts
+++ b/tests/integration/lib/gift-cards/repository.test.ts
@@ -1,0 +1,304 @@
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { env } from "cloudflare:workers";
+import { applyTestMigrations } from "../../helpers/d1";
+import { Money } from "@/lib/money";
+import {
+  GiftCardConflictError,
+  GiftCardUnavailableError,
+  createGiftCardRepository,
+} from "@/lib/gift-cards/repository";
+import type { IssueGiftCardInput, ReserveGiftCardInput } from "@/lib/gift-cards/domain";
+
+const now = 1_800_000_000;
+const hash = "a".repeat(64);
+const quote = "b".repeat(64);
+
+function issuance(overrides: Partial<IssueGiftCardInput> = {}): IssueGiftCardInput {
+  return {
+    id: "gift_one",
+    codeHash: { keyVersion: 1, digest: hash },
+    amount: Money.fromMinor(1_000, "USD"),
+    createdAt: now,
+    ...overrides,
+  };
+}
+
+function reservation(
+  id: string,
+  requestedAmount = 600,
+  overrides: Partial<ReserveGiftCardInput> = {},
+): ReserveGiftCardInput {
+  return {
+    id,
+    giftCardId: "gift_one",
+    requestKey: `checkout-${id}`,
+    quoteFingerprint: quote,
+    requestedAmount: Money.fromMinor(requestedAmount, "USD"),
+    reservedAt: now,
+    expiresAt: now + 600,
+    ...overrides,
+  };
+}
+
+async function insertPendingOrder(id: string): Promise<void> {
+  await env.DB.prepare(`INSERT INTO orders
+    (id, status, total_amount, currency_code, items, payment_status, created_at, updated_at)
+    VALUES (?, 'pending', ?, 'USD', '[]', 'pending', ?, ?)`)
+    .bind(
+      id,
+      JSON.stringify({ amount: 1, currency: "USD" }),
+      new Date(now * 1_000).toISOString(),
+      new Date(now * 1_000).toISOString(),
+    ).run();
+}
+
+describe("gift-card repository on real D1", () => {
+  beforeAll(async () => {
+    await applyTestMigrations();
+  });
+
+  beforeEach(async () => {
+    await env.DB.batch([
+      env.DB.prepare("DELETE FROM gift_card_deliveries"),
+      env.DB.prepare("DELETE FROM gift_card_ledger_entries"),
+      env.DB.prepare("DELETE FROM gift_card_reservations"),
+      env.DB.prepare("DELETE FROM gift_card_accounts"),
+      env.DB.prepare("DELETE FROM orders WHERE id LIKE 'gift-order-%'"),
+    ]);
+  });
+
+  it("issues exactly one account and ledger entry and converges an exact retry", async () => {
+    const repository = createGiftCardRepository(env.DB);
+    const first = await repository.issueAccount(issuance());
+    const retry = await repository.issueAccount(issuance());
+    expect(first.created).toBe(true);
+    expect(retry.created).toBe(false);
+    expect(retry.account).toEqual(first.account);
+    expect(retry.issuance).toEqual(first.issuance);
+    await expect(repository.findAccountByCodeHash({ keyVersion: 1, digest: hash }))
+      .resolves.toMatchObject({ id: "gift_one", currency: "USD" });
+    await expect(repository.readBalance("gift_one", now)).resolves.toMatchObject({
+      ledgerBalance: Money.fromMinor(1_000, "USD"),
+      heldAmount: Money.zero("USD"),
+      availableBalance: Money.fromMinor(1_000, "USD"),
+    });
+  });
+
+  it("uses the version+digest pair as lookup identity and rejects collisions", async () => {
+    const repository = createGiftCardRepository(env.DB);
+    await repository.issueAccount(issuance());
+    await expect(repository.issueAccount(issuance({
+      id: "gift_rotated",
+      codeHash: { keyVersion: 2, digest: hash },
+    }))).resolves.toMatchObject({ created: true });
+    await expect(repository.findAccountByCodeHash({ keyVersion: 2, digest: hash }))
+      .resolves.toMatchObject({ id: "gift_rotated" });
+    await expect(repository.issueAccount(issuance({ id: "gift_collision" })))
+      .rejects.toBeInstanceOf(GiftCardConflictError);
+  });
+
+  it("atomically caps concurrent holds at the ledger-derived balance", async () => {
+    const repository = createGiftCardRepository(env.DB);
+    await repository.issueAccount(issuance());
+    let open!: () => void;
+    const barrier = new Promise<void>((resolve) => { open = resolve; });
+    const hold = async (id: string) => {
+      await barrier;
+      return repository.reserve(reservation(id, 700));
+    };
+    const left = hold("reservation_left");
+    const right = hold("reservation_right");
+    open();
+    const results = await Promise.all([left, right]);
+    expect(results.every((result) => result.available)).toBe(true);
+    const amounts = results.map((result) => result.available
+      ? result.reservation.amount.toMinorUnits()
+      : 0).sort((a, b) => a - b);
+    expect(amounts).toEqual([300, 700]);
+    await expect(repository.readBalance("gift_one", now)).resolves.toMatchObject({
+      ledgerBalance: Money.fromMinor(1_000, "USD"),
+      heldAmount: Money.fromMinor(1_000, "USD"),
+      availableBalance: Money.zero("USD"),
+    });
+    await expect(repository.reserve(reservation("reservation_late", 1)))
+      .resolves.toEqual({ available: false });
+  });
+
+  it("converges exact request retries and rejects changed request facts", async () => {
+    const repository = createGiftCardRepository(env.DB);
+    await repository.issueAccount(issuance());
+    const input = reservation("reservation_one");
+    await expect(repository.reserve(input)).resolves.toMatchObject({
+      available: true,
+      created: true,
+    });
+    await expect(repository.reserve({
+      ...input,
+      reservedAt: input.reservedAt + 10,
+      expiresAt: input.expiresAt + 10,
+    })).resolves.toMatchObject({
+      available: true,
+      created: false,
+    });
+    await expect(repository.reserve({
+      ...input,
+      id: "reservation_changed",
+      quoteFingerprint: "c".repeat(64),
+    })).rejects.toBeInstanceOf(GiftCardConflictError);
+  });
+
+  it("releases expired open holds while committed holds survive expiry", async () => {
+    const repository = createGiftCardRepository(env.DB);
+    await repository.issueAccount(issuance());
+    const first = await repository.reserve(reservation("reservation_expiring", 800));
+    expect(first.available).toBe(true);
+    await expect(repository.readBalance("gift_one", now + 601)).resolves.toMatchObject({
+      heldAmount: Money.zero("USD"),
+      availableBalance: Money.fromMinor(1_000, "USD"),
+    });
+    await repository.releaseReservation({
+      reservationId: "reservation_expiring",
+      reason: "expired checkout",
+      releasedAt: now + 601,
+    });
+    const committed = await repository.reserve(reservation("reservation_committed", 900, {
+      reservedAt: now + 601,
+      expiresAt: now + 1_201,
+    }));
+    expect(committed.available).toBe(true);
+    await insertPendingOrder("gift-order-commit");
+    await repository.commitReservation({
+      reservationId: "reservation_committed",
+      orderId: "gift-order-commit",
+      expectedAmount: Money.fromMinor(900, "USD"),
+      committedAt: now + 700,
+    });
+    await expect(repository.readBalance("gift_one", now + 2_000)).resolves.toMatchObject({
+      heldAmount: Money.fromMinor(900, "USD"),
+      availableBalance: Money.fromMinor(100, "USD"),
+    });
+  });
+
+  it("settles one negative ledger entry and preserves availability across retries", async () => {
+    const repository = createGiftCardRepository(env.DB);
+    await repository.issueAccount(issuance());
+    await repository.reserve(reservation("reservation_settle", 600));
+    await insertPendingOrder("gift-order-settle");
+    await repository.commitReservation({
+      reservationId: "reservation_settle",
+      orderId: "gift-order-settle",
+      expectedAmount: Money.fromMinor(600, "USD"),
+      committedAt: now + 100,
+    });
+    let open!: () => void;
+    const barrier = new Promise<void>((resolve) => { open = resolve; });
+    const settle = async () => {
+      await barrier;
+      return repository.settleReservation({
+        reservationId: "reservation_settle",
+        orderId: "gift-order-settle",
+        settledAt: now + 200,
+      });
+    };
+    const left = settle();
+    const right = settle();
+    open();
+    const results = await Promise.all([left, right]);
+    expect(results.map(({ created }) => created).sort()).toEqual([false, true]);
+    await expect(repository.readBalance("gift_one", now + 200)).resolves.toMatchObject({
+      ledgerBalance: Money.fromMinor(400, "USD"),
+      heldAmount: Money.zero("USD"),
+      availableBalance: Money.fromMinor(400, "USD"),
+    });
+  });
+
+  it("serializes commit against release with exactly one terminal winner", async () => {
+    const repository = createGiftCardRepository(env.DB);
+    await repository.issueAccount(issuance());
+    await repository.reserve(reservation("reservation_race", 500));
+    await insertPendingOrder("gift-order-race");
+    let open!: () => void;
+    const barrier = new Promise<void>((resolve) => { open = resolve; });
+    const commit = (async () => {
+      await barrier;
+      return repository.commitReservation({
+        reservationId: "reservation_race",
+        orderId: "gift-order-race",
+        expectedAmount: Money.fromMinor(500, "USD"),
+        committedAt: now + 100,
+      });
+    })();
+    const release = (async () => {
+      await barrier;
+      return repository.releaseReservation({
+        reservationId: "reservation_race",
+        reason: "checkout canceled",
+        releasedAt: now + 100,
+      });
+    })();
+    open();
+    const results = await Promise.allSettled([commit, release]);
+    expect(results.filter(({ status }) => status === "fulfilled")).toHaveLength(1);
+    expect(results.filter(({ status }) => status === "rejected")).toHaveLength(1);
+    const durable = await repository.findReservationById("reservation_race");
+    expect(Boolean(durable?.committedAt) !== Boolean(durable?.releasedAt)).toBe(true);
+  });
+
+  it("fails closed for late commitment and refuses release after commitment", async () => {
+    const repository = createGiftCardRepository(env.DB);
+    await repository.issueAccount(issuance());
+    await repository.reserve(reservation("reservation_late_commit", 500));
+    await insertPendingOrder("gift-order-late");
+    await expect(repository.commitReservation({
+      reservationId: "reservation_late_commit",
+      orderId: "gift-order-late",
+      expectedAmount: Money.fromMinor(500, "USD"),
+      committedAt: now + 601,
+    })).rejects.toBeInstanceOf(GiftCardUnavailableError);
+
+    await repository.reserve(reservation("reservation_no_release", 500));
+    await repository.commitReservation({
+      reservationId: "reservation_no_release",
+      orderId: "gift-order-late",
+      expectedAmount: Money.fromMinor(500, "USD"),
+      committedAt: now + 100,
+    });
+    await expect(repository.releaseReservation({
+      reservationId: "reservation_no_release",
+      reason: "must not release",
+      releasedAt: now + 101,
+    })).rejects.toBeInstanceOf(GiftCardConflictError);
+  });
+
+  it("enforces balance invariants for raw future writers", async () => {
+    const repository = createGiftCardRepository(env.DB);
+    await repository.issueAccount(issuance());
+    await expect(env.DB.prepare(`INSERT INTO gift_card_ledger_entries
+      (id, gift_card_id, currency_code, entry_type, amount_delta_minor,
+       business_key, created_at)
+      VALUES ('bad_adjustment', 'gift_one', 'USD', 'adjustment', -1001,
+       'bad-adjustment', ?)`)
+      .bind(now + 1).run()).rejects.toThrow("ledger balance");
+    await expect(env.DB.prepare(`INSERT INTO gift_card_reservations
+      (id, gift_card_id, currency_code, request_key, quote_fingerprint,
+       requested_amount_minor, amount_minor, reserved_at, expires_at)
+      VALUES ('bad_reservation', 'gift_one', 'USD', 'bad-request-key', ?,
+       1001, 1001, ?, ?)`)
+      .bind(quote, now, now + 100).run()).rejects.toThrow("available balance");
+
+    await repository.reserve(reservation("reservation_guard", 500));
+    await insertPendingOrder("gift-order-guard");
+    await repository.commitReservation({
+      reservationId: "reservation_guard",
+      orderId: "gift-order-guard",
+      expectedAmount: Money.fromMinor(500, "USD"),
+      committedAt: now + 10,
+    });
+    await expect(env.DB.prepare(`INSERT INTO gift_card_ledger_entries
+      (id, gift_card_id, currency_code, entry_type, amount_delta_minor,
+       business_key, order_id, reservation_id, created_at)
+      VALUES ('bad_redemption', 'gift_one', 'USD', 'redemption', -1,
+       'bad-redemption', 'gift-order-guard', 'reservation_guard', ?)`)
+      .bind(now + 20).run()).rejects.toThrow("committed reservation");
+  });
+});

--- a/tests/integration/lib/gift-cards/repository.test.ts
+++ b/tests/integration/lib/gift-cards/repository.test.ts
@@ -10,12 +10,14 @@ import {
 import type { IssueGiftCardInput, ReserveGiftCardInput } from "@/lib/gift-cards/domain";
 
 const now = 1_800_000_000;
-const hash = "a".repeat(64);
 const quote = "b".repeat(64);
+let testSequence = 0;
+let giftCardId = "gift_uninitialized";
+let hash = "0".repeat(64);
 
 function issuance(overrides: Partial<IssueGiftCardInput> = {}): IssueGiftCardInput {
   return {
-    id: "gift_one",
+    id: giftCardId,
     codeHash: { keyVersion: 1, digest: hash },
     amount: Money.fromMinor(1_000, "USD"),
     createdAt: now,
@@ -30,7 +32,7 @@ function reservation(
 ): ReserveGiftCardInput {
   return {
     id,
-    giftCardId: "gift_one",
+    giftCardId,
     requestKey: `checkout-${id}`,
     quoteFingerprint: quote,
     requestedAmount: Money.fromMinor(requestedAmount, "USD"),
@@ -57,14 +59,10 @@ describe("gift-card repository on real D1", () => {
     await applyTestMigrations();
   });
 
-  beforeEach(async () => {
-    await env.DB.batch([
-      env.DB.prepare("DELETE FROM gift_card_deliveries"),
-      env.DB.prepare("DELETE FROM gift_card_ledger_entries"),
-      env.DB.prepare("DELETE FROM gift_card_reservations"),
-      env.DB.prepare("DELETE FROM gift_card_accounts"),
-      env.DB.prepare("DELETE FROM orders WHERE id LIKE 'gift-order-%'"),
-    ]);
+  beforeEach(() => {
+    testSequence += 1;
+    giftCardId = `gift_test_${testSequence}`;
+    hash = testSequence.toString(16).padStart(64, "0");
   });
 
   it("issues exactly one account and ledger entry and converges an exact retry", async () => {
@@ -76,8 +74,8 @@ describe("gift-card repository on real D1", () => {
     expect(retry.account).toEqual(first.account);
     expect(retry.issuance).toEqual(first.issuance);
     await expect(repository.findAccountByCodeHash({ keyVersion: 1, digest: hash }))
-      .resolves.toMatchObject({ id: "gift_one", currency: "USD" });
-    await expect(repository.readBalance("gift_one", now)).resolves.toMatchObject({
+      .resolves.toMatchObject({ id: giftCardId, currency: "USD" });
+    await expect(repository.readBalance(giftCardId, now)).resolves.toMatchObject({
       ledgerBalance: Money.fromMinor(1_000, "USD"),
       heldAmount: Money.zero("USD"),
       availableBalance: Money.fromMinor(1_000, "USD"),
@@ -115,7 +113,7 @@ describe("gift-card repository on real D1", () => {
       ? result.reservation.amount.toMinorUnits()
       : 0).sort((a, b) => a - b);
     expect(amounts).toEqual([300, 700]);
-    await expect(repository.readBalance("gift_one", now)).resolves.toMatchObject({
+    await expect(repository.readBalance(giftCardId, now)).resolves.toMatchObject({
       ledgerBalance: Money.fromMinor(1_000, "USD"),
       heldAmount: Money.fromMinor(1_000, "USD"),
       availableBalance: Money.zero("USD"),
@@ -152,7 +150,7 @@ describe("gift-card repository on real D1", () => {
     await repository.issueAccount(issuance());
     const first = await repository.reserve(reservation("reservation_expiring", 800));
     expect(first.available).toBe(true);
-    await expect(repository.readBalance("gift_one", now + 601)).resolves.toMatchObject({
+    await expect(repository.readBalance(giftCardId, now + 601)).resolves.toMatchObject({
       heldAmount: Money.zero("USD"),
       availableBalance: Money.fromMinor(1_000, "USD"),
     });
@@ -173,7 +171,7 @@ describe("gift-card repository on real D1", () => {
       expectedAmount: Money.fromMinor(900, "USD"),
       committedAt: now + 700,
     });
-    await expect(repository.readBalance("gift_one", now + 2_000)).resolves.toMatchObject({
+    await expect(repository.readBalance(giftCardId, now + 2_000)).resolves.toMatchObject({
       heldAmount: Money.fromMinor(900, "USD"),
       availableBalance: Money.fromMinor(100, "USD"),
     });
@@ -205,7 +203,7 @@ describe("gift-card repository on real D1", () => {
     open();
     const results = await Promise.all([left, right]);
     expect(results.map(({ created }) => created).sort()).toEqual([false, true]);
-    await expect(repository.readBalance("gift_one", now + 200)).resolves.toMatchObject({
+    await expect(repository.readBalance(giftCardId, now + 200)).resolves.toMatchObject({
       ledgerBalance: Money.fromMinor(400, "USD"),
       heldAmount: Money.zero("USD"),
       availableBalance: Money.fromMinor(400, "USD"),
@@ -276,15 +274,15 @@ describe("gift-card repository on real D1", () => {
     await expect(env.DB.prepare(`INSERT INTO gift_card_ledger_entries
       (id, gift_card_id, currency_code, entry_type, amount_delta_minor,
        business_key, created_at)
-      VALUES ('bad_adjustment', 'gift_one', 'USD', 'adjustment', -1001,
+      VALUES ('bad_adjustment', ?, 'USD', 'adjustment', -1001,
        'bad-adjustment', ?)`)
-      .bind(now + 1).run()).rejects.toThrow("ledger balance");
+      .bind(giftCardId, now + 1).run()).rejects.toThrow("ledger balance");
     await expect(env.DB.prepare(`INSERT INTO gift_card_reservations
       (id, gift_card_id, currency_code, request_key, quote_fingerprint,
        requested_amount_minor, amount_minor, reserved_at, expires_at)
-      VALUES ('bad_reservation', 'gift_one', 'USD', 'bad-request-key', ?,
+      VALUES ('bad_reservation', ?, 'USD', 'bad-request-key', ?,
        1001, 1001, ?, ?)`)
-      .bind(quote, now, now + 100).run()).rejects.toThrow("available balance");
+      .bind(giftCardId, quote, now, now + 100).run()).rejects.toThrow("available balance");
 
     await repository.reserve(reservation("reservation_guard", 500));
     await insertPendingOrder("gift-order-guard");
@@ -297,8 +295,123 @@ describe("gift-card repository on real D1", () => {
     await expect(env.DB.prepare(`INSERT INTO gift_card_ledger_entries
       (id, gift_card_id, currency_code, entry_type, amount_delta_minor,
        business_key, order_id, reservation_id, created_at)
-      VALUES ('bad_redemption', 'gift_one', 'USD', 'redemption', -1,
+      VALUES ('bad_redemption', ?, 'USD', 'redemption', -1,
        'bad-redemption', 'gift-order-guard', 'reservation_guard', ?)`)
-      .bind(now + 20).run()).rejects.toThrow("committed reservation");
+      .bind(giftCardId, now + 20).run()).rejects.toThrow("committed reservation");
+  });
+
+  it("keeps ledger rows append-only and freezes durable financial identity", async () => {
+    const repository = createGiftCardRepository(env.DB);
+    const issued = await repository.issueAccount(issuance());
+
+    await expect(env.DB.prepare(`UPDATE gift_card_ledger_entries
+      SET amount_delta_minor = 999 WHERE id = ?`)
+      .bind(issued.issuance.id).run()).rejects.toThrow("append-only");
+    await expect(env.DB.prepare("DELETE FROM gift_card_ledger_entries WHERE id = ?")
+      .bind(issued.issuance.id).run()).rejects.toThrow("append-only");
+    await expect(env.DB.prepare(`UPDATE gift_card_accounts
+      SET code_hash = ? WHERE id = ?`)
+      .bind("f".repeat(64), giftCardId).run()).rejects.toThrow("identity is immutable");
+
+    await env.DB.prepare(`UPDATE gift_card_accounts
+      SET status = 'disabled', disabled_at = ? WHERE id = ?`)
+      .bind(now + 1, giftCardId).run();
+    await expect(env.DB.prepare(`UPDATE gift_card_accounts
+      SET status = 'active', disabled_at = NULL WHERE id = ?`)
+      .bind(giftCardId).run()).rejects.toThrow("status transition is invalid");
+
+    const secondRepository = createGiftCardRepository(env.DB);
+    const mutableGiftCardId = `${giftCardId}_reservation`;
+    await secondRepository.issueAccount(issuance({
+      id: mutableGiftCardId,
+      codeHash: { keyVersion: 1, digest: "e".repeat(64) },
+    }));
+    const input = reservation("reservation_identity", 400, {
+      giftCardId: mutableGiftCardId,
+    });
+    await secondRepository.reserve(input);
+    await expect(env.DB.prepare(`UPDATE gift_card_reservations
+      SET quote_fingerprint = ?, amount_minor = 399 WHERE id = ?`)
+      .bind("d".repeat(64), input.id).run()).rejects.toThrow("identity is immutable");
+    await expect(secondRepository.releaseReservation({
+      reservationId: input.id,
+      reason: "customer canceled",
+      releasedAt: now + 1,
+    })).resolves.toMatchObject({ released: true });
+  });
+
+  it("serializes concurrent restorations at the referenced redemption cap", async () => {
+    const repository = createGiftCardRepository(env.DB);
+    await repository.issueAccount(issuance());
+    await repository.reserve(reservation("reservation_restore", 600));
+    await insertPendingOrder("gift-order-restore");
+    await repository.commitReservation({
+      reservationId: "reservation_restore",
+      orderId: "gift-order-restore",
+      expectedAmount: Money.fromMinor(600, "USD"),
+      committedAt: now + 10,
+    });
+    const redemption = await repository.settleReservation({
+      reservationId: "reservation_restore",
+      orderId: "gift-order-restore",
+      settledAt: now + 20,
+      entryId: "redemption_restore",
+    });
+
+    await expect(env.DB.prepare(`INSERT INTO gift_card_ledger_entries
+      (id, gift_card_id, currency_code, entry_type, amount_delta_minor,
+       business_key, related_entry_id, created_at)
+      VALUES ('restoration_missing_order', ?, 'USD', 'restoration', 1,
+       'restoration-missing-order', ?, ?)`)
+      .bind(giftCardId, redemption.entry.id, now + 21).run()).rejects.toThrow();
+
+    const otherCardId = `${giftCardId}_other`;
+    await repository.issueAccount(issuance({
+      id: otherCardId,
+      codeHash: { keyVersion: 2, digest: hash },
+    }));
+    await expect(env.DB.prepare(`INSERT INTO gift_card_ledger_entries
+      (id, gift_card_id, currency_code, entry_type, amount_delta_minor,
+       business_key, order_id, related_entry_id, created_at)
+      VALUES ('restoration_wrong_card', ?, 'USD', 'restoration', 100,
+       'restoration-wrong-card', 'gift-order-restore', ?, ?)`)
+      .bind(otherCardId, redemption.entry.id, now + 21).run())
+      .rejects.toThrow("conflicts with its redemption");
+
+    let open!: () => void;
+    const barrier = new Promise<void>((resolve) => { open = resolve; });
+    const restore = async (id: string) => {
+      await barrier;
+      return env.DB.prepare(`INSERT INTO gift_card_ledger_entries
+        (id, gift_card_id, currency_code, entry_type, amount_delta_minor,
+         business_key, order_id, related_entry_id, created_at)
+        VALUES (?, ?, 'USD', 'restoration', 400, ?, 'gift-order-restore', ?, ?)`)
+        .bind(id, giftCardId, `business-${id}`, redemption.entry.id, now + 30).run();
+    };
+    const left = restore("restoration_left");
+    const right = restore("restoration_right");
+    open();
+    const results = await Promise.allSettled([left, right]);
+    expect(results.filter(({ status }) => status === "fulfilled")).toHaveLength(1);
+    expect(results.filter(({ status }) => status === "rejected")).toHaveLength(1);
+
+    const restored = await env.DB.prepare(`SELECT SUM(amount_delta_minor) AS amount
+      FROM gift_card_ledger_entries
+      WHERE entry_type = 'restoration' AND related_entry_id = ?`)
+      .bind(redemption.entry.id).first<{ amount: number }>();
+    expect(restored?.amount).toBe(400);
+    await env.DB.prepare(`INSERT INTO gift_card_ledger_entries
+      (id, gift_card_id, currency_code, entry_type, amount_delta_minor,
+       business_key, order_id, related_entry_id, created_at)
+      VALUES ('restoration_remainder', ?, 'USD', 'restoration', 200,
+       'restoration-remainder', 'gift-order-restore', ?, ?)`)
+      .bind(giftCardId, redemption.entry.id, now + 31).run();
+    await expect(env.DB.prepare(`INSERT INTO gift_card_ledger_entries
+      (id, gift_card_id, currency_code, entry_type, amount_delta_minor,
+       business_key, order_id, related_entry_id, created_at)
+      VALUES ('restoration_over_cap', ?, 'USD', 'restoration', 1,
+       'restoration-over-cap', 'gift-order-restore', ?, ?)`)
+      .bind(giftCardId, redemption.entry.id, now + 32).run())
+      .rejects.toThrow();
   });
 });

--- a/tests/integration/lib/services/gift-card-fulfillment.test.ts
+++ b/tests/integration/lib/services/gift-card-fulfillment.test.ts
@@ -141,6 +141,57 @@ describe('gift-card issuance and durable delivery on real D1', () => {
     expect(JSON.stringify(durableState)).not.toContain(deliveredCode);
   });
 
+  it('holds a scheduled card until its delivery date, then sends', async () => {
+    const order = giftOrder();
+    order.items[0].gift_card!.deliveryDate = '2030-01-01';
+    const due = Math.floor(Date.UTC(2030, 0, 1) / 1_000);
+    await insertOrder(order);
+
+    // Paid effect issues the card but must not email the recipient before the date.
+    await fulfillPaidGiftCards(order, { environment: runtimeEnvironment(), now });
+    expect(mocks.send).not.toHaveBeenCalled();
+    const scheduled = await env.DB.prepare(`SELECT status, attempt_count, deliver_after
+      FROM gift_card_deliveries WHERE order_id = ?`).bind(order.id)
+      .first<{ status: string; attempt_count: number; deliver_after: number }>();
+    expect(scheduled).toEqual({ status: 'pending', attempt_count: 0, deliver_after: due });
+
+    // A drain before the date claims nothing.
+    await expect(drainGiftCardDeliveries({ environment: runtimeEnvironment(), now: now + 1 }))
+      .resolves.toEqual({ attempted: 0 });
+    expect(mocks.send).not.toHaveBeenCalled();
+
+    // Once due, the drain delivers.
+    mocks.send.mockResolvedValueOnce({ success: true, id: 'provider-scheduled' });
+    await expect(drainGiftCardDeliveries({ environment: runtimeEnvironment(), now: due }))
+      .resolves.toEqual({ attempted: 1 });
+    expect(mocks.send).toHaveBeenCalledTimes(1);
+    await expect(env.DB.prepare(`SELECT status FROM gift_card_deliveries WHERE order_id = ?`)
+      .bind(order.id).first()).resolves.toMatchObject({ status: 'sent' });
+  });
+
+  it('escalates a permanently failing delivery to review after the attempt budget', async () => {
+    const order = giftOrder();
+    await insertOrder(order);
+    mocks.send.mockResolvedValue({ success: false, error: 'permanent bounce' });
+
+    // Attempt 1 happens in the paid effect; drain until the budget is exhausted.
+    await fulfillPaidGiftCards(order, { environment: runtimeEnvironment(), now });
+    for (let attempt = 1; attempt <= 7; attempt += 1) {
+      await drainGiftCardDeliveries({ environment: runtimeEnvironment(), now: now + attempt });
+    }
+
+    const parked = await env.DB.prepare(`SELECT status, attempt_count, completed_at
+      FROM gift_card_deliveries WHERE order_id = ?`).bind(order.id)
+      .first<{ status: string; attempt_count: number; completed_at: number }>();
+    expect(parked).toEqual({ status: 'needs_review', attempt_count: 8, completed_at: now + 7 });
+
+    // A terminal review row is no longer reclaimed.
+    const sends = mocks.send.mock.calls.length;
+    await expect(drainGiftCardDeliveries({ environment: runtimeEnvironment(), now: now + 8 }))
+      .resolves.toEqual({ attempted: 0 });
+    expect(mocks.send).toHaveBeenCalledTimes(sends);
+  });
+
   it('moves corrupted retry material to review without rendering or sending a bearer code', async () => {
     const order = giftOrder();
     await insertOrder(order);

--- a/tests/integration/lib/services/gift-card-fulfillment.test.ts
+++ b/tests/integration/lib/services/gift-card-fulfillment.test.ts
@@ -1,0 +1,159 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { env } from 'cloudflare:workers';
+import { applyTestMigrations } from '../../helpers/d1';
+import { Money } from '@/lib/money';
+
+const mocks = vi.hoisted(() => ({ send: vi.fn() }));
+
+vi.mock('@/lib/email/sender', () => ({ sendEmail: mocks.send }));
+vi.mock('@/lib/store-config', () => ({
+  getStoreConfig: () => ({
+    identity: { name: 'Test Store' },
+    contact: { senderEmail: 'Test Store <orders@example.test>' },
+  }),
+}));
+
+import { drainGiftCardDeliveries, fulfillPaidGiftCards } from '@/lib/services/gift-card-fulfillment';
+import type { Order } from '@/lib/types/order';
+
+const now = 1_800_000_000;
+const deliveryKey = 'base64:AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=';
+const hmacKey = 'gift-card-hmac-key-material-for-worker-tests-0001';
+let sequence = 0;
+
+function giftOrder(): Order {
+  sequence += 1;
+  const id = `gift-fulfillment-order-${sequence}`;
+  return {
+    id,
+    status: 'processing',
+    payment_status: 'paid',
+    payment_method: 'gift_card',
+    total_amount: Money.fromMinor(2_500, 'USD').toJSON(),
+    currency_code: 'USD',
+    items: [{
+      id: `gift-fulfillment-line-${sequence}`,
+      product_id: 'gift-product',
+      sku: 'GIFT-25',
+      product_name: 'Gift card',
+      quantity: 1,
+      unit_price: Money.fromMinor(2_500, 'USD').toJSON(),
+      total_price: Money.fromMinor(2_500, 'USD').toJSON(),
+      fulfillment_type: 'digital',
+      gift_card: {
+        recipientEmail: `recipient-${sequence}@example.test`,
+        recipientName: 'Recipient',
+      },
+    }],
+  };
+}
+
+function runtimeEnvironment(): Record<string, unknown> & { DB: D1Database } {
+  return {
+    DB: env.DB,
+    GIFT_CARD_CODE_HMAC_CURRENT_VERSION: '1',
+    GIFT_CARD_CODE_HMAC_KEYS_JSON: JSON.stringify({ 1: hmacKey }),
+    GIFT_CARD_DELIVERY_CURRENT_VERSION: '1',
+    GIFT_CARD_DELIVERY_KEYS_JSON: JSON.stringify({ 1: deliveryKey }),
+  };
+}
+
+async function insertOrder(order: Order): Promise<void> {
+  await env.DB.prepare(`INSERT INTO orders
+    (id, customer_id, status, total_amount, currency_code, items, payment_status, created_at, updated_at)
+    VALUES (?, NULL, ?, ?, ?, ?, ?, ?, ?)`)
+    .bind(
+      order.id,
+      order.status,
+      JSON.stringify(order.total_amount),
+      order.currency_code,
+      JSON.stringify(order.items),
+      order.payment_status,
+      new Date(now * 1_000).toISOString(),
+      new Date(now * 1_000).toISOString(),
+    ).run();
+}
+
+beforeAll(async () => {
+  await applyTestMigrations();
+});
+
+beforeEach(() => {
+  mocks.send.mockReset();
+});
+
+describe('gift-card issuance and durable delivery on real D1', () => {
+  it('issues once, retries delivery, and never persists the bearer code', async () => {
+    const order = giftOrder();
+    await insertOrder(order);
+    let deliveredCode = '';
+    mocks.send.mockImplementationOnce(async (message: { text: string }) => {
+      deliveredCode = message.text.match(/Code: ([A-Z0-9-]+)/)?.[1] ?? '';
+      return { success: false, error: 'temporary provider failure' };
+    });
+
+    await fulfillPaidGiftCards(order, { environment: runtimeEnvironment(), now });
+
+    expect(deliveredCode).toMatch(/^GC-(?:[A-Z0-9]{4}-){6}[A-Z0-9]{4}$/);
+    const initial = await env.DB.prepare(`SELECT status, attempt_count, code_ciphertext,
+      code_nonce, code_key_version FROM gift_card_deliveries WHERE order_id = ?`)
+      .bind(order.id).first<{
+        status: string;
+        attempt_count: number;
+        code_ciphertext: string | null;
+        code_nonce: string | null;
+        code_key_version: number | null;
+      }>();
+    expect(initial).toMatchObject({
+      status: 'pending', attempt_count: 1, code_key_version: 1,
+    });
+    expect(initial?.code_ciphertext).toBeTruthy();
+    expect(initial?.code_ciphertext).not.toContain(deliveredCode);
+    expect(initial?.code_nonce).toBeTruthy();
+
+    mocks.send.mockResolvedValueOnce({ success: true, id: 'provider-message-1' });
+    await expect(drainGiftCardDeliveries({ environment: runtimeEnvironment(), now: now + 1 }))
+      .resolves.toEqual({ attempted: 1 });
+
+    const persisted = await env.DB.prepare(`SELECT
+      (SELECT COUNT(*) FROM gift_card_accounts WHERE issued_order_id = ?) AS accounts,
+      (SELECT COUNT(*) FROM gift_card_ledger_entries WHERE order_id = ? AND entry_type = 'issuance') AS issuances,
+      (SELECT status FROM gift_card_deliveries WHERE order_id = ?) AS delivery_status`)
+      .bind(order.id, order.id, order.id).first<{
+        accounts: number;
+        issuances: number;
+        delivery_status: string;
+      }>();
+    expect(persisted).toEqual({ accounts: 1, issuances: 1, delivery_status: 'sent' });
+
+    // Repeat the paid effect. It must neither issue a second value nor send a
+    // second email after the durable delivery is terminal.
+    await fulfillPaidGiftCards(order, { environment: runtimeEnvironment(), now: now + 2 });
+    expect(mocks.send).toHaveBeenCalledTimes(2);
+    await expect(env.DB.prepare(`SELECT COUNT(*) AS count FROM gift_card_accounts WHERE issued_order_id = ?`)
+      .bind(order.id).first<{ count: number }>()).resolves.toEqual({ count: 1 });
+
+    const durableState = await env.DB.prepare(`SELECT
+      (SELECT group_concat(code_hash, '|') FROM gift_card_accounts WHERE issued_order_id = ?) AS hashes,
+      (SELECT group_concat(code_ciphertext, '|') FROM gift_card_deliveries WHERE order_id = ?) AS ciphertexts,
+      (SELECT group_concat(items, '|') FROM orders WHERE id = ?) AS order_items`)
+      .bind(order.id, order.id, order.id).first();
+    expect(JSON.stringify(durableState)).not.toContain(deliveredCode);
+  });
+
+  it('moves corrupted retry material to review without rendering or sending a bearer code', async () => {
+    const order = giftOrder();
+    await insertOrder(order);
+    mocks.send.mockResolvedValueOnce({ success: false, error: 'temporary provider failure' });
+    await fulfillPaidGiftCards(order, { environment: runtimeEnvironment(), now });
+    await env.DB.prepare(`UPDATE gift_card_deliveries SET code_ciphertext = NULL,
+      code_nonce = NULL, code_key_version = NULL
+      WHERE order_id = ?`).bind(order.id).run();
+
+    await expect(drainGiftCardDeliveries({ environment: runtimeEnvironment(), now: now + 1 }))
+      .resolves.toEqual({ attempted: 1 });
+    expect(mocks.send).toHaveBeenCalledTimes(1);
+    await expect(env.DB.prepare(`SELECT status, completed_at FROM gift_card_deliveries WHERE order_id = ?`)
+      .bind(order.id).first()).resolves.toMatchObject({ status: 'needs_review', completed_at: now + 1 });
+  });
+});

--- a/tests/unit/app/api/gift-card-presentation-routes.test.ts
+++ b/tests/unit/app/api/gift-card-presentation-routes.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mocks = vi.hoisted(() => ({
+  auth: vi.fn(),
+  context: vi.fn(),
+  rateLimit: vi.fn(),
+  customerCards: vi.fn(),
+  adminCards: vi.fn(),
+  adminAuth: vi.fn(),
+}));
+
+vi.mock('@clerk/nextjs/server', () => ({ auth: mocks.auth }));
+vi.mock('@opennextjs/cloudflare', () => ({ getCloudflareContext: mocks.context }));
+vi.mock('@/lib/rate-limit', () => ({ enforceRateLimit: mocks.rateLimit }));
+vi.mock('@/lib/gift-cards/presentations', () => ({
+  listCustomerGiftCardPresentations: mocks.customerCards,
+  listAdminGiftCardPresentations: mocks.adminCards,
+}));
+vi.mock('@/lib/auth/admin-middleware', () => ({ checkAdminPermissions: mocks.adminAuth }));
+
+import { GET as customerGet } from '@/app/api/gift-cards/route';
+import { GET as adminGet } from '@/app/api/admin/gift-cards/route';
+
+const safeCard = {
+  issuedAmount: { amount: 25, currency: 'USD', precision: 2 },
+  availableBalance: { amount: 20, currency: 'USD', precision: 2 },
+  status: 'active',
+  createdAt: 1_700_000_000,
+  delivery: { status: 'sent', attempts: 1 },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.auth.mockResolvedValue({ userId: 'user_owner' });
+  mocks.rateLimit.mockResolvedValue(null);
+  mocks.context.mockResolvedValue({ env: { DB: {} } });
+  mocks.customerCards.mockResolvedValue([safeCard]);
+  mocks.adminAuth.mockResolvedValue({ success: true, userId: 'admin_one' });
+  mocks.adminCards.mockResolvedValue({ cards: [{ ...safeCard, issuedOrderId: 'WEB-1', issuedLineId: 'line_1' }], total: 1 });
+});
+
+describe('gift-card presentation routes', () => {
+  it('requires customer authentication before rate limiting or D1', async () => {
+    mocks.auth.mockResolvedValue({ userId: null });
+    const response = await customerGet();
+    expect(response.status).toBe(401);
+    expect(mocks.rateLimit).not.toHaveBeenCalled();
+    expect(mocks.context).not.toHaveBeenCalled();
+  });
+
+  it('keeps purchased-card visibility available under reconciliation-only mode', async () => {
+    mocks.context.mockResolvedValue({ env: { DB: {}, STORE_FEATURE_GIFT_CARD_RECONCILIATION: 'true', STORE_FEATURE_GIFT_CARD_ACQUISITION: 'false' } });
+    const response = await customerGet();
+    expect(response.status).toBe(200);
+    expect(mocks.customerCards).toHaveBeenCalledWith(expect.objectContaining({ customerId: 'user_owner', limit: 100 }));
+    const body = await response.json() as { cards: Array<Record<string, unknown>> };
+    expect(body.cards).toEqual([safeCard]);
+    expect(JSON.stringify(body)).not.toMatch(/code|hash|cipher|nonce|gift_card_id/i);
+  });
+
+  it('returns an empty customer projection without touching D1 while reconciliation is disabled', async () => {
+    mocks.context.mockResolvedValue({ env: { DB: {}, STORE_FEATURE_GIFT_CARD_RECONCILIATION: 'false' } });
+    const response = await customerGet();
+    await expect(response.json()).resolves.toEqual({ cards: [] });
+    expect(mocks.customerCards).not.toHaveBeenCalled();
+  });
+
+  it('authenticates administrators before validating or reading the queue', async () => {
+    mocks.adminAuth.mockResolvedValue({ success: false, error: 'Admin access required' });
+    const response = await adminGet(new NextRequest('https://store.example/api/admin/gift-cards?limit=999'));
+    expect(response.status).toBe(401);
+    expect(mocks.context).not.toHaveBeenCalled();
+  });
+
+  it('uses bounded admin pagination and a safe operational projection', async () => {
+    mocks.context.mockResolvedValue({ env: { DB: {}, STORE_FEATURE_GIFT_CARD_RECONCILIATION: 'true' } });
+    const response = await adminGet(new NextRequest('https://store.example/api/admin/gift-cards?status=active&limit=10&offset=2'));
+    expect(response.status).toBe(200);
+    expect(mocks.adminCards).toHaveBeenCalledWith(expect.objectContaining({ status: 'active', limit: 10, offset: 2 }));
+    const body = await response.json() as { cards: Array<Record<string, unknown>> };
+    expect(body.cards[0]).toMatchObject({ ...safeCard, issuedOrderId: 'WEB-1' });
+    expect(JSON.stringify(body)).not.toMatch(/code|hash|cipher|nonce|gift_card_id/i);
+  });
+
+  it.each(['status=unknown', 'status=active&status=disabled', 'limit=0', 'limit=101', 'offset=-1', 'offset=1000001'])(
+    'rejects malformed administrative queries: %s',
+    async (query) => {
+      const response = await adminGet(new NextRequest(`https://store.example/api/admin/gift-cards?${query}`));
+      expect(response.status).toBe(400);
+      expect(mocks.context).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/tests/unit/app/api/orders-finalization-telemetry.test.ts
+++ b/tests/unit/app/api/orders-finalization-telemetry.test.ts
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => ({
   finalizeOrderPayment: vi.fn(),
   getDbAsync: vi.fn(),
   recordTelemetry: vi.fn(),
+  capabilities: { giftCards: {}, subscriptions: {} },
 }));
 
 vi.mock('@clerk/nextjs/server', () => ({ auth: mocks.auth }));
@@ -20,6 +21,9 @@ vi.mock('@/lib/services/order-finalization', () => ({
 }));
 vi.mock('@/lib/observability/telemetry', () => ({
   recordTelemetry: mocks.recordTelemetry,
+}));
+vi.mock('@/lib/commerce/runtime', () => ({
+  resolveRuntimeCommerceCapabilities: vi.fn(async () => mocks.capabilities),
 }));
 
 import { POST } from '@/app/api/orders/route';
@@ -54,6 +58,7 @@ describe('order finalization telemetry behavior', () => {
       customerId: undefined,
       enforceOwnership: true,
       sendEmail: true,
+      capabilities: mocks.capabilities,
     });
     expect(mocks.getDbAsync).not.toHaveBeenCalled();
     expect(mocks.recordTelemetry).toHaveBeenCalledWith(

--- a/tests/unit/app/api/orders-refund-ledger.test.ts
+++ b/tests/unit/app/api/orders-refund-ledger.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   recordTelemetry: vi.fn(),
   writes: [] as Array<Record<string, unknown>>,
   order: {} as Record<string, any>,
+  restoreTender: vi.fn(),
 }));
 
 vi.mock('@/lib/auth/unified-auth', () => ({
@@ -19,6 +20,11 @@ vi.mock('@/lib/stripe', () => ({
   getStripeClient: () => ({
     refunds: { create: mocks.refundsCreate, retrieve: mocks.refundsRetrieve },
   }),
+}));
+vi.mock('@/lib/commerce/runtime', () => ({
+  resolveRuntimeCommerceCapabilities: vi.fn(async () => ({
+    giftCards: { restoreTender: mocks.restoreTender },
+  })),
 }));
 vi.mock('@/lib/payments/refund-ledger-store', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/lib/payments/refund-ledger-store')>();
@@ -86,6 +92,8 @@ beforeEach(() => {
   mocks.mutateRefundLedger.mockReset();
   mocks.mutateRefundLedger.mockImplementation(mutateLedgerSuccess);
   mocks.writes.length = 0;
+  mocks.restoreTender.mockReset();
+  mocks.restoreTender.mockResolvedValue(undefined);
   mocks.order = {
     id: 'WEB-REFUND-1',
     status: 'processing',
@@ -106,6 +114,86 @@ beforeEach(() => {
 });
 
 describe('refund route durable ordering', () => {
+  it('splits a mixed tender refund, settles cash first, then restores the gift tender', async () => {
+    mocks.order.extensions = {
+      payment_intent_id: 'pi_refund',
+      checkout_tender: { amount: 600, currency: 'USD' },
+      checkout_tender_state: { v: 1, reservationId: 'gift_reservation_refund' },
+      refunds: [], refunds_version: 0,
+    };
+    mocks.refundsCreate.mockResolvedValue({
+      id: 're_mixed', amount: 400, status: 'succeeded', payment_intent: 'pi_refund',
+    });
+
+    const response = await POST(request({ amount: 700 }));
+
+    expect(response.status).toBe(200);
+    expect(mocks.refundsCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ amount: 400, payment_intent: 'pi_refund' }), expect.anything()
+    );
+    expect(mocks.restoreTender).toHaveBeenCalledWith(expect.objectContaining({
+      refundKey: expect.stringMatching(/^refund:[a-f0-9]{64}$/),
+      amount: expect.objectContaining({}),
+    }));
+    const entry = mocks.order.extensions.refunds[0];
+    expect(entry).toMatchObject({
+      cash_amount: 400, gift_amount: 300, gift_restoration_status: 'succeeded',
+      status: 'succeeded', stripe_refund_id: 're_mixed',
+    });
+  });
+
+  it('finalizes a fully gift-funded refund without contacting Stripe', async () => {
+    mocks.order.external_references = null;
+    mocks.order.extensions = {
+      checkout_tender: { amount: 1_000, currency: 'USD' },
+      checkout_tender_state: { v: 1, reservationId: 'gift_reservation_refund' },
+      refunds: [], refunds_version: 0,
+    };
+
+    const response = await POST(request({ type: 'full', amount: undefined, items: [] }));
+
+    expect(response.status).toBe(200);
+    expect(mocks.refundsCreate).not.toHaveBeenCalled();
+    expect(mocks.refundsRetrieve).not.toHaveBeenCalled();
+    expect(mocks.restoreTender).toHaveBeenCalledOnce();
+    expect(mocks.order.extensions.refunds[0]).toMatchObject({
+      cash_amount: 0, gift_amount: 1_000, gift_restoration_status: 'succeeded',
+      status: 'succeeded', provider_status: 'not_applicable',
+    });
+    expect(mocks.order.payment_status).toBe('refunded');
+  });
+
+  it('keeps a cash-settled mixed refund pending until idempotent gift restoration succeeds', async () => {
+    mocks.order.extensions = {
+      payment_intent_id: 'pi_refund',
+      checkout_tender: { amount: 600, currency: 'USD' },
+      checkout_tender_state: { v: 1, reservationId: 'gift_reservation_refund' },
+      refunds: [], refunds_version: 0,
+    };
+    mocks.refundsCreate.mockResolvedValue({
+      id: 're_restore', amount: 400, status: 'succeeded', payment_intent: 'pi_refund',
+    });
+    mocks.restoreTender.mockRejectedValueOnce(new Error('D1 transient'));
+
+    const first = await POST(request({ amount: 700 }));
+    expect(first.status).toBe(503);
+    expect(mocks.order.extensions.refunds[0]).toMatchObject({
+      status: 'pending', stripe_refund_id: 're_restore', gift_restoration_status: 'pending',
+    });
+
+    mocks.refundsRetrieve.mockResolvedValue({
+      id: 're_restore', amount: 400, status: 'succeeded', payment_intent: 'pi_refund',
+    });
+    const retry = await POST(request({ amount: 700 }));
+    expect(retry.status).toBe(200);
+    expect(mocks.refundsCreate).toHaveBeenCalledOnce();
+    expect(mocks.refundsRetrieve).toHaveBeenCalledWith('re_restore');
+    expect(mocks.restoreTender).toHaveBeenCalledTimes(2);
+    expect(mocks.order.extensions.refunds[0]).toMatchObject({
+      status: 'succeeded', gift_restoration_status: 'succeeded',
+    });
+  });
+
   it('persists pending before Stripe and forwards the key as SDK options', async () => {
     mocks.refundsCreate.mockImplementation(async (_params, options) => {
       expect(mocks.writes).toHaveLength(1);

--- a/tests/unit/app/api/stripe-webhook-retry.test.ts
+++ b/tests/unit/app/api/stripe-webhook-retry.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   completeWebhookEvent: vi.fn(),
   failWebhookEvent: vi.fn(),
   recordTelemetry: vi.fn(),
+  capabilities: { giftCards: {}, subscriptions: {} },
 }));
 
 vi.mock('@/lib/stripe', () => ({
@@ -29,6 +30,9 @@ vi.mock('@/lib/webhooks/processed-events', () => ({
 }));
 vi.mock('@/lib/observability/telemetry', () => ({
   recordTelemetry: mocks.recordTelemetry,
+}));
+vi.mock('@/lib/commerce/runtime', () => ({
+  resolveRuntimeCommerceCapabilities: vi.fn(async () => mocks.capabilities),
 }));
 
 import { POST } from '@/app/api/webhooks/stripe/route';

--- a/tests/unit/components/cart-line-source.test.ts
+++ b/tests/unit/components/cart-line-source.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const root = process.cwd();
+
+describe('stable cart-line UI projection', () => {
+  it('keys and mutates cart rows by lineId', () => {
+    const drawer = readFileSync(join(root, 'components/cart/CartDrawer.tsx'), 'utf8');
+    const card = readFileSync(join(root, 'components/cart/CartItemCard.tsx'), 'utf8');
+    expect(drawer).toContain('key={item.lineId}');
+    expect(card).toContain('updateQuantity(item.lineId');
+    expect(card).toContain('removeItem(item.lineId)');
+    expect(card).not.toContain('removeItem(item.variantId)');
+  });
+
+  it('uses the exact safe checkout-line projection', () => {
+    const checkout = readFileSync(join(root, 'components/checkout/CheckoutClient.tsx'), 'utf8');
+    expect(checkout).toContain('items: items.map(projectCartLineForCheckout)');
+    expect(checkout).not.toContain('giftCardToken');
+  });
+});

--- a/tests/unit/components/cart-line-source.test.ts
+++ b/tests/unit/components/cart-line-source.test.ts
@@ -17,6 +17,7 @@ describe('stable cart-line UI projection', () => {
   it('uses the exact safe checkout-line projection', () => {
     const checkout = readFileSync(join(root, 'components/checkout/CheckoutClient.tsx'), 'utf8');
     expect(checkout).toContain('items: items.map(projectCartLineForCheckout)');
-    expect(checkout).not.toContain('giftCardToken');
+    expect(checkout).toContain('giftCardToken: giftCardToken.trim()');
+    expect(checkout).toContain('giftCardRequestKey: giftCardRequestKey.current');
   });
 });

--- a/tests/unit/lib/commerce/capabilities.test.ts
+++ b/tests/unit/lib/commerce/capabilities.test.ts
@@ -26,7 +26,8 @@ describe("commerce capability resolution", () => {
     const subscriptions = vi.fn();
     const resolved = resolveCommerceCapabilities(
       {
-        giftCards: false,
+        giftCardAcquisition: false,
+        giftCardReconciliation: false,
         subscriptionAcquisition: false,
         subscriptionReconciliation: false,
       },
@@ -42,7 +43,8 @@ describe("commerce capability resolution", () => {
 
   it("fails configuration instead of silently enabling an absent provider", () => {
     expect(() => resolveCommerceCapabilities({
-      giftCards: false,
+      giftCardAcquisition: false,
+      giftCardReconciliation: false,
       subscriptionAcquisition: false,
       subscriptionReconciliation: true,
     })).toThrow(CommerceCapabilityConfigurationError);
@@ -67,7 +69,8 @@ describe("commerce capability resolution", () => {
     const subscriptions = vi.fn(() => subscriptionCapability);
     const resolved = resolveCommerceCapabilities(
       {
-        giftCards: false,
+        giftCardAcquisition: false,
+        giftCardReconciliation: false,
         subscriptionAcquisition: false,
         subscriptionReconciliation: true,
       },
@@ -87,11 +90,69 @@ describe("commerce capability resolution", () => {
 
   it("requires reconciliation before enabling new subscription sales", () => {
     expect(() => resolveCommerceCapabilities({
-      giftCards: false,
+      giftCardAcquisition: false,
+      giftCardReconciliation: false,
       subscriptionAcquisition: true,
       subscriptionReconciliation: false,
     }, {
       subscriptions: () => ({ orderPaid: vi.fn() }),
     })).toThrow("requires lifecycle and invoice reconciliation");
+  });
+
+  it("requires gift-card reconciliation before accepting new tender", () => {
+    expect(() => resolveCommerceCapabilities({
+      giftCardAcquisition: true,
+      giftCardReconciliation: false,
+      subscriptionAcquisition: false,
+      subscriptionReconciliation: false,
+    }, {
+      giftCards: () => ({
+        resolveTender: vi.fn(),
+        verifyReservedTender: vi.fn(),
+        applyTender: vi.fn(),
+        releaseTender: vi.fn(),
+      }),
+    })).toThrow("requires reservation reconciliation");
+  });
+
+  it("keeps reconciliation installed while acquisition rejects nonempty tokens", async () => {
+    const capability = {
+      resolveTender: vi.fn(),
+      verifyReservedTender: vi.fn(async () => undefined),
+      applyTender: vi.fn(async () => undefined),
+      releaseTender: vi.fn(async () => undefined),
+    };
+    const factory = vi.fn(() => capability);
+    const resolved = resolveCommerceCapabilities({
+      giftCardAcquisition: false,
+      giftCardReconciliation: true,
+      subscriptionAcquisition: false,
+      subscriptionReconciliation: false,
+    }, { giftCards: factory });
+
+    expect(factory).toHaveBeenCalledOnce();
+    await expect(resolved.giftCards.resolveTender({
+      currency: "USD",
+      amountDue: Money.fromMinor(100, "USD"),
+    })).resolves.toEqual({ amount: Money.zero("USD") });
+    expect(capability.resolveTender).not.toHaveBeenCalled();
+    await expect(resolved.giftCards.resolveTender({
+      token: "GC-NOT-USED",
+      currency: "USD",
+      amountDue: Money.fromMinor(100, "USD"),
+    })).rejects.toThrow("disabled");
+    await resolved.giftCards.applyTender({ order: paidOrder() });
+    expect(capability.applyTender).toHaveBeenCalledOnce();
+  });
+
+  it("rejects disabled bearer input and protected nonzero settlement", async () => {
+    await expect(noOpCommerceCapabilities.giftCards.resolveTender({
+      token: "GC-NOT-USED",
+      currency: "USD",
+      amountDue: Money.fromMinor(100, "USD"),
+    })).rejects.toThrow("disabled");
+    await expect(noOpCommerceCapabilities.giftCards.applyTender({
+      order: paidOrder({ checkout_tender: Money.fromMinor(100, "USD").toJSON() }),
+    })).rejects.toThrow("disabled");
   });
 });

--- a/tests/unit/lib/commerce/capabilities.test.ts
+++ b/tests/unit/lib/commerce/capabilities.test.ts
@@ -121,6 +121,7 @@ describe("commerce capability resolution", () => {
       verifyReservedTender: vi.fn(async () => undefined),
       applyTender: vi.fn(async () => undefined),
       releaseTender: vi.fn(async () => undefined),
+      restoreTender: vi.fn(async () => undefined),
     };
     const factory = vi.fn(() => capability);
     const resolved = resolveCommerceCapabilities({
@@ -143,6 +144,11 @@ describe("commerce capability resolution", () => {
     })).rejects.toThrow("disabled");
     await resolved.giftCards.applyTender({ order: paidOrder() });
     expect(capability.applyTender).toHaveBeenCalledOnce();
+    await resolved.giftCards.restoreTender!({
+      order: paidOrder(), state: { v: 1, reservationId: 'gift_reservation_one' },
+      refundKey: 'refund-one', amount: Money.fromMinor(100, 'USD'),
+    });
+    expect(capability.restoreTender).toHaveBeenCalledOnce();
   });
 
   it("rejects disabled bearer input and protected nonzero settlement", async () => {

--- a/tests/unit/lib/gift-cards/capability.test.ts
+++ b/tests/unit/lib/gift-cards/capability.test.ts
@@ -95,6 +95,24 @@ function harness(options: {
         createdAt: requestIdentity.reservedAt + 10,
       },
     })),
+    findSettledRedemption: vi.fn(async () => ({
+      id: "entry_one",
+      giftCardId: "gift_one",
+      entryType: "redemption" as const,
+      amountDelta: Money.fromMinor(-700, "USD"),
+      businessKey: "gift-card/redemption/gift_reservation_one/v1",
+      orderId: "order_one",
+      reservationId: "gift_reservation_one",
+      createdAt: requestIdentity.reservedAt + 10,
+    })),
+    restoreRedemption: vi.fn(async () => ({
+      created: true,
+      entry: {
+        id: 'restore_one', giftCardId: 'gift_one', entryType: 'restoration' as const,
+        amountDelta: Money.fromMinor(100, 'USD'), businessKey: 'gift-card/restoration/entry_one/refund-one/v1',
+        orderId: 'order_one', relatedEntryId: 'entry_one', createdAt: requestIdentity.reservedAt + 20,
+      },
+    })),
     releaseReservation: vi.fn(async () => ({ released: true, reservation: durableReservation })),
   };
   const resolveLookupRuntime = vi.fn(async () => ({ repository, keyRing }));
@@ -108,6 +126,20 @@ function harness(options: {
 }
 
 describe("repository-backed gift-card capability", () => {
+  it('restores a settled tender using only its opaque reservation state', async () => {
+    const { capability, repository } = harness();
+    await capability.restoreTender({
+      order: order(), state: { v: 1, reservationId: 'gift_reservation_one' },
+      refundKey: 'refund-one', amount: Money.fromMinor(100, 'USD'),
+    });
+    expect(repository.findSettledRedemption).toHaveBeenCalledWith({
+      reservationId: 'gift_reservation_one', orderId: 'order_one',
+    });
+    expect(repository.restoreRedemption).toHaveBeenCalledWith(expect.objectContaining({
+      redemptionEntryId: 'entry_one', refundKey: 'refund-one', amount: Money.fromMinor(100, 'USD'),
+    }));
+  });
+
   it("does zero runtime work without a bearer token", async () => {
     const { capability, resolveLookupRuntime, resolveRepository } = harness();
     await expect(capability.resolveTender({

--- a/tests/unit/lib/gift-cards/capability.test.ts
+++ b/tests/unit/lib/gift-cards/capability.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it, vi } from "vitest";
+import { Money } from "@/lib/money";
+import {
+  createRepositoryBackedGiftCardCapability,
+  GiftCardTenderReconciliationError,
+  GiftCardTenderRequestError,
+  GiftCardTenderUnavailableError,
+} from "@/lib/gift-cards/capability";
+import type { GiftCardAccount, GiftCardReservation } from "@/lib/gift-cards/domain";
+import type { Order } from "@/lib/types/order";
+
+const token = "GC-2345-6789-ABCD-EFGH-JKLM-NPQR-STUV";
+const requestIdentity = {
+  requestKey: "checkout-request-one",
+  quoteFingerprint: "a".repeat(64),
+  reservedAt: 1_800_000_000,
+  expiresAt: 1_800_000_600,
+};
+const keyRing = {
+  currentVersion: 2,
+  keys: {
+    1: "previous-gift-card-hmac-key-material-001",
+    2: "current-gift-card-hmac-key-material-0001",
+  },
+};
+
+function account(overrides: Partial<GiftCardAccount> = {}): GiftCardAccount {
+  return {
+    id: "gift_one",
+    codeHash: { keyVersion: 2, digest: "b".repeat(64) },
+    currency: "USD",
+    status: "active",
+    issuanceEntryId: "issuance_one",
+    issuanceBusinessKey: "gift-card/issuance/gift_one/v1",
+    issuedAmount: Money.fromMinor(1_000, "USD"),
+    createdAt: requestIdentity.reservedAt - 100,
+    ...overrides,
+  };
+}
+
+function reservation(overrides: Partial<GiftCardReservation> = {}): GiftCardReservation {
+  return {
+    id: "gift_reservation_one",
+    giftCardId: "gift_one",
+    requestKey: requestIdentity.requestKey,
+    quoteFingerprint: requestIdentity.quoteFingerprint,
+    requestedAmount: Money.fromMinor(700, "USD"),
+    amount: Money.fromMinor(700, "USD"),
+    reservedAt: requestIdentity.reservedAt,
+    expiresAt: requestIdentity.expiresAt,
+    ...overrides,
+  };
+}
+
+function order(tender = 700): Order {
+  return {
+    id: "order_one",
+    status: "processing",
+    payment_status: "paid",
+    total_amount: Money.fromMinor(2_000, "USD").toJSON(),
+    currency_code: "USD",
+    items: [],
+    extensions: { checkout_tender: Money.fromMinor(tender, "USD").toJSON() },
+  };
+}
+
+function harness(options: {
+  matchedAccount?: GiftCardAccount;
+  match?: boolean;
+  available?: boolean;
+  lookupError?: Error;
+} = {}) {
+  const durableReservation = reservation();
+  const repository = {
+    findAccountByCodeHash: vi.fn(async ({ keyVersion }: { keyVersion: number }) => {
+      if (options.lookupError) throw options.lookupError;
+      return keyVersion === 2 && options.match !== false
+        ? (options.matchedAccount ?? account())
+        : undefined;
+    }),
+    reserve: vi.fn(async () => options.available === false
+      ? { available: false as const }
+      : { available: true as const, created: true, reservation: durableReservation }),
+    commitReservation: vi.fn(async () => durableReservation),
+    settleReservation: vi.fn(async () => ({
+      created: true,
+      entry: {
+        id: "entry_one",
+        giftCardId: "gift_one",
+        entryType: "redemption" as const,
+        amountDelta: Money.fromMinor(-700, "USD"),
+        businessKey: "gift-card/redemption/gift_reservation_one/v1",
+        orderId: "order_one",
+        reservationId: "gift_reservation_one",
+        createdAt: requestIdentity.reservedAt + 10,
+      },
+    })),
+    releaseReservation: vi.fn(async () => ({ released: true, reservation: durableReservation })),
+  };
+  const resolveLookupRuntime = vi.fn(async () => ({ repository, keyRing }));
+  const resolveRepository = vi.fn(async () => repository);
+  const capability = createRepositoryBackedGiftCardCapability({
+    resolveLookupRuntime,
+    resolveRepository,
+    now: () => requestIdentity.reservedAt + 10,
+  });
+  return { capability, repository, resolveLookupRuntime, resolveRepository };
+}
+
+describe("repository-backed gift-card capability", () => {
+  it("does zero runtime work without a bearer token", async () => {
+    const { capability, resolveLookupRuntime, resolveRepository } = harness();
+    await expect(capability.resolveTender({
+      currency: "USD",
+      amountDue: Money.fromMinor(700, "USD"),
+    })).resolves.toEqual({ amount: Money.zero("USD") });
+    expect(resolveLookupRuntime).not.toHaveBeenCalled();
+    expect(resolveRepository).not.toHaveBeenCalled();
+  });
+
+  it("requires durable request identity before touching keys or D1", async () => {
+    const { capability, resolveLookupRuntime } = harness();
+    await expect(capability.resolveTender({
+      token,
+      currency: "USD",
+      amountDue: Money.fromMinor(700, "USD"),
+    })).rejects.toBeInstanceOf(GiftCardTenderRequestError);
+    expect(resolveLookupRuntime).not.toHaveBeenCalled();
+
+    for (const invalid of [
+      { ...requestIdentity, requestKey: "short" },
+      { ...requestIdentity, quoteFingerprint: "A".repeat(64) },
+      { ...requestIdentity, expiresAt: requestIdentity.reservedAt },
+    ]) {
+      await expect(capability.resolveTender({
+        token,
+        currency: "USD",
+        amountDue: Money.fromMinor(700, "USD"),
+        requestIdentity: invalid,
+      })).rejects.toBeInstanceOf(GiftCardTenderRequestError);
+    }
+    expect(resolveLookupRuntime).not.toHaveBeenCalled();
+  });
+
+  it("digests every rotation candidate and returns reservation-only v1 state", async () => {
+    const { capability, repository } = harness();
+    const resolved = await capability.resolveTender({
+      token,
+      currency: "USD",
+      amountDue: Money.fromMinor(700, "USD"),
+      requestIdentity,
+    });
+
+    expect(repository.findAccountByCodeHash).toHaveBeenCalledTimes(2);
+    expect(repository.reserve).toHaveBeenCalledWith(expect.objectContaining({
+      giftCardId: "gift_one",
+      requestKey: requestIdentity.requestKey,
+      quoteFingerprint: requestIdentity.quoteFingerprint,
+      requestedAmount: Money.fromMinor(700, "USD"),
+      reservedAt: requestIdentity.reservedAt,
+      expiresAt: requestIdentity.expiresAt,
+    }));
+    expect(resolved.amount).toEqual(Money.fromMinor(700, "USD"));
+    expect(resolved.state).toEqual({ v: 1, reservationId: "gift_reservation_one" });
+    expect(JSON.stringify(resolved.state)).not.toContain(token);
+    expect(JSON.stringify(resolved.state)).not.toContain("gift_one");
+  });
+
+  it.each([
+    ["malformed code", { token: "not-a-code" }, {}],
+    ["unknown code", {}, { match: false }],
+    ["disabled account", {}, { matchedAccount: account({ status: "disabled", disabledAt: requestIdentity.reservedAt }) }],
+    ["currency mismatch", {}, { matchedAccount: account({ currency: "EUR", issuedAmount: Money.fromMinor(1_000, "EUR") }) }],
+    ["empty balance", {}, { available: false }],
+    ["lookup failure", {}, { lookupError: new Error("D1 binding secret detail") }],
+  ])("uses one fixed unavailable failure for %s", async (_label, input, options) => {
+    const { capability } = harness(options as Parameters<typeof harness>[0]);
+    let caught: unknown;
+    try {
+      await capability.resolveTender({
+        token,
+        currency: "USD",
+        amountDue: Money.fromMinor(700, "USD"),
+        requestIdentity,
+        ...input,
+      });
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(GiftCardTenderUnavailableError);
+    expect((caught as Error).message).toBe("Gift-card tender is unavailable");
+    expect((caught as Error).message).not.toContain(token);
+    expect((caught as Error).message).not.toContain("D1 binding secret detail");
+  });
+
+  it("commits exact order and amount before idempotent settlement", async () => {
+    const { capability, repository } = harness();
+    const state = { v: 1, reservationId: "gift_reservation_one" };
+    const expectedTender = Money.fromMinor(700, "USD");
+    await capability.verifyReservedTender({ order: order(), state, expectedTender });
+    expect(repository.commitReservation).toHaveBeenCalledWith({
+      reservationId: "gift_reservation_one",
+      orderId: "order_one",
+      expectedAmount: expectedTender,
+      committedAt: requestIdentity.reservedAt + 10,
+    });
+
+    await capability.applyTender({ order: order(), state });
+    await capability.applyTender({ order: order(), state });
+    expect(repository.settleReservation).toHaveBeenCalledTimes(2);
+    expect(repository.settleReservation).toHaveBeenLastCalledWith({
+      reservationId: "gift_reservation_one",
+      orderId: "order_one",
+      settledAt: requestIdentity.reservedAt + 10,
+    });
+  });
+
+  it("releases open holds and rejects tampered state without repository work", async () => {
+    const { capability, repository, resolveRepository } = harness();
+    await capability.releaseTender({
+      state: { v: 1, reservationId: "gift_reservation_one" },
+      reason: "payment setup failed",
+    });
+    expect(repository.releaseReservation).toHaveBeenCalledWith({
+      reservationId: "gift_reservation_one",
+      reason: "payment setup failed",
+      releasedAt: requestIdentity.reservedAt + 10,
+    });
+
+    resolveRepository.mockClear();
+    await expect(capability.verifyReservedTender({
+      order: order(),
+      state: { v: 1, reservationId: "gift_reservation_one", giftCardId: "gift_one" },
+      expectedTender: Money.fromMinor(700, "USD"),
+    })).rejects.toBeInstanceOf(GiftCardTenderReconciliationError);
+    expect(resolveRepository).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/lib/gift-cards/code.test.ts
+++ b/tests/unit/lib/gift-cards/code.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  GIFT_CARD_CODE_DIGEST_CONTRACT_VERSION,
+  GIFT_CARD_CODE_ENTROPY_BITS,
+  GIFT_CARD_CODE_LENGTH,
+  GiftCardCodeConfigurationError,
+  GiftCardCodeCryptoError,
+  GiftCardCodeGenerationError,
+  MAX_GIFT_CARD_CODE_KEY_VERSIONS,
+  digestGiftCardCode,
+  generateGiftCardCode,
+  giftCardLookupCandidates,
+  normalizeGiftCardCode,
+  type GiftCardKeyRing,
+} from "@/lib/gift-cards/code";
+
+const CODE = "GC-2345-6789-ABCD-EFGH-JKLM-NPQR-STUV";
+const CURRENT_SECRET = "current-gift-card-hmac-key-material-0001";
+const PREVIOUS_SECRET = "previous-gift-card-hmac-key-material-001";
+
+function keyRing(overrides: Partial<GiftCardKeyRing> = {}): GiftCardKeyRing {
+  return {
+    currentVersion: 2,
+    keys: { 1: PREVIOUS_SECRET, 2: CURRENT_SECRET },
+    ...overrides,
+  };
+}
+
+describe("gift-card bearer-code generation", () => {
+  it("uses the Workers-compatible Web Crypto CSPRNG by default", () => {
+    const getRandomValues = vi.spyOn(crypto, "getRandomValues");
+    expect(generateGiftCardCode()).toMatch(/^GC-/);
+    expect(getRandomValues).toHaveBeenCalled();
+    getRandomValues.mockRestore();
+  });
+
+  it("generates a neutral canonical code with at least 128 bits of entropy", () => {
+    const randomFill = vi.fn((target: Uint8Array) => {
+      target.forEach((_, index) => { target[index] = index; });
+    });
+
+    const code = generateGiftCardCode({ randomFill });
+
+    expect(code).toMatch(/^GC-(?:[23456789A-HJ-NP-Z]{4}-){6}[23456789A-HJ-NP-Z]{4}$/);
+    expect(code).toHaveLength(GIFT_CARD_CODE_LENGTH);
+    expect(GIFT_CARD_CODE_ENTROPY_BITS).toBe(140);
+    expect(GIFT_CARD_CODE_ENTROPY_BITS).toBeGreaterThanOrEqual(128);
+    expect(randomFill).toHaveBeenCalledOnce();
+    expect(code).not.toMatch(/MERCORA|BEAUTEAS|TEA|STORE/);
+  });
+
+  it("rejects out-of-range random bytes instead of reducing them modulo the alphabet", () => {
+    let batch = 0;
+    const code = generateGiftCardCode({
+      randomFill(target) {
+        target.fill(batch === 0 ? 255 : 0);
+        batch += 1;
+      },
+    });
+
+    expect(batch).toBe(2);
+    expect(code).toBe("GC-2222-2222-2222-2222-2222-2222-2222");
+  });
+
+  it("fails closed with a fixed error if entropy is unavailable or never accepted", () => {
+    const entropyMessage = "raw-provider-secret-must-not-be-logged";
+    expect(() => generateGiftCardCode({
+      randomFill() { throw new Error(entropyMessage); },
+    })).toThrow(GiftCardCodeGenerationError);
+    try {
+      generateGiftCardCode({ randomFill() { throw new Error(entropyMessage); } });
+    } catch (error) {
+      expect(String(error)).not.toContain(entropyMessage);
+      expect(error).toMatchObject({ message: "Gift-card code generation failed" });
+    }
+
+    expect(() => generateGiftCardCode({
+      randomFill(target) { target.fill(255); },
+    })).toThrow(GiftCardCodeGenerationError);
+  });
+});
+
+describe("gift-card bearer-code normalization", () => {
+  it("accepts only exact separators and the ASCII alphabet, with lowercase normalized", () => {
+    expect(normalizeGiftCardCode(CODE)).toBe(CODE);
+    expect(normalizeGiftCardCode(CODE.toLowerCase())).toBe(CODE);
+  });
+
+  it.each([
+    null,
+    undefined,
+    123,
+    "",
+    ` ${CODE}`,
+    `${CODE} `,
+    CODE.replace("GC-", "GIFT-"),
+    CODE.replaceAll("-", ""),
+    CODE.replace("-2345-", " 2345 "),
+    CODE.replace("2", "0"),
+    CODE.replace("2", "1"),
+    CODE.replace("2", "I"),
+    CODE.replace("2", "O"),
+    CODE.replace("2", "２"),
+    CODE.replace("S", "ſ"),
+    CODE.replace("K", "K"),
+    `${CODE}${"X".repeat(1_000)}`,
+  ])("rejects malformed or ambiguous input without throwing: %j", (value) => {
+    expect(normalizeGiftCardCode(value)).toBeNull();
+  });
+});
+
+describe("gift-card HMAC lookup identities", () => {
+  it("freezes the purpose-, contract-, and key-version-domain-separated digest", async () => {
+    expect(GIFT_CARD_CODE_DIGEST_CONTRACT_VERSION).toBe(1);
+    await expect(digestGiftCardCode(CODE, keyRing())).resolves.toEqual({
+      keyVersion: 2,
+      digest: "df3906d559ae28e67336f983afbb989f974974d3a5bf2f006e30719de68fc566",
+    });
+  });
+
+  it("uses only the current version for issuance and every bounded version for rotation lookup", async () => {
+    const issuance = await digestGiftCardCode(CODE.toLowerCase(), keyRing());
+    const candidates = await giftCardLookupCandidates(CODE, {
+      currentVersion: 2,
+      keys: {
+        1: PREVIOUS_SECRET,
+        2: CURRENT_SECRET,
+        3: "newer-but-not-current-gift-card-key-0003",
+      },
+    });
+
+    expect(issuance).toMatchObject({ keyVersion: 2 });
+    expect(candidates.map((candidate) => candidate.keyVersion)).toEqual([2, 3, 1]);
+    expect(candidates).toHaveLength(3);
+    expect(new Set(candidates.map((candidate) => candidate.digest)).size).toBe(3);
+    for (const candidate of candidates) {
+      expect(candidate).toEqual({
+        keyVersion: expect.any(Number),
+        digest: expect.stringMatching(/^[a-f0-9]{64}$/),
+      });
+      expect(Object.isFrozen(candidate)).toBe(true);
+    }
+    expect(Object.isFrozen(candidates)).toBe(true);
+  });
+
+  it("separates identical key material by key version", async () => {
+    const versionOne = await digestGiftCardCode(CODE, {
+      currentVersion: 1,
+      keys: { 1: CURRENT_SECRET },
+    });
+    const versionTwo = await digestGiftCardCode(CODE, {
+      currentVersion: 2,
+      keys: { 2: CURRENT_SECRET },
+    });
+
+    expect(versionOne?.digest).not.toBe(versionTwo?.digest);
+  });
+
+  it("returns only constant-shape lookup authority and never the bearer code or key", async () => {
+    const lookup = await digestGiftCardCode(CODE, keyRing());
+    const candidates = await giftCardLookupCandidates(CODE, keyRing());
+    const loggable = JSON.stringify({ lookup, candidates });
+
+    expect(loggable).not.toContain(CODE);
+    expect(loggable).not.toContain(CURRENT_SECRET);
+    expect(loggable).not.toContain(PREVIOUS_SECRET);
+    expect(Object.keys(lookup!)).toEqual(["keyVersion", "digest"]);
+    expect(candidates.every(({ keyVersion, digest }) =>
+      Number.isSafeInteger(keyVersion) && keyVersion > 0 && /^[a-f0-9]{64}$/.test(digest)
+    )).toBe(true);
+  });
+
+  it("rejects malformed bearer input without exposing it in results or errors", async () => {
+    const attackerInput = `${CODE}-private@example.test`;
+    await expect(digestGiftCardCode(attackerInput, keyRing())).resolves.toBeNull();
+    await expect(giftCardLookupCandidates(attackerInput, keyRing())).resolves.toEqual([]);
+  });
+
+  it("imports a copied Uint8Array key without retaining caller mutation", async () => {
+    const bytes = new TextEncoder().encode(CURRENT_SECRET);
+    const promise = digestGiftCardCode(CODE, { currentVersion: 7, keys: { 7: bytes } });
+    bytes.fill(0);
+    await expect(promise).resolves.toEqual({
+      keyVersion: 7,
+      digest: expect.stringMatching(/^[a-f0-9]{64}$/),
+    });
+  });
+
+  it("masks WebCrypto failures without echoing code or key material", async () => {
+    const sign = vi.spyOn(crypto.subtle, "sign").mockRejectedValueOnce(
+      new Error(`provider failed for ${CODE} ${CURRENT_SECRET}`),
+    );
+    let thrown: unknown;
+    try {
+      await digestGiftCardCode(CODE, keyRing());
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(GiftCardCodeCryptoError);
+    expect(String(thrown)).toBe("GiftCardCodeCryptoError: Gift-card code digest could not be computed");
+    expect(String(thrown)).not.toContain(CODE);
+    expect(String(thrown)).not.toContain(CURRENT_SECRET);
+    sign.mockRestore();
+  });
+});
+
+describe("gift-card key-ring validation", () => {
+  const malformed: unknown[] = [
+    null,
+    undefined,
+    {},
+    { currentVersion: 0, keys: { 0: CURRENT_SECRET } },
+    { currentVersion: -1, keys: { 1: CURRENT_SECRET } },
+    { currentVersion: 1.5, keys: { 1: CURRENT_SECRET } },
+    { currentVersion: Number.MAX_SAFE_INTEGER + 1, keys: { 1: CURRENT_SECRET } },
+    { currentVersion: 2, keys: { 1: PREVIOUS_SECRET } },
+    { currentVersion: 1, keys: { "01": CURRENT_SECRET } },
+    { currentVersion: 1, keys: [] },
+    { currentVersion: 1, keys: { 1: "short" } },
+    { currentVersion: 1, keys: { 1: new Uint8Array(31) } },
+    { currentVersion: 1, keys: { 1: "x".repeat(4_097) } },
+    {
+      currentVersion: 1,
+      keys: Object.fromEntries(Array.from(
+        { length: MAX_GIFT_CARD_CODE_KEY_VERSIONS + 1 },
+        (_, index) => [index + 1, `${CURRENT_SECRET}-${index}`],
+      )),
+    },
+  ];
+
+  it.each(malformed)("fails closed for malformed or unavailable key rings: %#", async (value) => {
+    await expect(digestGiftCardCode(CODE, value as GiftCardKeyRing))
+      .rejects.toBeInstanceOf(GiftCardCodeConfigurationError);
+  });
+
+  it("masks hostile configuration getter errors", async () => {
+    const secretInError = "operator-secret-from-getter";
+    const keys = new Proxy({}, {
+      ownKeys() { throw new Error(secretInError); },
+    });
+    let thrown: unknown;
+    try {
+      await giftCardLookupCandidates(CODE, { currentVersion: 1, keys });
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(GiftCardCodeConfigurationError);
+    expect(String(thrown)).not.toContain(secretInError);
+    expect(String(thrown)).not.toContain(CODE);
+  });
+
+  it("validates configuration before treating malformed input as an ordinary miss", async () => {
+    await expect(digestGiftCardCode("invalid", { currentVersion: 1, keys: {} }))
+      .rejects.toBeInstanceOf(GiftCardCodeConfigurationError);
+    await expect(giftCardLookupCandidates("invalid", { currentVersion: 1, keys: {} }))
+      .rejects.toBeInstanceOf(GiftCardCodeConfigurationError);
+  });
+});

--- a/tests/unit/lib/gift-cards/config.test.ts
+++ b/tests/unit/lib/gift-cards/config.test.ts
@@ -65,4 +65,12 @@ describe("gift-card runtime configuration", () => {
       keys: { 1: 'base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=' },
     });
   });
+
+  it('rejects a delivery key that does not decode to a 32-byte AES-256 key', () => {
+    expect(() => parseGiftCardDeliveryKeyRing({
+      GIFT_CARD_DELIVERY_CURRENT_VERSION: '1',
+      // Valid base64 shape, but only 16 decoded bytes.
+      GIFT_CARD_DELIVERY_KEYS_JSON: JSON.stringify({ 1: 'base64:AAAAAAAAAAAAAAAAAAAAAA==' }),
+    })).toThrow('Gift-card runtime configuration is unavailable');
+  });
 });

--- a/tests/unit/lib/gift-cards/config.test.ts
+++ b/tests/unit/lib/gift-cards/config.test.ts
@@ -3,6 +3,7 @@ import { resolveStoreConfig } from "@/lib/store-config";
 import {
   GiftCardRuntimeConfigurationError,
   parseGiftCardCodeKeyRing,
+  parseGiftCardDeliveryKeyRing,
 } from "@/lib/gift-cards/config";
 
 const current = "current-gift-card-hmac-key-material-0001";
@@ -51,5 +52,17 @@ describe("gift-card runtime configuration", () => {
     });
     expect(JSON.stringify(config)).not.toContain(current);
     expect(config).not.toHaveProperty("giftCardCodeKeyRing");
+  });
+
+  it('parses an independently versioned AES-GCM delivery key ring', () => {
+    expect(parseGiftCardDeliveryKeyRing({
+      GIFT_CARD_DELIVERY_CURRENT_VERSION: '1',
+      GIFT_CARD_DELIVERY_KEYS_JSON: JSON.stringify({
+        1: 'base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=',
+      }),
+    })).toEqual({
+      currentVersion: 1,
+      keys: { 1: 'base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=' },
+    });
   });
 });

--- a/tests/unit/lib/gift-cards/config.test.ts
+++ b/tests/unit/lib/gift-cards/config.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { resolveStoreConfig } from "@/lib/store-config";
+import {
+  GiftCardRuntimeConfigurationError,
+  parseGiftCardCodeKeyRing,
+} from "@/lib/gift-cards/config";
+
+const current = "current-gift-card-hmac-key-material-0001";
+const previous = "previous-gift-card-hmac-key-material-001";
+
+describe("gift-card runtime configuration", () => {
+  it("parses a bounded server-only rotation ring", () => {
+    expect(parseGiftCardCodeKeyRing({
+      GIFT_CARD_CODE_HMAC_CURRENT_VERSION: "2",
+      GIFT_CARD_CODE_HMAC_KEYS_JSON: JSON.stringify({ 1: previous, 2: current }),
+    })).toEqual({
+      currentVersion: 2,
+      keys: { 1: previous, 2: current },
+    });
+  });
+
+  it.each([
+    {},
+    { GIFT_CARD_CODE_HMAC_CURRENT_VERSION: "0", GIFT_CARD_CODE_HMAC_KEYS_JSON: "{}" },
+    { GIFT_CARD_CODE_HMAC_CURRENT_VERSION: "2", GIFT_CARD_CODE_HMAC_KEYS_JSON: "not-json" },
+    { GIFT_CARD_CODE_HMAC_CURRENT_VERSION: "2", GIFT_CARD_CODE_HMAC_KEYS_JSON: JSON.stringify({ 1: previous }) },
+    { GIFT_CARD_CODE_HMAC_CURRENT_VERSION: "1", GIFT_CARD_CODE_HMAC_KEYS_JSON: JSON.stringify({ 1: "short" }) },
+    { GIFT_CARD_CODE_HMAC_CURRENT_VERSION: "1", GIFT_CARD_CODE_HMAC_KEYS_JSON: JSON.stringify({ 1: current, 2: previous, 3: current, 4: previous, 5: current }) },
+  ])("fails closed with one redacted error for malformed key-ring input", (environment) => {
+    let caught: unknown;
+    try {
+      parseGiftCardCodeKeyRing(environment);
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(GiftCardRuntimeConfigurationError);
+    expect((caught as Error).message).toBe("Gift-card runtime configuration is unavailable");
+    expect((caught as Error).message).not.toContain(current);
+  });
+
+  it("never copies secret ring values into public StoreConfig", () => {
+    const config = resolveStoreConfig({
+      STORE_FEATURE_GIFT_CARD_ACQUISITION: "true",
+      STORE_FEATURE_GIFT_CARD_RECONCILIATION: "true",
+      GIFT_CARD_CODE_HMAC_CURRENT_VERSION: "2",
+      GIFT_CARD_CODE_HMAC_KEYS_JSON: JSON.stringify({ 2: current }),
+    });
+    expect(config.commerce.features).toMatchObject({
+      giftCardAcquisition: true,
+      giftCardReconciliation: true,
+    });
+    expect(JSON.stringify(config)).not.toContain(current);
+    expect(config).not.toHaveProperty("giftCardCodeKeyRing");
+  });
+});

--- a/tests/unit/lib/gift-cards/customization.test.ts
+++ b/tests/unit/lib/gift-cards/customization.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  GiftCardCustomizationValidationError,
+  parseGiftCardCustomization,
+} from '@/lib/gift-cards/customization';
+
+describe('gift-card customization', () => {
+  it('normalizes the exact public recipient projection', () => {
+    expect(parseGiftCardCustomization({
+      recipientEmail: '  Recipient@Example.COM ',
+      recipientName: '  Ada   Lovelace ',
+      message: ' Enjoy this!  \r\n  From us ',
+      deliveryDate: '2026-12-24',
+    })).toEqual({
+      recipientEmail: 'recipient@example.com',
+      recipientName: 'Ada Lovelace',
+      message: 'Enjoy this!\nFrom us',
+      deliveryDate: '2026-12-24',
+    });
+  });
+
+  it.each([
+    { recipientEmail: 'recipient@example.com', code: 'GC-SECRET' },
+    { recipientEmail: 'recipient@example.com', token: 'secret' },
+    { recipientEmail: 'not-an-email' },
+    { recipientEmail: 'recipient@example.com', deliveryDate: '2026-02-29' },
+    { recipientEmail: 'recipient@example.com', recipientName: 'x'.repeat(101) },
+    { recipientEmail: 'recipient@example.com', message: 'x'.repeat(501) },
+    Object.assign(Object.create({}), { recipientEmail: 'recipient@example.com' }),
+  ])('rejects malformed, oversized, or extra-key input', (value) => {
+    expect(() => parseGiftCardCustomization(value)).toThrow(
+      GiftCardCustomizationValidationError,
+    );
+  });
+});

--- a/tests/unit/lib/gift-cards/domain.test.ts
+++ b/tests/unit/lib/gift-cards/domain.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { Money } from "@/lib/money";
+import {
+  assertGiftCardCodeHash,
+  assertIssueGiftCardInput,
+  assertReserveGiftCardInput,
+  giftCardIssuanceBusinessKey,
+  giftCardRedemptionBusinessKey,
+} from "@/lib/gift-cards/domain";
+
+const digest = "a".repeat(64);
+
+describe("gift-card domain", () => {
+  it("accepts only the frozen versioned code-hash identity", () => {
+    expect(() => assertGiftCardCodeHash({ keyVersion: 1, digest })).not.toThrow();
+    for (const invalid of [
+      { keyVersion: 0, digest },
+      { keyVersion: 1.5, digest },
+      { keyVersion: 1, digest: "A".repeat(64) },
+      { keyVersion: 1, digest: "g".repeat(64) },
+      { keyVersion: 1, digest: "a".repeat(63) },
+    ]) {
+      expect(() => assertGiftCardCodeHash(invalid)).toThrow();
+    }
+  });
+
+  it("requires positive safe Money and exact issuance attribution", () => {
+    expect(() => assertIssueGiftCardInput({
+      id: "gift_one",
+      codeHash: { keyVersion: 1, digest },
+      amount: Money.fromMinor(2_500, "USD"),
+      issuedOrderId: "order_one",
+      issuedLineId: "line_one",
+      createdAt: 1_800_000_000,
+    })).not.toThrow();
+    expect(() => assertIssueGiftCardInput({
+      id: "gift_one",
+      codeHash: { keyVersion: 1, digest },
+      amount: Money.zero("USD"),
+      createdAt: 1_800_000_000,
+    })).toThrow("positive");
+    expect(() => assertIssueGiftCardInput({
+      id: "gift_one",
+      codeHash: { keyVersion: 1, digest },
+      amount: Money.fromMinor(2_500, "USD"),
+      issuedOrderId: "order_one",
+      createdAt: 1_800_000_000,
+    })).toThrow("together");
+  });
+
+  it("binds reservation identity to an exact request, quote, amount, and lease", () => {
+    expect(() => assertReserveGiftCardInput({
+      id: "reservation_one",
+      giftCardId: "gift_one",
+      requestKey: "checkout-request-one",
+      quoteFingerprint: "b".repeat(64),
+      requestedAmount: Money.fromMinor(1_000, "USD"),
+      reservedAt: 100,
+      expiresAt: 200,
+    })).not.toThrow();
+    expect(() => assertReserveGiftCardInput({
+      id: "reservation_one",
+      giftCardId: "gift_one",
+      requestKey: "checkout-request-one",
+      quoteFingerprint: "b".repeat(64),
+      requestedAmount: Money.fromMinor(1_000, "USD"),
+      reservedAt: 200,
+      expiresAt: 200,
+    })).toThrow("follow");
+  });
+
+  it("derives bounded business identities without bearer material", () => {
+    expect(giftCardIssuanceBusinessKey("gift_one"))
+      .toBe("gift-card/issuance/gift_one/v1");
+    expect(giftCardRedemptionBusinessKey("reservation_one"))
+      .toBe("gift-card/redemption/reservation_one/v1");
+  });
+});

--- a/tests/unit/lib/gift-cards/encryption.test.ts
+++ b/tests/unit/lib/gift-cards/encryption.test.ts
@@ -1,0 +1,279 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  GIFT_CARD_DELIVERY_ENCRYPTION_CONTRACT_VERSION,
+  GIFT_CARD_DELIVERY_KEY_BYTES,
+  GIFT_CARD_DELIVERY_NONCE_BYTES,
+  MAX_GIFT_CARD_DELIVERY_KEY_VERSIONS,
+  GiftCardDecryptionError,
+  GiftCardEncryptionConfigurationError,
+  GiftCardEncryptionError,
+  GiftCardEncryptionInputError,
+  decryptGiftCardDeliveryCode,
+  encryptGiftCardDeliveryCode,
+  type EncryptedGiftCardDeliveryCode,
+  type GiftCardEncryptionKeyRing,
+} from "@/lib/gift-cards/encryption";
+
+const CODE = "GC-2345-6789-ABCD-EFGH-JKLM-NPQR-STUV";
+const GIFT_CARD_ID = "gift_card_01JABC";
+const DELIVERY_ID = "delivery:01JXYZ";
+const KEY_1 = Uint8Array.from({ length: 32 }, (_, index) => index);
+const KEY_2 = Uint8Array.from({ length: 32 }, (_, index) => 255 - index);
+const KEY_1_BASE64 = "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=";
+
+function ring(overrides: Partial<GiftCardEncryptionKeyRing> = {}): GiftCardEncryptionKeyRing {
+  return {
+    currentVersion: 2,
+    keys: { 1: KEY_1, 2: KEY_2 },
+    ...overrides,
+  };
+}
+
+function deterministicRandom(target: Uint8Array): void {
+  target.forEach((_, index) => { target[index] = index; });
+}
+
+async function encrypted(
+  overrides: Partial<Parameters<typeof encryptGiftCardDeliveryCode>[0]> = {},
+): Promise<EncryptedGiftCardDeliveryCode> {
+  return encryptGiftCardDeliveryCode({
+    code: CODE,
+    giftCardId: GIFT_CARD_ID,
+    deliveryId: DELIVERY_ID,
+    keyRing: ring(),
+    randomFill: deterministicRandom,
+    ...overrides,
+  });
+}
+
+function fixedDecryptionError(error: unknown): void {
+  expect(error).toBeInstanceOf(GiftCardDecryptionError);
+  expect(error).toMatchObject({ message: "Gift-card delivery code could not be decrypted" });
+  expect(String(error)).not.toContain(CODE);
+  expect(String(error)).not.toContain(KEY_1_BASE64);
+}
+
+describe("gift-card delivery encryption", () => {
+  it("freezes the Workers-compatible AES-256-GCM wire contract", async () => {
+    expect(GIFT_CARD_DELIVERY_ENCRYPTION_CONTRACT_VERSION).toBe(1);
+    expect(GIFT_CARD_DELIVERY_KEY_BYTES).toBe(32);
+    expect(GIFT_CARD_DELIVERY_NONCE_BYTES).toBe(12);
+    expect(MAX_GIFT_CARD_DELIVERY_KEY_VERSIONS).toBe(4);
+
+    const result = await encrypted({
+      keyRing: { currentVersion: 1, keys: { 1: `base64:${KEY_1_BASE64}` } },
+    });
+
+    expect(result).toEqual({
+      keyVersion: 1,
+      nonce: "AAECAwQFBgcICQoL",
+      ciphertext: "AEH7KfbR9za7dq+ynKg6Lsf7wnK3M3I2cyuoqFM5UeAsQ/qp+bTs7joq6camMJtRdiKOhME=",
+    });
+    expect(Object.isFrozen(result)).toBe(true);
+    expect(JSON.stringify(result)).not.toContain(CODE);
+    expect(Object.keys(result).sort()).toEqual(["ciphertext", "keyVersion", "nonce"]);
+  });
+
+  it("round trips only through the matching gift-card and delivery AAD", async () => {
+    const value = await encrypted();
+    await expect(decryptGiftCardDeliveryCode({
+      encrypted: value,
+      giftCardId: GIFT_CARD_ID,
+      deliveryId: DELIVERY_ID,
+      keyRing: ring(),
+    })).resolves.toBe(CODE);
+
+    for (const aad of [
+      { giftCardId: "gift_card_other", deliveryId: DELIVERY_ID },
+      { giftCardId: GIFT_CARD_ID, deliveryId: "delivery_other" },
+    ]) {
+      await expect(decryptGiftCardDeliveryCode({ encrypted: value, keyRing: ring(), ...aad }))
+        .rejects.toSatisfy((error: unknown) => {
+          fixedDecryptionError(error);
+          return true;
+        });
+    }
+  });
+
+  it("uses a fresh 96-bit Web Crypto nonce by default", async () => {
+    const getRandomValues = vi.spyOn(crypto, "getRandomValues");
+    const first = await encrypted({ randomFill: undefined });
+    const second = await encrypted({ randomFill: undefined });
+    expect(getRandomValues).toHaveBeenCalledTimes(2);
+    expect(first.nonce).not.toBe(second.nonce);
+    expect(first.ciphertext).not.toBe(second.ciphertext);
+    getRandomValues.mockRestore();
+  });
+
+  it("encrypts with the current key and decrypts retained historical versions", async () => {
+    const old = await encrypted({ keyRing: { currentVersion: 1, keys: { 1: KEY_1 } } });
+    expect(old.keyVersion).toBe(1);
+    await expect(decryptGiftCardDeliveryCode({
+      encrypted: old,
+      giftCardId: GIFT_CARD_ID,
+      deliveryId: DELIVERY_ID,
+      keyRing: ring(),
+    })).resolves.toBe(CODE);
+
+    const current = await encrypted();
+    expect(current.keyVersion).toBe(2);
+    await expect(decryptGiftCardDeliveryCode({
+      encrypted: old,
+      giftCardId: GIFT_CARD_ID,
+      deliveryId: DELIVERY_ID,
+      keyRing: { currentVersion: 2, keys: { 2: KEY_2 } },
+    })).rejects.toBeInstanceOf(GiftCardDecryptionError);
+  });
+
+  it("accepts only exact canonical code and bounded ASCII AAD identifiers", async () => {
+    const invalidIds = ["", " leading", "trailing ", "two words", "ümlaut", "nul\0id", "x".repeat(129)];
+    await expect(encrypted({ code: CODE.toLowerCase() })).rejects.toBeInstanceOf(GiftCardEncryptionInputError);
+    for (const id of invalidIds) {
+      await expect(encrypted({ giftCardId: id })).rejects.toMatchObject({
+        message: "Gift-card delivery encryption input is invalid",
+      });
+      await expect(encrypted({ deliveryId: id })).rejects.toBeInstanceOf(GiftCardEncryptionInputError);
+    }
+  });
+
+  it("masks entropy and provider crypto failures without exposing plaintext", async () => {
+    const secretFailure = `provider failed for ${CODE} ${KEY_1_BASE64}`;
+    try {
+      await encrypted({ randomFill() { throw new Error(secretFailure); } });
+      expect.fail("expected encryption to fail");
+    } catch (error) {
+      expect(error).toBeInstanceOf(GiftCardEncryptionError);
+      expect(error).toMatchObject({ message: "Gift-card delivery code could not be encrypted" });
+      expect(String(error)).not.toContain(CODE);
+      expect(String(error)).not.toContain(KEY_1_BASE64);
+    }
+  });
+
+  it("copies caller-owned key bytes before zeroizing local material", async () => {
+    const callerKey = Uint8Array.from(KEY_1);
+    const before = Uint8Array.from(callerKey);
+    await encrypted({ keyRing: { currentVersion: 1, keys: { 1: callerKey } } });
+    expect(callerKey).toEqual(before);
+  });
+});
+
+describe("gift-card delivery decryption validation", () => {
+  it("fails closed for tampering, wrong keys, and payload relocation", async () => {
+    const value = await encrypted();
+    const tamperedCiphertext = `${value.ciphertext.slice(0, -2)}A=`;
+    const cases: Array<{ payload: unknown; keyRing?: GiftCardEncryptionKeyRing }> = [
+      { payload: { ...value, nonce: "AQECAwQFBgcICQoL" } },
+      { payload: { ...value, ciphertext: tamperedCiphertext } },
+      { payload: { ...value, keyVersion: 1 } },
+      { payload: value, keyRing: { currentVersion: 2, keys: { 2: KEY_1 } } },
+    ];
+    for (const testCase of cases) {
+      try {
+        await decryptGiftCardDeliveryCode({
+          encrypted: testCase.payload,
+          giftCardId: GIFT_CARD_ID,
+          deliveryId: DELIVERY_ID,
+          keyRing: testCase.keyRing ?? ring(),
+        });
+        expect.fail("expected decryption to fail");
+      } catch (error) {
+        fixedDecryptionError(error);
+      }
+    }
+  });
+
+  it.each([
+    null,
+    [],
+    {},
+    { keyVersion: 2, nonce: "AAECAwQFBgcICQoL" },
+    { keyVersion: 2, nonce: "AAECAwQFBgcICQoL", ciphertext: "AAAA", extra: true },
+    { keyVersion: 0, nonce: "AAECAwQFBgcICQoL", ciphertext: "A".repeat(72) },
+    { keyVersion: 1.5, nonce: "AAECAwQFBgcICQoL", ciphertext: "A".repeat(72) },
+    { keyVersion: "2", nonce: "AAECAwQFBgcICQoL", ciphertext: "A".repeat(72) },
+    { keyVersion: 2, nonce: "AAECAwQFBgcICQo", ciphertext: "A".repeat(72) },
+    { keyVersion: 2, nonce: "AAECAwQFBgcICQo_", ciphertext: "A".repeat(72) },
+    { keyVersion: 2, nonce: "AAAA", ciphertext: "A".repeat(72) },
+    { keyVersion: 2, nonce: "AAECAwQFBgcICQoL", ciphertext: "AAAA" },
+    { keyVersion: 2, nonce: "AAECAwQFBgcICQoL", ciphertext: "A".repeat(76) },
+  ])("rejects malformed payloads with a fixed redacted error: %j", async (payload) => {
+    await expect(decryptGiftCardDeliveryCode({
+      encrypted: payload,
+      giftCardId: GIFT_CARD_ID,
+      deliveryId: DELIVERY_ID,
+      keyRing: ring(),
+    })).rejects.toMatchObject({ message: "Gift-card delivery code could not be decrypted" });
+  });
+
+  it("rejects accessors, symbols, and duplicate proxy keys without evaluating data", async () => {
+    let getterCalled = false;
+    const accessorPayload = {
+      keyVersion: 2,
+      nonce: "AAECAwQFBgcICQoL",
+      get ciphertext() {
+        getterCalled = true;
+        return CODE;
+      },
+    };
+    const symbolPayload = { ...(await encrypted()), [Symbol("secret")]: CODE };
+    const duplicatePayload = new Proxy({}, {
+      ownKeys: () => ["keyVersion", "nonce", "nonce", "ciphertext"],
+    });
+    for (const payload of [accessorPayload, symbolPayload, duplicatePayload]) {
+      await expect(decryptGiftCardDeliveryCode({
+        encrypted: payload,
+        giftCardId: GIFT_CARD_ID,
+        deliveryId: DELIVERY_ID,
+        keyRing: ring(),
+      })).rejects.toBeInstanceOf(GiftCardDecryptionError);
+    }
+    expect(getterCalled).toBe(false);
+  });
+});
+
+describe("gift-card delivery encryption key configuration", () => {
+  it.each([
+    { currentVersion: 0, keys: { 1: KEY_1 } },
+    { currentVersion: 1.5, keys: { 1: KEY_1 } },
+    { currentVersion: 2, keys: { 1: KEY_1 } },
+    { currentVersion: 1, keys: {} },
+    { currentVersion: 1, keys: { 1: new Uint8Array(31) } },
+    { currentVersion: 1, keys: { 1: new Uint8Array(33) } },
+    { currentVersion: 1, keys: { 1: KEY_1_BASE64 } },
+    { currentVersion: 1, keys: { 1: "base64:AAAA" } },
+    { currentVersion: 1, keys: { "01": KEY_1 } },
+    { currentVersion: 1, keys: { 1: KEY_1, 2: KEY_1, 3: KEY_1, 4: KEY_1, 5: KEY_1 } },
+  ])("rejects a missing, malformed, noncanonical, or oversized key ring: %j", async (keyRing) => {
+    await expect(encrypted({ keyRing: keyRing as GiftCardEncryptionKeyRing }))
+      .rejects.toBeInstanceOf(GiftCardEncryptionConfigurationError);
+  });
+
+  it("rejects key accessors, symbols, and duplicate version properties", async () => {
+    let getterCalled = false;
+    const accessorKeys = Object.defineProperty({}, "1", {
+      enumerable: true,
+      get() {
+        getterCalled = true;
+        return KEY_1;
+      },
+    });
+    const symbolKeys = { 1: KEY_1, [Symbol("version")]: KEY_2 };
+    const duplicateKeys = new Proxy({}, {
+      ownKeys: () => ["1", "1"],
+    });
+    for (const keys of [accessorKeys, symbolKeys, duplicateKeys]) {
+      await expect(encrypted({
+        keyRing: { currentVersion: 1, keys } as GiftCardEncryptionKeyRing,
+      })).rejects.toBeInstanceOf(GiftCardEncryptionConfigurationError);
+    }
+    expect(getterCalled).toBe(false);
+  });
+
+  it("uses equivalent exact 32-byte Uint8Array and canonical base64 keys", async () => {
+    const bytesResult = await encrypted({ keyRing: { currentVersion: 1, keys: { 1: KEY_1 } } });
+    const stringResult = await encrypted({
+      keyRing: { currentVersion: 1, keys: { 1: `base64:${KEY_1_BASE64}` } },
+    });
+    expect(stringResult).toEqual(bytesResult);
+  });
+});

--- a/tests/unit/lib/gift-cards/line-identity.test.ts
+++ b/tests/unit/lib/gift-cards/line-identity.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createCartLineId,
+  normalizeCartItemForStore,
+  projectCartLineForCheckout,
+} from '@/lib/gift-cards/line-identity';
+
+const base = {
+  productId: 'product-one',
+  variantId: 'variant-2500',
+  name: '$25 Gift Card',
+  price: { amount: 2_500, currency: 'USD' },
+  quantity: 1,
+  primaryImageUrl: '',
+};
+
+describe('cart line identity', () => {
+  it('is stable for identical normalized recipient facts', () => {
+    const first = normalizeCartItemForStore({
+      ...base,
+      lineId: 'caller-controlled',
+      giftCardCustomization: { recipientEmail: 'ADA@EXAMPLE.COM' },
+    });
+    const second = normalizeCartItemForStore({
+      ...base,
+      giftCardCustomization: { recipientEmail: ' ada@example.com ' },
+    });
+
+    expect(first?.lineId).toBe(second?.lineId);
+    expect(first?.lineId).not.toBe('caller-controlled');
+  });
+
+  it('separates the same variant when canonical recipient facts differ', () => {
+    const ada = createCartLineId({
+      productId: base.productId,
+      variantId: base.variantId,
+      giftCardCustomization: { recipientEmail: 'ada@example.com' },
+    });
+    const grace = createCartLineId({
+      productId: base.productId,
+      variantId: base.variantId,
+      giftCardCustomization: { recipientEmail: 'grace@example.com' },
+    });
+
+    expect(ada).not.toBe(grace);
+  });
+
+  it('projects only authoritative IDs, quantity, and bounded customization', () => {
+    const item = normalizeCartItemForStore({
+      ...base,
+      giftCardToken: 'must-not-survive',
+      giftCardCustomization: {
+        recipientEmail: 'recipient@example.com',
+        recipientName: 'Recipient',
+      },
+    });
+    expect(item).not.toBeNull();
+
+    expect(projectCartLineForCheckout(item!)).toEqual({
+      lineId: item!.lineId,
+      productId: base.productId,
+      variantId: base.variantId,
+      quantity: 1,
+      giftCardCustomization: {
+        recipientEmail: 'recipient@example.com',
+        recipientName: 'Recipient',
+      },
+    });
+    expect(JSON.stringify(item)).not.toContain('must-not-survive');
+  });
+
+  it('fails closed for invalid quantities and malformed customization', () => {
+    expect(normalizeCartItemForStore({ ...base, quantity: 1_001 })).toBeNull();
+    expect(normalizeCartItemForStore({
+      ...base,
+      giftCardCustomization: {
+        recipientEmail: 'recipient@example.com',
+        redemptionToken: 'secret',
+      },
+    })).toBeNull();
+  });
+});

--- a/tests/unit/lib/gift-cards/runtime.test.ts
+++ b/tests/unit/lib/gift-cards/runtime.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi } from "vitest";
+import { Money } from "@/lib/money";
+import { GiftCardTenderUnavailableError } from "@/lib/gift-cards/capability";
+import { GiftCardRuntimeConfigurationError } from "@/lib/gift-cards/config";
+import {
+  createRuntimeGiftCardCapability,
+  createRuntimeGiftCardCapabilityFactory,
+} from "@/lib/gift-cards/runtime";
+import type { GiftCardReservation } from "@/lib/gift-cards/domain";
+import type { Order } from "@/lib/types/order";
+
+const token = "GC-2345-6789-ABCD-EFGH-JKLM-NPQR-STUV";
+const identity = {
+  requestKey: "checkout-request-runtime",
+  quoteFingerprint: "a".repeat(64),
+  reservedAt: 1_800_000_000,
+  expiresAt: 1_800_000_600,
+};
+
+function durableReservation(): GiftCardReservation {
+  return {
+    id: "gift_reservation_runtime",
+    giftCardId: "gift_runtime",
+    requestKey: identity.requestKey,
+    quoteFingerprint: identity.quoteFingerprint,
+    requestedAmount: Money.fromMinor(500, "USD"),
+    amount: Money.fromMinor(500, "USD"),
+    reservedAt: identity.reservedAt,
+    expiresAt: identity.expiresAt,
+  };
+}
+
+function paidOrder(): Order {
+  return {
+    id: "order_runtime",
+    status: "processing",
+    payment_status: "paid",
+    total_amount: Money.fromMinor(1_000, "USD").toJSON(),
+    currency_code: "USD",
+    items: [],
+    extensions: { checkout_tender: Money.fromMinor(500, "USD").toJSON() },
+  };
+}
+
+describe("gift-card request-scoped runtime", () => {
+  it("does not resolve bindings or secrets while its factory and no-token path are idle", async () => {
+    const getEnvironment = vi.fn(async () => { throw new Error("must stay lazy"); });
+    const factory = createRuntimeGiftCardCapabilityFactory({ getEnvironment });
+    expect(getEnvironment).not.toHaveBeenCalled();
+    const capability = factory();
+    expect(getEnvironment).not.toHaveBeenCalled();
+    await expect(capability.resolveTender({
+      currency: "USD",
+      amountDue: Money.fromMinor(500, "USD"),
+    })).resolves.toEqual({ amount: Money.zero("USD") });
+    expect(getEnvironment).not.toHaveBeenCalled();
+  });
+
+  it("re-reads and re-parses the server key ring for each bearer request", async () => {
+    let environment: Record<string, unknown> = {
+      DB: {} as D1Database,
+      GIFT_CARD_CODE_HMAC_CURRENT_VERSION: "1",
+      GIFT_CARD_CODE_HMAC_KEYS_JSON: JSON.stringify({
+        1: "current-gift-card-hmac-key-material-0001",
+      }),
+    };
+    const getEnvironment = vi.fn(async () => environment);
+    const repository = {
+      findAccountByCodeHash: vi.fn(async () => undefined),
+      reserve: vi.fn(),
+      commitReservation: vi.fn(),
+      settleReservation: vi.fn(),
+      releaseReservation: vi.fn(),
+    };
+    const capability = createRuntimeGiftCardCapability({
+      getEnvironment,
+      repositoryFactory: vi.fn(() => repository) as never,
+    });
+    await expect(capability.resolveTender({
+      token,
+      currency: "USD",
+      amountDue: Money.fromMinor(500, "USD"),
+      requestIdentity: identity,
+    })).rejects.toBeInstanceOf(GiftCardTenderUnavailableError);
+
+    environment = {
+      ...environment,
+      GIFT_CARD_CODE_HMAC_KEYS_JSON: "not-json",
+    };
+    await expect(capability.resolveTender({
+      token,
+      currency: "USD",
+      amountDue: Money.fromMinor(500, "USD"),
+      requestIdentity: identity,
+    })).rejects.toBeInstanceOf(GiftCardRuntimeConfigurationError);
+    expect(getEnvironment).toHaveBeenCalledTimes(2);
+  });
+
+  it("reconciles an existing reservation without parsing acquisition keys", async () => {
+    const reservation = durableReservation();
+    const repository = {
+      findAccountByCodeHash: vi.fn(),
+      reserve: vi.fn(),
+      commitReservation: vi.fn(async () => reservation),
+      settleReservation: vi.fn(),
+      releaseReservation: vi.fn(),
+    };
+    const getEnvironment = vi.fn(async () => ({ DB: {} as D1Database }));
+    const capability = createRuntimeGiftCardCapability({
+      getEnvironment,
+      repositoryFactory: vi.fn(() => repository) as never,
+      now: () => identity.reservedAt + 10,
+    });
+    await expect(capability.verifyReservedTender({
+      order: paidOrder(),
+      state: { v: 1, reservationId: reservation.id },
+      expectedTender: reservation.amount,
+    })).resolves.toBeUndefined();
+    expect(repository.commitReservation).toHaveBeenCalledOnce();
+    expect(getEnvironment).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/unit/lib/mcp/mcp-checkout.test.ts
+++ b/tests/unit/lib/mcp/mcp-checkout.test.ts
@@ -5,6 +5,8 @@ const mocks = vi.hoisted(() => ({
   assertInventory: vi.fn(),
   createPaymentIntent: vi.fn(),
   cancelPaymentIntent: vi.fn(),
+  finalizeZeroCash: vi.fn(),
+  capabilities: { giftCards: {}, subscriptions: {} },
   inserted: undefined as Record<string, unknown> | undefined,
   insertError: undefined as Error | undefined,
 }));
@@ -19,6 +21,12 @@ vi.mock('@/lib/services/inventory-adjustments', () => ({
 vi.mock('@/lib/stripe', () => ({
   createPaymentIntent: mocks.createPaymentIntent,
   cancelPaymentIntent: mocks.cancelPaymentIntent,
+}));
+vi.mock('@/lib/commerce/runtime', () => ({
+  resolveRuntimeCommerceCapabilities: vi.fn(async () => mocks.capabilities),
+}));
+vi.mock('@/lib/services/order-finalization', () => ({
+  finalizeZeroCashGiftOrder: mocks.finalizeZeroCash,
 }));
 vi.mock('@/lib/db', () => ({
   getDbAsync: vi.fn(async () => ({
@@ -87,6 +95,9 @@ beforeEach(() => {
     client_secret: 'secret',
   });
   mocks.cancelPaymentIntent.mockResolvedValue(undefined);
+  mocks.finalizeZeroCash.mockResolvedValue({
+    paid: true, promoted: true, order: { id: 'MCP-AGENT1-123456-A1B2C3D4' },
+  });
 });
 
 describe('MCP authoritative checkout', () => {
@@ -113,7 +124,10 @@ describe('MCP authoritative checkout', () => {
     });
 
     expect(mocks.priceCheckout).toHaveBeenCalledWith(expect.objectContaining({
-      items: [{ productId: 'catalog-product', variantId: 'catalog-variant', quantity: 2 }],
+      items: [expect.objectContaining({
+        lineId: expect.stringMatching(/^line_[0-9a-f]{16}$/),
+        productId: 'catalog-product', variantId: 'catalog-variant', quantity: 2,
+      })],
     }));
     expect(mocks.inserted?.items).toEqual(quote.items);
     expect(mocks.inserted?.total_amount).toEqual({ amount: 3149, currency: 'USD' });
@@ -156,5 +170,36 @@ describe('MCP authoritative checkout', () => {
       },
     })).rejects.toThrow('D1 unavailable');
     expect(mocks.cancelPaymentIntent).toHaveBeenCalledWith('pi_mcp_1');
+  });
+
+  it('finalizes a wholly gift-funded order without creating a Stripe PaymentIntent', async () => {
+    mocks.priceCheckout.mockResolvedValue({
+      ...quote,
+      tender: money(3149),
+      total: money(0),
+      tenderState: { v: 1, reservationId: 'gift_reservation_1' },
+    });
+    const result = await createMcpCheckout({
+      agentId: 'agent-1',
+      session,
+      input: {
+        shippingAddress: {
+          line1: '1 Main', city: 'Denver', region: 'CO', postal_code: '80202', country: 'US',
+        },
+        shippingMethodId: 'standard',
+        giftCardToken: 'opaque-gift-token',
+        giftCardRequestKey: 'mcp-gift-request-1',
+      },
+    });
+    expect(mocks.createPaymentIntent).not.toHaveBeenCalled();
+    expect(mocks.finalizeZeroCash).toHaveBeenCalledWith(expect.objectContaining({
+      enforceOwnership: false,
+      capabilities: mocks.capabilities,
+    }));
+    expect(mocks.inserted).toMatchObject({
+      payment_method: 'gift_card', payment_status: 'pending', external_references: null,
+    });
+    expect(result).toMatchObject({ noCash: true, amount: { amount: 0, currency: 'USD' } });
+    expect(result.paymentIntentId).toBeUndefined();
   });
 });

--- a/tests/unit/lib/mcp/mcp-place-order.test.ts
+++ b/tests/unit/lib/mcp/mcp-place-order.test.ts
@@ -4,7 +4,10 @@ const mocks = vi.hoisted(() => ({
   requireOwnedSession: vi.fn(),
   getBinding: vi.fn(),
   getOwnedOrder: vi.fn(),
+  getZeroCash: vi.fn(),
   finalize: vi.fn(),
+  finalizeZeroCash: vi.fn(),
+  capabilities: { giftCards: {}, subscriptions: {} },
   buildDelivery: vi.fn(),
 }));
 
@@ -12,11 +15,19 @@ vi.mock('@/lib/mcp/session', () => ({ requireOwnedSession: mocks.requireOwnedSes
 vi.mock('@/lib/mcp/checkout', () => ({
   getOwnedMcpOrderBinding: mocks.getBinding,
   getOwnedMcpOrder: mocks.getOwnedOrder,
+  getOwnedMcpZeroCashOrder: mocks.getZeroCash,
 }));
 vi.mock('@/lib/services/order-finalization', () => {
   class PaymentVerificationError extends Error {}
-  return { finalizeOrderPayment: mocks.finalize, PaymentVerificationError };
+  return {
+    finalizeOrderPayment: mocks.finalize,
+    finalizeZeroCashGiftOrder: mocks.finalizeZeroCash,
+    PaymentVerificationError,
+  };
 });
+vi.mock('@/lib/commerce/runtime', () => ({
+  resolveRuntimeCommerceCapabilities: vi.fn(async () => mocks.capabilities),
+}));
 vi.mock('@/lib/mcp/order-delivery', () => ({
   buildMcpOrderDelivery: mocks.buildDelivery,
 }));
@@ -43,6 +54,8 @@ beforeEach(() => {
   });
   mocks.getBinding.mockResolvedValue(paidOrder);
   mocks.finalize.mockResolvedValue({ paid: true, promoted: true, order: paidOrder });
+  mocks.getZeroCash.mockResolvedValue(paidOrder);
+  mocks.finalizeZeroCash.mockResolvedValue({ paid: true, promoted: false, order: paidOrder });
   mocks.buildDelivery.mockResolvedValue({
     shipment: {
       carrier: 'ups',
@@ -88,6 +101,18 @@ describe('MCP order finalization', () => {
     }, 'session-1', 'attacker');
     expect(result.error?.code).toBe('PAYMENT_NOT_BOUND');
     expect(mocks.finalize).not.toHaveBeenCalled();
+  });
+
+  it('accepts no PaymentIntent only for its owned zero-cash gift-funded order', async () => {
+    const result = await placeOrder({ orderId: paidOrder.id }, 'session-1', 'agent-1');
+    expect(mocks.getZeroCash).toHaveBeenCalledWith({
+      orderId: paidOrder.id, agentId: 'agent-1', sessionId: 'session-1',
+    });
+    expect(mocks.finalizeZeroCash).toHaveBeenCalledWith(expect.objectContaining({
+      orderId: paidOrder.id, capabilities: mocks.capabilities,
+    }));
+    expect(mocks.finalize).not.toHaveBeenCalled();
+    expect(result.success).toBe(true);
   });
 
   it('does not reveal orders belonging to another agent', async () => {

--- a/tests/unit/lib/payments/refund-ledger.test.ts
+++ b/tests/unit/lib/payments/refund-ledger.test.ts
@@ -112,6 +112,27 @@ describe('refund ledger decisions', () => {
     });
   });
 
+  it('accepts a completed zero-cash refund only after its gift restoration is recorded', async () => {
+    const key = await deriveRefundIdempotencyKey({
+      orderId: 'order-1', type: 'partial', refundAmount: 250,
+      settledSequence: 0, lineIds: ['line-1'],
+    });
+    const fingerprint = await deriveRefundRequestFingerprint({
+      orderId: 'order-1', type: 'partial', refundAmount: 250, lineIds: ['line-1'],
+    });
+    const entry = {
+      amount: 250, status: 'succeeded', type: 'partial' as const, items: ['line-1'],
+      settled_sequence: 0, idempotency_key: key, request_fingerprint: fingerprint,
+      cash_amount: 0, gift_amount: 250, provider_status: 'not_applicable',
+    };
+    await expect(decideRefundLedgerAction([entry], {
+      orderId: 'order-1', type: 'partial', amount: 250, lineIds: ['line-1'], totalAmount: 1_000,
+    })).resolves.toMatchObject({ action: 'reject', status: 409 });
+    await expect(decideRefundLedgerAction([{ ...entry, gift_restoration_status: 'succeeded' }], {
+      orderId: 'order-1', type: 'partial', amount: 250, lineIds: ['line-1'], totalAmount: 1_000,
+    })).resolves.toMatchObject({ action: 'completed', idempotencyKey: key });
+  });
+
   it('rejects a new reservation at the record bound and any provider-floor divergence', async () => {
     const full = Array.from({ length: 100 }, (_, index) => ({
       amount: 1,

--- a/tests/unit/lib/payments/refund-tender.test.ts
+++ b/tests/unit/lib/payments/refund-tender.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { allocateRefundTender } from '@/lib/payments/refund-tender';
+
+describe('mixed-tender refund allocation', () => {
+  it('allocates cash first, then restores gift value without rounding drift', () => {
+    expect(allocateRefundTender({
+      refundAmount: 700, cashPaid: 600, giftTender: 400, refundedCash: 0, restoredGift: 0,
+    })).toEqual({ cashAmount: 600, giftAmount: 100 });
+    expect(allocateRefundTender({
+      refundAmount: 300, cashPaid: 600, giftTender: 400, refundedCash: 600, restoredGift: 100,
+    })).toEqual({ cashAmount: 0, giftAmount: 300 });
+  });
+
+  it('rejects allocations that would exceed an original tender or remaining balance', () => {
+    expect(() => allocateRefundTender({
+      refundAmount: 1, cashPaid: 100, giftTender: 0, refundedCash: 101, restoredGift: 0,
+    })).toThrow(RangeError);
+    expect(() => allocateRefundTender({
+      refundAmount: 101, cashPaid: 100, giftTender: 0, refundedCash: 0, restoredGift: 0,
+    })).toThrow(RangeError);
+  });
+});

--- a/tests/unit/lib/services/checkout-pricing.test.ts
+++ b/tests/unit/lib/services/checkout-pricing.test.ts
@@ -139,6 +139,101 @@ describe('server-authoritative checkout pricing', () => {
     expect(resolveTender).toHaveBeenCalledOnce();
   });
 
+  it('never lets a promotion discount a gift-card line below face value', async () => {
+    const deps = dependencies({
+      getProduct: vi.fn(async (id: string) => id === 'gift_product'
+        ? {
+            id, name: 'Gift card', type: 'gift_card', fulfillment_type: 'digital',
+            status: 'active', tax_category: 'txcd_99999999', default_variant_id: 'gift_variant',
+          }
+        : {
+            id, name: id, status: 'active', categories: ['other'],
+            tax_category: 'txcd_99999999', default_variant_id: 'var_other',
+          }),
+      getProductVariant: vi.fn(async (id: string) => id === 'gift_variant'
+        ? {
+            id, product_id: 'gift_product', sku: 'GIFT', status: 'active',
+            option_values: [], shipping_required: false, price: Money.fromMinor(2_500).toJSON(),
+          }
+        : {
+            id, product_id: 'prod_other', sku: 'OTHER', status: 'active',
+            option_values: [], price: Money.fromMinor(2_000).toJSON(),
+          }),
+      validateCouponCode: vi.fn(async () => ({
+        canBeUsed: true,
+        coupon: { promotion_id: 'promo_half', code: 'HALF' },
+      })),
+      getPromotionById: vi.fn(async () => ({
+        id: 'promo_half',
+        name: 'Half off',
+        type: 'cart',
+        status: 'active',
+        stackable: true,
+        rules: { actions: [{ type: 'percentage_discount', value: 50 }] },
+      })),
+    });
+
+    const quote = await priceCheckout({
+      items: [
+        {
+          lineId: 'line_0123456789abcdef', productId: 'gift_product', variantId: 'gift_variant', quantity: 1,
+          giftCardCustomization: { recipientEmail: 'recipient@example.test' },
+        },
+        { productId: 'prod_other', variantId: 'var_other', quantity: 1 },
+      ],
+      shippingAddress: address,
+      shippingMethodId: 'standard',
+      discountCodes: ['HALF'],
+    }, { dependencies: deps as any });
+
+    // The gift-card line keeps its full $25 face value; only the $20 merchandise
+    // line is discounted (50% => $10). Issuance credits unit_price, so any gift
+    // discount would hand out free stored value.
+    expect(quote.lineAllocations[0]).toMatchObject({
+      lineId: quote.items[0].id,
+      merchandiseDiscount: { amount: 0, currency: 'USD' },
+      promotionCodes: [],
+    });
+    expect(quote.lineAllocations[1]).toMatchObject({
+      lineId: quote.items[1].id,
+      merchandiseDiscount: { amount: 1_000, currency: 'USD' },
+      promotionCodes: ['HALF'],
+    });
+  });
+
+  it('rejects gift-card tender that exceeds the non-gift eligible amount', async () => {
+    // An all-gift cart has zero tender-eligible value. A capability returning a
+    // positive tender would let stored value fund the gift-card purchase.
+    const resolveTender = vi.fn(async ({ currency }: { currency: string }) => ({
+      amount: Money.fromMinor(2_500, currency),
+    }));
+    await expect(priceCheckout({
+      items: [{
+        lineId: 'line_0123456789abcdef', productId: 'gift_product', variantId: 'gift_variant', quantity: 1,
+        giftCardCustomization: { recipientEmail: 'recipient@example.test' },
+      }],
+      shippingAddress: address,
+      shippingMethodId: '',
+      giftCardToken: 'GC-2345-2345-2345-2345-2345-2345-2345',
+      giftCardRequestKey: 'checkout-gift-1',
+    }, {
+      dependencies: dependencies({
+        getProduct: vi.fn(async () => ({
+          id: 'gift_product', name: 'Gift card', type: 'gift_card', fulfillment_type: 'digital',
+          status: 'active', tax_category: 'txcd_99999999', default_variant_id: 'gift_variant',
+        })),
+        getProductVariant: vi.fn(async () => ({
+          id: 'gift_variant', product_id: 'gift_product', sku: 'GIFT', status: 'active',
+          option_values: [], shipping_required: false, price: Money.fromMinor(2_500).toJSON(),
+        })),
+      }) as any,
+      capabilities: {
+        giftCards: { resolveTender, verifyReservedTender: vi.fn(), applyTender: vi.fn() },
+        subscriptions: { orderPaid: vi.fn() },
+      },
+    })).rejects.toThrow('invalid amount');
+  });
+
   it('rejects recipient metadata on a non-gift digital product', async () => {
     await expect(priceCheckout({
       items: [{

--- a/tests/unit/lib/services/checkout-pricing.test.ts
+++ b/tests/unit/lib/services/checkout-pricing.test.ts
@@ -99,6 +99,66 @@ describe('server-authoritative checkout pricing', () => {
     expect(orderPaid).not.toHaveBeenCalled();
   });
 
+  it('snapshots a digital gift-card line without shipping and excludes its value from tender', async () => {
+    const resolveTender = vi.fn(async ({ currency, amountDue }: { currency: string; amountDue: Money }) => {
+      expect(amountDue).toEqual(Money.zero(currency));
+      return { amount: Money.zero(currency) };
+    });
+    const quote = await priceCheckout({
+      items: [{
+        lineId: 'line_0123456789abcdef', productId: 'gift_product', variantId: 'gift_variant', quantity: 1,
+        giftCardCustomization: { recipientEmail: 'recipient@example.test', recipientName: 'Recipient' },
+      }],
+      shippingAddress: address,
+      shippingMethodId: '',
+      giftCardToken: 'GC-2345-2345-2345-2345-2345-2345-2345',
+      giftCardRequestKey: 'checkout-gift-1',
+    }, {
+      dependencies: dependencies({
+        getProduct: vi.fn(async () => ({
+          id: 'gift_product', name: 'Gift card', type: 'gift_card', fulfillment_type: 'digital',
+          status: 'active', tax_category: 'txcd_99999999', default_variant_id: 'gift_variant',
+        })),
+        getProductVariant: vi.fn(async () => ({
+          id: 'gift_variant', product_id: 'gift_product', sku: 'GIFT', status: 'active',
+          option_values: [], shipping_required: false, price: Money.fromMinor(2_500).toJSON(),
+        })),
+      }) as any,
+      capabilities: {
+        giftCards: { resolveTender, verifyReservedTender: vi.fn(), applyTender: vi.fn() },
+        subscriptions: { orderPaid: vi.fn() },
+      },
+    });
+
+    expect(quote.shipping).toEqual({ amount: 0, currency: 'USD' });
+    expect(quote.shippingMethod).toEqual({ id: 'digital', label: 'Digital delivery' });
+    expect(quote.items[0]).toMatchObject({
+      id: 'line_0123456789abcdef', fulfillment_type: 'digital',
+      gift_card: { recipientEmail: 'recipient@example.test' },
+    });
+    expect(resolveTender).toHaveBeenCalledOnce();
+  });
+
+  it('rejects recipient metadata on a non-gift digital product', async () => {
+    await expect(priceCheckout({
+      items: [{
+        productId: 'download', variantId: 'download_variant', quantity: 1,
+        giftCardCustomization: { recipientEmail: 'recipient@example.test' },
+      }],
+      shippingAddress: address,
+      shippingMethodId: '',
+    }, { dependencies: dependencies({
+      getProduct: vi.fn(async () => ({
+        id: 'download', name: 'Download', fulfillment_type: 'digital', status: 'active',
+        tax_category: 'txcd_99999999', default_variant_id: 'download_variant',
+      })),
+      getProductVariant: vi.fn(async () => ({
+        id: 'download_variant', product_id: 'download', sku: 'DL', status: 'active',
+        option_values: [], shipping_required: false, price: Money.fromMinor(500).toJSON(),
+      })),
+    }) as any })).rejects.toThrow('gift-card catalog items');
+  });
+
   it('uses the shared enabled shipping defaults on a fresh install', async () => {
     const quote = await priceCheckout({
       items: [{ productId: 'prod_1', variantId: 'var_1', quantity: 1 }],

--- a/tests/unit/lib/store-config.test.ts
+++ b/tests/unit/lib/store-config.test.ts
@@ -42,17 +42,21 @@ describe("resolveStoreConfig", () => {
   it("keeps optional money capabilities off unless explicitly enabled", () => {
     expect(resolveStoreConfig({}).commerce.features).toEqual({
       recommendations: true,
-      giftCards: false,
+      giftCardAcquisition: false,
+      giftCardReconciliation: false,
       subscriptionAcquisition: false,
       subscriptionReconciliation: false,
     });
     expect(resolveStoreConfig({
       STORE_FEATURE_RECOMMENDATIONS: "false",
+      STORE_FEATURE_GIFT_CARD_ACQUISITION: "true",
+      STORE_FEATURE_GIFT_CARD_RECONCILIATION: "true",
       STORE_FEATURE_SUBSCRIPTION_ACQUISITION: "true",
       STORE_FEATURE_SUBSCRIPTION_RECONCILIATION: "true",
     }).commerce.features).toEqual({
       recommendations: false,
-      giftCards: false,
+      giftCardAcquisition: true,
+      giftCardReconciliation: true,
       subscriptionAcquisition: true,
       subscriptionReconciliation: true,
     });

--- a/tests/unit/lib/stores/cart-store-lines.test.ts
+++ b/tests/unit/lib/stores/cart-store-lines.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { migrateCartState, useCartStore } from '@/lib/stores/cart-store';
+import type { StableCartItem } from '@/lib/types/cartitem';
+
+const base = {
+  productId: 'product-one',
+  variantId: 'variant-2500',
+  name: '$25 Gift Card',
+  price: { amount: 2_500, currency: 'USD' },
+  quantity: 1,
+  primaryImageUrl: '',
+};
+
+describe('stable cart lines', () => {
+  afterEach(() => useCartStore.setState({ items: [] }));
+
+  it('merges identical facts and separates different recipients', () => {
+    const addItem = useCartStore.getState().addItem;
+    addItem({
+      ...base,
+      giftCardCustomization: { recipientEmail: 'ada@example.com' },
+    });
+    addItem({
+      ...base,
+      giftCardCustomization: { recipientEmail: ' ADA@example.com ' },
+    });
+    addItem({
+      ...base,
+      giftCardCustomization: { recipientEmail: 'grace@example.com' },
+    });
+
+    const items = useCartStore.getState().items;
+    expect(items).toHaveLength(2);
+    expect(items.map((item) => item.quantity)).toEqual([2, 1]);
+    expect(new Set(items.map((item) => item.lineId)).size).toBe(2);
+  });
+
+  it('updates and removes only the addressed stable line', () => {
+    const store = useCartStore.getState();
+    store.addItem({ ...base, giftCardCustomization: { recipientEmail: 'ada@example.com' } });
+    store.addItem({ ...base, giftCardCustomization: { recipientEmail: 'grace@example.com' } });
+    const [ada, grace] = useCartStore.getState().items;
+
+    useCartStore.getState().updateQuantity(grace.lineId, 4);
+    expect(useCartStore.getState().items.map((item) => item.quantity)).toEqual([1, 4]);
+    useCartStore.getState().removeItem(ada.lineId);
+    expect(useCartStore.getState().items).toEqual([
+      expect.objectContaining({ lineId: grace.lineId, quantity: 4 }),
+    ]);
+  });
+
+  it('deterministically migrates legacy lines and strips non-cart secrets', () => {
+    const legacy = {
+      items: [
+        { ...base, price: 25, giftCardToken: 'must-not-survive' },
+        { ...base, price: 25 },
+        {
+          ...base,
+          price: 25,
+          giftCardCustomization: {
+            recipientEmail: 'recipient@example.com',
+            code: 'must-not-survive',
+          },
+        },
+      ],
+    };
+
+    const first = migrateCartState(legacy) as { items: StableCartItem[] };
+    const second = migrateCartState(legacy) as { items: StableCartItem[] };
+    expect(first.items).toHaveLength(1);
+    expect(first.items[0]).toMatchObject({ quantity: 2, price: { amount: 2_500, currency: 'USD' } });
+    expect(first.items[0].lineId).toBe(second.items[0].lineId);
+    expect(JSON.stringify(first)).not.toContain('must-not-survive');
+  });
+
+  it('preserves ordinary one-time cart merging behavior', () => {
+    useCartStore.getState().addItem(base);
+    useCartStore.getState().addItem(base);
+    expect(useCartStore.getState().items).toEqual([
+      expect.objectContaining({ variantId: base.variantId, quantity: 2 }),
+    ]);
+  });
+});

--- a/tests/unit/migrations/gift-cards-foundation.test.ts
+++ b/tests/unit/migrations/gift-cards-foundation.test.ts
@@ -32,10 +32,30 @@ describe("gift-card foundation migration", () => {
     expect(sql).toContain("gift_card_ledger_balance_guard");
     expect(sql).toContain("gift_card_ledger_issuance_guard");
     expect(sql).toContain("gift_card_ledger_redemption_guard");
+    expect(sql).toContain("gift_card_ledger_restoration_guard");
+    expect(sql).toContain("gift_card_ledger_append_only_update");
+    expect(sql).toContain("gift_card_ledger_append_only_delete");
     expect(sql).toContain("gift_card_reservations_balance_guard");
     expect(sql).toContain("SUM(entry.amount_delta_minor)");
     expect(sql).not.toMatch(/\bbalance_minor\b/);
     expect(sql).toContain("9007199254740991");
+  });
+
+  it("freezes financial identity while permitting guarded terminal transitions", () => {
+    expect(sql).toContain("gift_card_accounts_identity_immutable");
+    expect(sql).toContain("gift_card_accounts_status_transition_guard");
+    expect(sql).toContain("gift_card_reservations_identity_immutable");
+    expect(sql).toContain("gift_card_reservations_transition_guard");
+    expect(sql).toContain("NEW.committed_at >= OLD.reserved_at");
+    expect(sql).toContain("NEW.released_at >= OLD.reserved_at");
+  });
+
+  it("binds bounded restorations to the original redemption and order", () => {
+    expect(sql).toContain("redemption.id = NEW.related_entry_id");
+    expect(sql).toContain("redemption.gift_card_id = NEW.gift_card_id");
+    expect(sql).toContain("redemption.currency_code = NEW.currency_code");
+    expect(sql).toContain("redemption.order_id = NEW.order_id");
+    expect(sql).toContain("SUM(restoration.amount_delta_minor)");
   });
 
   it("makes issuance, reservation requests, redemption, and delivery deterministic", () => {

--- a/tests/unit/migrations/gift-cards-foundation.test.ts
+++ b/tests/unit/migrations/gift-cards-foundation.test.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const sql = readFileSync(
+  join(process.cwd(), "migrations", "0022_add_gift_cards.sql"),
+  "utf8",
+);
+const statements = sql.replace(/^\s*--.*$/gm, "");
+
+describe("gift-card foundation migration", () => {
+  it("is additive, default-empty, and leaves core order/webhook state intact", () => {
+    expect(sql).toContain("CREATE TABLE gift_card_accounts");
+    expect(sql).toContain("CREATE TABLE gift_card_reservations");
+    expect(sql).toContain("CREATE TABLE gift_card_ledger_entries");
+    expect(sql).toContain("CREATE TABLE gift_card_deliveries");
+    expect(statements).not.toMatch(/^\s*(?:DROP|DELETE|UPDATE|ALTER)\b/im);
+    expect(sql).not.toMatch(/CREATE TABLE\s+(?:IF NOT EXISTS\s+)?(?:orders|processed_webhook_events)/i);
+  });
+
+  it("stores only the versioned digest lookup and AEAD delivery placeholders", () => {
+    expect(sql).toContain("code_hash TEXT NOT NULL CHECK");
+    expect(sql).toContain("UNIQUE (code_hash_version, code_hash)");
+    expect(sql).toContain("code_ciphertext TEXT CHECK");
+    expect(sql).toContain("code_nonce TEXT CHECK");
+    expect(sql).toContain("code_key_version INTEGER CHECK");
+    expect(sql).not.toMatch(/(?:raw|plain)(?:text)?_?code/i);
+  });
+
+  it("derives balance from signed ledger entries and guards every raw writer", () => {
+    expect(sql).toContain("amount_delta_minor INTEGER NOT NULL");
+    expect(sql).toContain("gift_card_ledger_balance_guard");
+    expect(sql).toContain("gift_card_ledger_issuance_guard");
+    expect(sql).toContain("gift_card_ledger_redemption_guard");
+    expect(sql).toContain("gift_card_reservations_balance_guard");
+    expect(sql).toContain("SUM(entry.amount_delta_minor)");
+    expect(sql).not.toMatch(/\bbalance_minor\b/);
+    expect(sql).toContain("9007199254740991");
+  });
+
+  it("makes issuance, reservation requests, redemption, and delivery deterministic", () => {
+    expect(sql).toContain("issuance_business_key TEXT NOT NULL UNIQUE");
+    expect(sql).toContain("request_key TEXT NOT NULL UNIQUE");
+    expect(sql).toContain("business_key TEXT NOT NULL UNIQUE");
+    expect(sql).toContain("gift_card_ledger_reservation_unique");
+    expect(sql).toContain("email_idempotency_key TEXT NOT NULL UNIQUE");
+  });
+});

--- a/tests/unit/worker-cron-routing.test.ts
+++ b/tests/unit/worker-cron-routing.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mocks = vi.hoisted(() => ({
   drainOrderEffects: vi.fn(),
   drainInventoryAdjustments: vi.fn(),
+  drainGiftCardDeliveries: vi.fn(),
   regenerateAnalytics: vi.fn(),
   runRecommendationCron: vi.fn(),
   recordTelemetry: vi.fn(),
@@ -13,6 +14,9 @@ vi.mock('@/lib/services/order-effects', () => ({
 }));
 vi.mock('@/lib/services/inventory-adjustments', () => ({
   drainInventoryAdjustments: mocks.drainInventoryAdjustments,
+}));
+vi.mock('@/lib/services/gift-card-fulfillment', () => ({
+  drainGiftCardDeliveries: mocks.drainGiftCardDeliveries,
 }));
 vi.mock('@/lib/analytics/generate-insights', () => ({
   regenerateAnalytics: mocks.regenerateAnalytics,
@@ -41,6 +45,7 @@ function context(): { ctx: ExecutionContext; waits: Promise<unknown>[] } {
 beforeEach(() => {
   mocks.drainOrderEffects.mockResolvedValue({ claimed: 0, succeeded: 0, failed: 0 });
   mocks.drainInventoryAdjustments.mockResolvedValue({ claimed: 0, succeeded: 0, failed: 0 });
+  mocks.drainGiftCardDeliveries.mockResolvedValue({ attempted: 0 });
   mocks.regenerateAnalytics.mockResolvedValue(undefined);
   mocks.runRecommendationCron.mockResolvedValue(undefined);
 });
@@ -64,6 +69,30 @@ describe('Worker scheduled routing behavior', () => {
       },
       recoveryError,
     );
+  });
+
+  it('retries encrypted gift-card delivery under reconciliation even when acquisition is disabled', async () => {
+    const { ctx, waits } = context();
+    const runtime = {
+      DB: {} as D1Database,
+      STORE_FEATURE_GIFT_CARD_ACQUISITION: 'false',
+      STORE_FEATURE_GIFT_CARD_RECONCILIATION: 'true',
+    } as unknown as CloudflareEnv;
+
+    handleScheduled(controller('*/5 * * * *'), runtime, ctx);
+    await Promise.all(waits);
+
+    expect(mocks.drainGiftCardDeliveries).toHaveBeenCalledWith({
+      environment: runtime,
+      limit: 25,
+    });
+  });
+
+  it('does not open the gift-card retry boundary while reconciliation is disabled', async () => {
+    const { ctx, waits } = context();
+    handleScheduled(controller('*/5 * * * *'), { DB: {} } as CloudflareEnv, ctx);
+    await Promise.all(waits);
+    expect(mocks.drainGiftCardDeliveries).not.toHaveBeenCalled();
   });
 
   it('reports analytics failure while preserving background completion', async () => {


### PR DESCRIPTION
## O07 Gift Cards

Generic stored-value gift cards for Mercora, stacked on `agent/o06-subscriptions`. **Base this on `agent/o06-subscriptions`, not `main`** — it must not merge before O06.

Dependency chain: `O03 runtime safety` → `O06 subscriptions` → `O07 gift cards`.

### What it delivers
- Mixed-cart authoritative pricing: digital gift-card lines excluded from shipping and inventory; physical shipping retained for mixed carts; immutable order snapshots without bearer codes.
- Tender lifecycle over web and MCP with a stable request identity, explicit release/expiry, a real zero-cash finalizer for fully gift-funded orders, and the invariant that gift tender can never fund a gift-card line.
- Idempotent issuance after paid finalization; provider-neutral, retryable email delivery. Bearer codes are 140-bit, stored only as a keyed HMAC digest; retry material is AES-GCM encrypted and revealed only transiently at delivery.
- Refund convergence across cash and gift tender, restoring gift value exactly once, terminal only after both legs settle.
- Enumeration-resistant customer/admin surfaces with strict bounds, auth, rate limits, and secret-safe projections.
- Scheduler composition for reconciliation, reservation expiry, and delivery retries.

### Review-fix commit (top of branch)
The final commit closes six code-review findings:
- Gift-card lines are excluded from all promotion eligibility, so stored value is never discounted below the face value issuance credits.
- Resolved gift-card tender is validated against the non-gift eligible amount, not the whole checkout total.
- The customer-selected delivery date is honored via a `deliver_after` column gating the delivery claim and drain.
- A permanently failing delivery escalates to `needs_review` after a bounded attempt budget instead of retrying forever.
- A delivery key that does not decode to a 32-byte AES-256 key is rejected at config load.
- Each issued account is read once during the paid effect instead of twice.

### Verification
- Unit: 230 files / 1680 tests pass.
- Workers/D1: 27 files / 149 tests pass.
- `tsc --noEmit`, `eslint` (changed files), and `next build`: pass.

https://claude.ai/code/session_01S6GAvoeyzqR6iGMgB92KL9
