### PR TITLE
Platform bug fixes reconstructed from BeauTeas

### DIFF
--- a/app/admin/settings/page.tsx
+++ b/app/admin/settings/page.tsx
@@ -53,6 +53,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { parseSettingRows } from "@/lib/admin/settings-parse";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -129,6 +130,14 @@ export default function AdminSettingsPage() {
   const [loading, setLoading] = useState(false);
   const [saved, setSaved] = useState(false);
   const [initialLoad, setInitialLoad] = useState(true);
+  // Whether the form is showing STORED settings rather than the defaults below.
+  // Saving while this is false writes those defaults over every setting: one
+  // unparseable row used to abort the whole load (see the JSON.parse loop in
+  // loadSettings), leaving every field on its default, and the next Save then
+  // overwrote all stored settings. The load can no longer fail that way
+  // (lib/admin/settings-parse.ts); this guard makes the blast radius zero if it
+  // ever fails for another reason.
+  const [settingsLoaded, setSettingsLoaded] = useState(false);
   
   const [systemSettings, setSystemSettings] = useState<SystemSettings>({
     maintenance_mode: false,
@@ -200,11 +209,23 @@ export default function AdminSettingsPage() {
       const response = await fetch('/api/admin/settings');
       if (response.ok) {
         const { settings } = await response.json() as any;
-        
+
+        // Parse EVERY row before touching state. JSON.parse used to run
+        // unguarded in this loop, so a single non-JSON row aborted the whole
+        // load and the next Save then overwrote every stored setting with the
+        // component defaults. See lib/admin/settings-parse.ts.
+        const { values: parsedValues, nonJsonKeys } = parseSettingRows(settings);
+        if (nonJsonKeys.length > 0) {
+          console.warn(
+            `[admin/settings] ${nonJsonKeys.length} non-JSON setting(s) read as raw strings:`,
+            nonJsonKeys.join(', ')
+          );
+        }
+
         // Parse settings by category
-        settings.forEach((setting: any) => {
-          const value = JSON.parse(setting.value);
-          
+        (settings as any[]).forEach((setting: any) => {
+          const value = parsedValues.get(setting.key) as any;
+
           if (setting.category === 'system') {
             if (setting.key === 'system.maintenance_mode') setSystemSettings(prev => ({ ...prev, maintenance_mode: value }));
             if (setting.key === 'system.maintenance_message') setSystemSettings(prev => ({ ...prev, maintenance_message: value }));
@@ -238,8 +259,17 @@ export default function AdminSettingsPage() {
             if (setting.key === 'social.tiktok') setSocialMediaSettings(prev => ({ ...prev, tiktok: value }));
           }
         });
+
+        // Only now is the form showing STORED values rather than the defaults.
+        // Saving before this point writes those defaults over every setting, so
+        // the Save button stays disabled until it flips.
+        setSettingsLoaded(true);
+      } else {
+        setSettingsLoaded(false);
+        console.error('[admin/settings] settings request failed:', response.status);
       }
     } catch (error) {
+      setSettingsLoaded(false);
       console.error('Error loading settings:', error);
     } finally {
       setLoading(false);
@@ -338,9 +368,15 @@ export default function AdminSettingsPage() {
   };
 
   const handleSave = async () => {
+    // Never write the component defaults over stored settings. See settingsLoaded.
+    if (!settingsLoaded) {
+      console.error('[admin/settings] refusing to save: settings never loaded');
+      return;
+    }
+
     setLoading(true);
     setSaved(false);
-    
+
     try {
       // Build updates array from all settings
       const updates = [
@@ -457,7 +493,12 @@ export default function AdminSettingsPage() {
           )}
           <Button
             onClick={handleSave}
-            disabled={loading}
+            disabled={loading || !settingsLoaded}
+            title={
+              settingsLoaded
+                ? undefined
+                : "Settings haven't loaded, so saving would overwrite them with defaults. Reload the page."
+            }
             className="bg-orange-600 hover:bg-orange-700"
           >
             {loading ? (
@@ -469,6 +510,23 @@ export default function AdminSettingsPage() {
           </Button>
         </div>
       </div>
+
+      {/* Saving before the stored settings load would write the component
+          defaults over every setting, so say so rather than leaving a disabled
+          button with no explanation. */}
+      {!initialLoad && !settingsLoaded && (
+        <div className="bg-red-950 border border-red-800 rounded-lg p-4">
+          <div className="flex items-center space-x-2">
+            <AlertCircle className="w-5 h-5 text-red-400 flex-shrink-0" />
+            <p className="text-sm text-red-200">
+              <strong>Settings could not be loaded.</strong> The fields below are showing
+              defaults, not your stored values, so saving is disabled to keep it from
+              overwriting them. Reload the page; if it keeps failing, check the browser
+              console.
+            </p>
+          </div>
+        </div>
+      )}
 
       {/* Tab Navigation */}
       <div className="flex space-x-1 bg-neutral-800 p-1 rounded-lg">

--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -41,6 +41,7 @@ import Link from "next/link";
 import Image from "next/image";
 import type { Product, ProductVariant } from "@/lib/types";
 import { getDarkBlurPlaceholder } from "@/lib/utils/image-placeholders";
+import { resolveProductImageSrc } from "@/lib/utils/product-image";
 import { normalizeProductRating } from "@/lib/utils/ratings";
 import { StarRating } from "@/components/reviews/StarRating";
 import { Money } from "@/lib/money";
@@ -101,31 +102,15 @@ export default function ProductCard({ product, priority = false }: ProductCardPr
     typeof product.slug === "string"
       ? product.slug
       : Object.values(product.slug || {})[0] || "";
-  // Handle consistent flat JSON structure: {"url": "...", "alt_text": "..."}
-  const imageUrl = (() => {
-    try {
-      if (!product.primary_image) return "/products/placeholder.png";
-      
-      // If it's a JSON string, parse it first
-      let imageData = product.primary_image;
-      if (typeof imageData === "string" && (imageData as string).startsWith("{")) {
-        try {
-          imageData = JSON.parse(imageData);
-        } catch {
-          return "/products/placeholder.png";
-        }
-      }
-      
-      const img = imageData as any;
-      const url = img?.url;
-      
-      if (!url) return "/products/placeholder.png";
-      
-      return url.startsWith("/") ? url : "/" + url;
-    } catch {
-      return "/products/placeholder.png";
-    }
-  })();
+  // Both stored shapes, flat ({url}) and MACH ({file:{url}}), resolve here. This
+  // used to read `img.url` only, so a product saved through the admin editor —
+  // which writes the MACH shape — silently lost its card image to the
+  // placeholder while its PDP kept working. See lib/utils/product-image.ts.
+  const imageUrl = resolveProductImageSrc(
+    product.primary_image,
+    product.media,
+    "/products/placeholder.png"
+  );
   const imageAlt = name;
   const ratingSummary = normalizeProductRating(product.rating);
   const hasRatings = Boolean(ratingSummary && ratingSummary.count > 0);

--- a/components/admin/ProductEditor.tsx
+++ b/components/admin/ProductEditor.tsx
@@ -214,11 +214,11 @@ export default function ProductEditor({
 
   const addNewVariant = () => {
     // Save current variant data first
-    saveCurrentVariantData();
+    const savedVariants = saveCurrentVariantData();
     
     const newVariant = {
       id: `new-variant-${Date.now()}`,
-      sku: `SKU-${variants.length + 1}`,
+      sku: `SKU-${savedVariants.length + 1}`,
       price: { amount: 0, currency: "USD" },
       option_values: [],
       status: "active",
@@ -226,7 +226,7 @@ export default function ProductEditor({
       shipping_required: true
     };
     
-    const newVariants = [...variants, newVariant];
+    const newVariants = [...savedVariants, newVariant];
     setVariants(newVariants);
     setSelectedVariantIndex(newVariants.length - 1);
     

--- a/components/admin/ProductEditor.tsx
+++ b/components/admin/ProductEditor.tsx
@@ -151,9 +151,14 @@ export default function ProductEditor({
     }
   };
 
-  const saveCurrentVariantData = () => {
-    if (variants.length === 0) return;
-    
+  // Returns the merged variants array. handleSave (and the add/remove/switch
+  // paths) must use THIS return value, not the `variants` state: a React setter
+  // does not update the binding the running function already closed over, so
+  // reading `variants` in the same tick after calling this yields the pre-edit
+  // array and the save silently rewrites the database with the old values.
+  const saveCurrentVariantData = (): any[] => {
+    if (variants.length === 0) return variants;
+
     const updatedVariants = [...variants];
     const currentVariant = updatedVariants[selectedVariantIndex] || {};
     
@@ -187,7 +192,13 @@ export default function ProductEditor({
       compare_at_price: compareAtPrice ? Money.fromMajor(compareAtPrice).toJSON() : undefined,
       cost: cost ? Money.fromMajor(cost).toJSON() : undefined,
       sku: sku || undefined,
-      inventory: inventory ? { quantity: parseInt(inventory) } : undefined,
+      // Merge onto the existing inventory record rather than rebuilding it from
+      // the quantity field alone: `track_inventory` and `allow_backorder` live
+      // on this same object and are what make a variant purchasable at quantity
+      // 0. Overwriting with `{ quantity }` silently stripped them on every edit.
+      inventory: inventory
+        ? { ...(currentVariant.inventory ?? {}), quantity: parseInt(inventory) }
+        : currentVariant.inventory,
       weight: weight ? { value: parseFloat(weight), unit: "lb" } : undefined,
       dimensions: dimensionsObj,
       barcode: barcode || undefined,
@@ -196,8 +207,9 @@ export default function ProductEditor({
       position: variantPosition ? parseInt(variantPosition) : undefined,
       attributes: attributesObj
     };
-    
+
     setVariants(updatedVariants);
+    return updatedVariants;
   };
 
   const addNewVariant = () => {
@@ -512,10 +524,12 @@ export default function ProductEditor({
   const handleSave = async () => {
     setSaving(true);
     try {
-      // Save current variant data before saving
-      if (variants.length > 0 && selectedVariantIndex < variants.length) {
-        saveCurrentVariantData();
-      }
+      // Save current variant data before saving. Use the RETURNED array, not
+      // the `variants` state, which is not yet updated within this handler tick.
+      const savedVariants =
+        variants.length > 0 && selectedVariantIndex < variants.length
+          ? saveCurrentVariantData()
+          : variants;
 
       const productData: Partial<Product> = {
         ...(product?.id && !isNew ? { id: product.id } : {}), // Include ID for existing products
@@ -645,10 +659,10 @@ export default function ProductEditor({
       }
 
       // Add all variants data
-      if (variants.length > 0) {
-        productData.variants = variants;
+      if (savedVariants.length > 0) {
+        productData.variants = savedVariants;
         // Set default variant to first variant
-        productData.default_variant_id = variants[0]?.id;
+        productData.default_variant_id = savedVariants[0]?.id;
       } else if (isNew) {
         // For new products without variants, create a default variant
         const defaultVariant = {

--- a/components/agent/ProductCard.tsx
+++ b/components/agent/ProductCard.tsx
@@ -3,10 +3,14 @@
 import Image from "next/image";
 import Link from "next/link";
 import { fromWireMoney } from "@/lib/money";
+import { resolveProductImageSrc } from "@/lib/utils/product-image";
 
 export default function ProductCard({ product }: { product: any }) {
-  // Extract primary image URL from the new product structure
-  const imageUrl = product.primary_image?.url || product.media?.[0]?.url || "/placeholder.jpg";
+  // Accepts both stored shapes — flat ({url}) and MACH ({file:{url}}) from the
+  // admin editor. Reading only `.url` here made the card fall back to the
+  // placeholder for any product saved through the editor. See
+  // lib/utils/product-image.ts.
+  const imageUrl = resolveProductImageSrc(product.primary_image, product.media, "/placeholder.jpg");
   
   // Get price from first variant. These arrive as MACH wire money (decimal
   // major units), not the minor units Mercora stores.

--- a/lib/admin/settings-parse.ts
+++ b/lib/admin/settings-parse.ts
@@ -1,0 +1,86 @@
+/**
+ * === Admin settings row parsing (pure) ===
+ *
+ * `admin_settings.value` is JSON for every row the app writes, but not
+ * necessarily for legacy rows that predate that convention or that arrive from
+ * an import, which can hold bare strings:
+ *
+ *   currency = USD
+ *   store_name = Acme
+ *   social_instagram = https://instagram.com/acme
+ *
+ * The admin settings page used to call `JSON.parse(setting.value)` unguarded
+ * inside a `forEach`. The first non-JSON row threw, the loop aborted, the outer
+ * `catch` swallowed it, and NOTHING loaded — every field silently kept its
+ * hardcoded default. Because the page then saves every category from that same
+ * state, one click of Save wrote those defaults over every stored setting.
+ * Nothing errored, and the page looked normal throughout, because the defaults
+ * are plausible values.
+ *
+ * So: a row that is not JSON is not corrupt, it is a bare string, and it must
+ * never be able to take the whole page down with it.
+ */
+
+/**
+ * One `admin_settings.value` as a usable value. JSON when the row holds JSON,
+ * the raw string when it doesn't (the legacy shape), and `undefined` only for a
+ * genuinely absent value — never a throw.
+ */
+export function parseSettingValue(raw: unknown): unknown {
+  if (raw === null || raw === undefined) return undefined;
+  if (typeof raw !== 'string') return raw;
+
+  try {
+    return JSON.parse(raw);
+  } catch {
+    // A bare legacy string ("USD", "https://instagram.com/acme"). Returning it
+    // as-is is what the row means; the alternative that shipped was losing every
+    // other row alongside it.
+    return raw;
+  }
+}
+
+export interface SettingRow {
+  key?: unknown;
+  value?: unknown;
+  category?: unknown;
+}
+
+export interface ParsedSettings {
+  /** key → parsed value, for every row that had a usable key. */
+  values: Map<string, unknown>;
+  /** Keys whose value was not JSON, for logging. Not an error condition. */
+  nonJsonKeys: string[];
+}
+
+/**
+ * Parse a settings payload row by row. A bad row is recorded, never thrown, so
+ * the caller always receives every OTHER row.
+ */
+export function parseSettingRows(rows: unknown): ParsedSettings {
+  const values = new Map<string, unknown>();
+  const nonJsonKeys: string[] = [];
+
+  if (!Array.isArray(rows)) return { values, nonJsonKeys };
+
+  for (const row of rows as SettingRow[]) {
+    if (!row || typeof row !== 'object') continue;
+    const key = typeof row.key === 'string' ? row.key : null;
+    if (!key) continue;
+
+    const parsed = parseSettingValue(row.value);
+    if (typeof row.value === 'string' && typeof parsed === 'string' && parsed === row.value) {
+      // Round-tripped unchanged, i.e. it did not parse as JSON. A JSON string
+      // row ('"USD"') parses to 'USD' and is NOT flagged, which is correct —
+      // only genuinely non-JSON rows land here.
+      try {
+        JSON.parse(row.value);
+      } catch {
+        nonJsonKeys.push(key);
+      }
+    }
+    values.set(key, parsed);
+  }
+
+  return { values, nonJsonKeys };
+}

--- a/lib/models/mach/products.ts
+++ b/lib/models/mach/products.ts
@@ -362,81 +362,72 @@ export async function updateProduct(id: string, updates: Partial<Product>): Prom
           updated_at: new Date().toISOString()
         };
         
-        // Update inventory if provided
-        if (variant.inventory) {
-          variantUpdateData.inventory = JSON.stringify(variant.inventory);
+        // PASS JSON VALUES THROUGH UNSERIALIZED. Every JSON-shaped column on
+        // `product_variants` is declared `mode: 'json'` (lib/db/schema/products.ts),
+        // so Drizzle serializes the value itself on write. This loop used to
+        // `JSON.stringify` each one first, which made Drizzle stringify the string
+        // AGAIN and store `"{\"quantity\":250}"` — a JSON *text* scalar, not an
+        // object.
+        //
+        // That stays invisible for a long time because every JavaScript reader
+        // recovers from it (a `Money.fromStored`/parse path re-parses a string
+        // that starts with `{`). SQL does not. The guarded stock decrement in
+        // lib/services/inventory-adjustments.ts matches on
+        // `json_extract(inventory, '$.quantity')`, which returns NULL for a text
+        // scalar, so its compare-and-swap matches zero rows and a sale of an
+        // affected variant is recorded as oversold while its stock never moves.
+        //
+        // `updateProductVariant` elsewhere has always passed values straight
+        // through; this loop was the only writer that did not.
+        const JSON_VARIANT_COLUMNS = [
+          'inventory',
+          'price',
+          'weight',
+          'dimensions',
+          'compare_at_price',
+          'cost',
+          'media',
+          'attributes',
+          'option_values',
+        ] as const;
+
+        for (const column of JSON_VARIANT_COLUMNS) {
+          const value = (variant as unknown as Record<string, unknown>)[column];
+          if (value) {
+            variantUpdateData[column] = value;
+          }
         }
-        
-        // Update price if provided
-        if (variant.price) {
-          variantUpdateData.price = JSON.stringify(variant.price);
-        }
-        
+
         // Update SKU if provided
         if (variant.sku) {
           variantUpdateData.sku = variant.sku;
         }
-        
-        // Update weight if provided
-        if (variant.weight) {
-          variantUpdateData.weight = JSON.stringify(variant.weight);
-        }
-        
-        // Update dimensions if provided
-        if (variant.dimensions) {
-          variantUpdateData.dimensions = JSON.stringify(variant.dimensions);
-        }
-        
+
         // Update barcode if provided
         if (variant.barcode) {
           variantUpdateData.barcode = variant.barcode;
         }
-        
+
         // Update status if provided
         if (variant.status) {
           variantUpdateData.status = variant.status;
         }
-        
+
         // Update position if provided
         if (variant.position !== undefined) {
           variantUpdateData.position = variant.position;
         }
-        
-        // Update compare_at_price if provided
-        if (variant.compare_at_price) {
-          variantUpdateData.compare_at_price = JSON.stringify(variant.compare_at_price);
-        }
-        
-        // Update cost if provided
-        if (variant.cost) {
-          variantUpdateData.cost = JSON.stringify(variant.cost);
-        }
-        
+
         // Update tax_category if provided
         if (variant.tax_category) {
           variantUpdateData.tax_category = variant.tax_category;
         }
-        
+
         // Update shipping_required if provided
         if (variant.shipping_required !== undefined) {
           variantUpdateData.shipping_required = variant.shipping_required ? 1 : 0;
         }
-        
-        // Update media if provided
-        if (variant.media) {
-          variantUpdateData.media = JSON.stringify(variant.media);
-        }
-        
-        // Update attributes if provided
-        if (variant.attributes) {
-          variantUpdateData.attributes = JSON.stringify(variant.attributes);
-        }
-        
-        // Update option_values if provided
-        if (variant.option_values) {
-          variantUpdateData.option_values = JSON.stringify(variant.option_values);
-        }
-        
+
         // Perform the update only if there are fields to update
         const fieldsToUpdate = Object.keys(variantUpdateData).filter(key => key !== 'updated_at');
         if (fieldsToUpdate.length > 0) {

--- a/lib/utils/product-image.ts
+++ b/lib/utils/product-image.ts
@@ -1,0 +1,107 @@
+/**
+ * === Product image URL resolution (pure) ===
+ *
+ * `products.primary_image` and `products.media` hold TWO shapes, and both are
+ * legitimate:
+ *
+ *   flat (Shopify ETL):  { "url": "products/x.jpg", "alt_text": "..." }
+ *   MACH (admin editor): { "type": "image", "file": { "url": "products/x.jpg",
+ *                          "format": "jpg" }, "accessibility": { ... } }
+ *
+ * Reading only one of them is how the storefront lost every product image on the
+ * homepage: the cards read `img.url` alone, so the moment a product was saved
+ * through /admin/products (which writes the MACH shape) its card fell back to
+ * `/placeholder.svg`. The PDP kept working the whole time because
+ * ProductDisplay already read `?.url || ?.file?.url`, which is why this looked
+ * like an image-hosting problem rather than a shape mismatch.
+ *
+ * Rather than rewrite the stored data, every reader resolves through here. A
+ * migration could normalize the rows, but it would only hold until the next
+ * writer disagreed; accepting both shapes is what actually keeps the images on
+ * the page.
+ *
+ * PURE ON PURPOSE - no imports. Both product cards are client components.
+ */
+
+/**
+ * One image record in either shape, or a JSON string of one, or a bare path.
+ * Also accepts a `src` key as a third fallback, for records that carry the URL
+ * under that name.
+ */
+function urlFromImageRecord(image: unknown): string | null {
+  if (!image) return null;
+
+  if (typeof image === 'string') {
+    const trimmed = image.trim();
+    if (trimmed === '') return null;
+    // A column read that skipped JSON parsing, or a bare path/URL.
+    if (trimmed.startsWith('{')) {
+      try {
+        return urlFromImageRecord(JSON.parse(trimmed));
+      } catch {
+        return null;
+      }
+    }
+    return trimmed;
+  }
+
+  if (typeof image !== 'object') return null;
+
+  const record = image as Record<string, any>;
+  const candidates = [record.url, record.file?.url, record.src];
+
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string' && candidate.trim() !== '') {
+      return candidate.trim();
+    }
+  }
+
+  return null;
+}
+
+/**
+ * The display URL for a product's image, from its `primary_image` with `media`
+ * as a fallback, or `null` when neither carries one. Accepts either stored
+ * shape, in either field.
+ */
+export function resolveProductImageUrl(
+  primaryImage: unknown,
+  media?: unknown
+): string | null {
+  const primary = urlFromImageRecord(primaryImage);
+  if (primary) return primary;
+
+  let items: unknown = media;
+  if (typeof items === 'string' && items.trim().startsWith('[')) {
+    try {
+      items = JSON.parse(items);
+    } catch {
+      return null;
+    }
+  }
+
+  if (!Array.isArray(items)) return null;
+
+  for (const item of items) {
+    const url = urlFromImageRecord(item);
+    if (url) return url;
+  }
+
+  return null;
+}
+
+/**
+ * The same resolution, returning a `src` ready for the Image component: a
+ * root-relative path, falling back to the placeholder. R2 keys are stored
+ * without a leading slash (`products/x.jpg`) and the image loader expects one.
+ */
+export function resolveProductImageSrc(
+  primaryImage: unknown,
+  media?: unknown,
+  placeholder = '/placeholder.svg'
+): string {
+  const url = resolveProductImageUrl(primaryImage, media);
+  if (!url) return placeholder;
+  if (/^https?:\/\//i.test(url) || url.startsWith('/')) return url;
+  return `/${url}`;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14089,9 +14089,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/tests/unit/lib/admin/settings-parse.test.ts
+++ b/tests/unit/lib/admin/settings-parse.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Admin settings parsing must be resilient to a single non-JSON row.
+ *
+ * The settings page used to `JSON.parse(setting.value)` unguarded in a loop over
+ * every row. A single legacy row holding a bare string (currency = USD,
+ * social_instagram = https://..., store_name = Acme) threw, the loop aborted,
+ * and NOTHING loaded — every field kept its hardcoded default, and because the
+ * page saves every category from that same state, the next Save wrote those
+ * defaults over every stored setting. One un-parseable row must never cost you
+ * the others.
+ */
+import { describe, it, expect } from 'vitest';
+
+import { parseSettingValue, parseSettingRows } from '@/lib/admin/settings-parse';
+
+describe('parseSettingValue', () => {
+  it('parses JSON rows', () => {
+    expect(parseSettingValue('1')).toBe(1);
+    expect(parseSettingValue('true')).toBe(true);
+    expect(parseSettingValue('"USD"')).toBe('USD');
+    expect(parseSettingValue('[]')).toEqual([]);
+    expect(parseSettingValue('{"a":1}')).toEqual({ a: 1 });
+  });
+
+  it('returns a bare legacy string instead of throwing', () => {
+    expect(parseSettingValue('USD')).toBe('USD');
+    expect(parseSettingValue('https://instagram.com/acme')).toBe(
+      'https://instagram.com/acme'
+    );
+    expect(parseSettingValue('Welcome to Acme')).toBe('Welcome to Acme');
+    expect(parseSettingValue('/promo')).toBe('/promo');
+  });
+
+  it('treats absent values as undefined, never a throw', () => {
+    expect(parseSettingValue(null)).toBeUndefined();
+    expect(parseSettingValue(undefined)).toBeUndefined();
+  });
+});
+
+describe('parseSettingRows', () => {
+  it('keeps every good row when a legacy row sits in the middle', () => {
+    const { values } = parseSettingRows([
+      { key: 'system.maintenance_mode', value: 'false', category: 'system' },
+      { key: 'currency', value: 'USD', category: 'store' },
+      { key: 'shipping.methods', value: '[]', category: 'shipping' },
+      { key: 'social_instagram', value: 'https://instagram.com/acme', category: 'social' },
+      { key: 'promotions.banner_enabled', value: 'true', category: 'promotions' },
+    ]);
+
+    // The bug: everything after `currency` was lost, so these were all undefined
+    // and the page saved its defaults over them.
+    expect(values.get('system.maintenance_mode')).toBe(false);
+    expect(values.get('shipping.methods')).toEqual([]);
+    expect(values.get('promotions.banner_enabled')).toBe(true);
+    expect(values.get('currency')).toBe('USD');
+    expect(values.get('social_instagram')).toBe('https://instagram.com/acme');
+  });
+
+  it('reports which rows were not JSON without treating them as failures', () => {
+    const { nonJsonKeys } = parseSettingRows([
+      { key: 'currency', value: 'USD' },
+      { key: 'shipping.methods', value: '[]' },
+      { key: 'store_name', value: 'Acme' },
+      // A JSON string row must NOT be reported: '"info"' is valid JSON.
+      { key: 'promotions.banner_type', value: '"info"' },
+    ]);
+
+    expect(nonJsonKeys).toEqual(['currency', 'store_name']);
+  });
+
+  it('skips malformed rows rather than throwing', () => {
+    const { values } = parseSettingRows([
+      null,
+      'not a row',
+      { value: 'orphan with no key' },
+      { key: 'currency', value: '"USD"' },
+    ]);
+
+    expect(values.size).toBe(1);
+    expect(values.get('currency')).toBe('USD');
+  });
+
+  it('returns empty rather than throwing on a non-array payload', () => {
+    expect(parseSettingRows(undefined).values.size).toBe(0);
+    expect(parseSettingRows({ settings: [] }).values.size).toBe(0);
+  });
+});

--- a/tests/unit/lib/models/update-product-variant-json.test.ts
+++ b/tests/unit/lib/models/update-product-variant-json.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Regression test for the variant-write path in `updateProduct`.
+ *
+ * Every JSON-shaped column on `product_variants` is declared `mode: 'json'`
+ * (lib/db/schema/products.ts), so Drizzle serializes the value on write. This
+ * loop used to `JSON.stringify` each value first, so Drizzle stringified the
+ * string again and the column ended up holding a JSON *text* scalar
+ * (`"{\"quantity\":250}"`) instead of an object.
+ *
+ * Why that is worth a test rather than a comment: JavaScript readers that
+ * re-parse a string beginning with `{` recover from it, so nothing errors and
+ * nothing looks wrong on the storefront. The damage is only visible from SQL —
+ * `json_extract(inventory, '$.quantity')` is NULL for a text scalar, which the
+ * guarded stock decrement in lib/services/inventory-adjustments.ts coalesces to
+ * 0, so it matches zero rows and a sale of an affected variant is recorded as
+ * oversold while its stock never moves.
+ *
+ * The assertion is therefore on the exact TYPE handed to Drizzle, which is the
+ * only layer where the bug is observable.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../../lib/db', () => ({
+  getDbAsync: vi.fn(),
+}));
+
+import { updateProduct } from '@/lib/models/mach/products';
+import { getDbAsync } from '@/lib/db';
+
+let variantSets: any[] = [];
+
+function makeDb() {
+  return {
+    update: vi.fn().mockImplementation(() => ({
+      set: vi.fn().mockImplementation((row: any) => {
+        // The product UPDATE and the variant UPDATE both land here; only the
+        // variant write carries these columns.
+        if ('inventory' in row || 'price' in row || 'option_values' in row) {
+          variantSets.push(row);
+        }
+        return { where: vi.fn().mockResolvedValue(undefined) };
+      }),
+    })),
+    select: vi.fn().mockImplementation(() => ({
+      from: vi.fn().mockImplementation(() => ({
+        where: vi.fn().mockResolvedValue([]),
+      })),
+    })),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  variantSets = [];
+  vi.mocked(getDbAsync).mockResolvedValue(makeDb() as any);
+});
+
+const INVENTORY = { track_inventory: true, quantity: 144, allow_backorder: false };
+const PRICE = { amount: 300, currency: 'USD' };
+
+describe('updateProduct — variant JSON columns', () => {
+  it('hands Drizzle OBJECTS, never pre-stringified JSON', async () => {
+    await updateProduct('prod_1', {
+      name: 'Test Product',
+      variants: [
+        {
+          id: 'variant_1',
+          inventory: INVENTORY,
+          price: PRICE,
+          compare_at_price: { amount: 2000, currency: 'USD' },
+          option_values: [{ option_id: 'size', value: 'One box' }],
+          media: [{ type: 'image' }],
+        } as any,
+      ],
+    } as any);
+
+    expect(variantSets).toHaveLength(1);
+    const written = variantSets[0];
+
+    // The bug: `typeof written.inventory === 'string'`.
+    expect(typeof written.inventory).toBe('object');
+    expect(written.inventory).toEqual(INVENTORY);
+    expect(typeof written.price).toBe('object');
+    expect(written.price).toEqual(PRICE);
+    expect(typeof written.compare_at_price).toBe('object');
+    expect(Array.isArray(written.option_values)).toBe(true);
+    expect(Array.isArray(written.media)).toBe(true);
+  });
+
+  it('still writes scalar columns as scalars', async () => {
+    await updateProduct('prod_1', {
+      name: 'Test Product',
+      variants: [
+        {
+          id: 'variant_1',
+          inventory: INVENTORY,
+          sku: 'SKU-1',
+          status: 'active',
+          position: 1,
+          shipping_required: true,
+        } as any,
+      ],
+    } as any);
+
+    const written = variantSets[0];
+    expect(written.sku).toBe('SKU-1');
+    expect(written.status).toBe('active');
+    expect(written.position).toBe(1);
+    // Booleans persist as SQLite integers on this column.
+    expect(written.shipping_required).toBe(1);
+  });
+
+  it('omits columns the caller did not supply', async () => {
+    // The loop is additive: a partial variant update must not null out the
+    // columns it says nothing about.
+    await updateProduct('prod_1', {
+      name: 'Test Product',
+      variants: [{ id: 'variant_1', inventory: INVENTORY } as any],
+    } as any);
+
+    const written = variantSets[0];
+    expect(written).not.toHaveProperty('price');
+    expect(written).not.toHaveProperty('media');
+    expect(written).not.toHaveProperty('cost');
+  });
+});

--- a/tests/unit/lib/utils/product-image.test.ts
+++ b/tests/unit/lib/utils/product-image.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Unit tests for product image resolution.
+ *
+ * `products.primary_image` holds two shapes: the flat `{url, alt_text}` the
+ * Shopify ETL wrote, and the MACH `{type, file: {url}, accessibility}` the admin
+ * editor writes. The product cards read `img.url` alone, so saving a product
+ * through /admin/products silently replaced its card image with
+ * `/placeholder.svg` — on the homepage, the category pages, and Chai's cards —
+ * while the PDP kept rendering it, because ProductDisplay already read both.
+ *
+ * These pin BOTH shapes in both fields. The card is the only place a customer
+ * sees the catalog before clicking, so a silent fallback here is invisible in
+ * exactly the way this was.
+ */
+import { describe, it, expect } from 'vitest';
+
+import { resolveProductImageUrl, resolveProductImageSrc } from '@/lib/utils/product-image';
+
+const FLAT = { url: 'products/x.jpg', alt_text: 'X' };
+const MACH = {
+  type: 'image',
+  file: { url: 'products/x.jpg', format: 'jpg' },
+  accessibility: { alt_text: 'X' },
+};
+
+describe('resolveProductImageUrl', () => {
+  it('reads the flat ETL shape', () => {
+    expect(resolveProductImageUrl(FLAT)).toBe('products/x.jpg');
+  });
+
+  it('reads the MACH shape the admin editor writes', () => {
+    expect(resolveProductImageUrl(MACH)).toBe('products/x.jpg');
+  });
+
+  it('parses either shape out of an unparsed JSON string', () => {
+    expect(resolveProductImageUrl(JSON.stringify(FLAT))).toBe('products/x.jpg');
+    expect(resolveProductImageUrl(JSON.stringify(MACH))).toBe('products/x.jpg');
+  });
+
+  it('falls back to media when there is no primary image', () => {
+    expect(resolveProductImageUrl(null, [MACH])).toBe('products/x.jpg');
+    expect(resolveProductImageUrl(undefined, [FLAT])).toBe('products/x.jpg');
+    expect(resolveProductImageUrl(null, JSON.stringify([FLAT]))).toBe('products/x.jpg');
+  });
+
+  it('skips media entries that carry no url', () => {
+    expect(resolveProductImageUrl(null, [{ type: 'image' }, FLAT])).toBe('products/x.jpg');
+  });
+
+  it('treats a bare string as the path it is', () => {
+    // Some rows store the key directly rather than a record.
+    expect(resolveProductImageUrl('products/x.jpg')).toBe('products/x.jpg');
+  });
+
+  it('returns null when nothing resolves', () => {
+    // '{broken' looks like JSON and fails to parse — the only string form that
+    // is not a usable path.
+    for (const empty of [null, undefined, '', '   ', {}, { file: {} }, '{broken', []]) {
+      expect(resolveProductImageUrl(empty)).toBeNull();
+    }
+    expect(resolveProductImageUrl(null, [])).toBeNull();
+    expect(resolveProductImageUrl(null, 'nonsense')).toBeNull();
+  });
+});
+
+describe('resolveProductImageSrc', () => {
+  it('roots an R2 key so the image loader can resolve it', () => {
+    // R2 keys are stored without a leading slash.
+    expect(resolveProductImageSrc(FLAT)).toBe('/products/x.jpg');
+    expect(resolveProductImageSrc(MACH)).toBe('/products/x.jpg');
+  });
+
+  it('leaves absolute paths and external URLs alone', () => {
+    expect(resolveProductImageSrc({ url: '/already-rooted.jpg' })).toBe('/already-rooted.jpg');
+    expect(resolveProductImageSrc({ url: 'https://cdn.example.com/x.jpg' })).toBe(
+      'https://cdn.example.com/x.jpg'
+    );
+  });
+
+  it('falls back to the placeholder rather than an empty src', () => {
+    expect(resolveProductImageSrc(null)).toBe('/placeholder.svg');
+    expect(resolveProductImageSrc({ file: {} }, [])).toBe('/placeholder.svg');
+  });
+});


### PR DESCRIPTION
## What this is

Four platform bug fixes developed in the BeauTeas downstream and reconstructed here against current Mercora `main`, per the upstreaming plan (reconstructed, not cherry-picked — the histories are unrelated). Each was confirmed to reproduce in Mercora's own source before inclusion; BeauTeas branding, sale behavior, and data-repair migrations are excluded.

## Fixes

**1. Admin variant saves discard edits and double-encode JSON** (`lib/models/mach/products.ts`, `components/admin/ProductEditor.tsx`)

Two bugs on the admin product write path:
- `updateProduct` `JSON.stringify`d each variant value before handing it to Drizzle, but every JSON-shaped column on `product_variants` is `mode: 'json'`, which serializes on write — so the column ended up holding a JSON *text* scalar (`"{\"quantity\":250}"`) instead of an object. JS readers recover by re-parsing, but SQL doesn't: the guarded decrement in `lib/services/inventory-adjustments.ts` matches on `json_extract(inventory, '$.quantity')`, which is NULL for a text scalar, so its compare-and-swap matches zero rows and a sale is recorded oversold while stock never moves. Now passes JSON values through unserialized.
- `handleSave` called `saveCurrentVariantData()` (which commits form fields via `setVariants`) then read the `variants` state in the same tick, so the PUT carried the pre-edit array and silently discarded the admin's edits while returning 200. `saveCurrentVariantData` now returns the merged array and `handleSave` sends that. It also merges onto the existing inventory record instead of rebuilding it from `quantity` alone, so editing quantity no longer strips `track_inventory`/`allow_backorder`.

**2. One unparseable `admin_settings` row wipes all settings** (`lib/admin/settings-parse.ts`, `app/admin/settings/page.tsx`)

`loadSettings` ran `JSON.parse(setting.value)` unguarded inside a `forEach`, so a single non-JSON row (a legacy or imported bare string) threw, aborted the whole load, and left every field on its hardcoded default. Because the page saves every category from that same state, the next Save overwrote every stored setting with those defaults — no error, normal-looking page. Adds a pure row-by-row parser (returns a non-JSON row as its raw string instead of throwing) and a `settingsLoaded` guard that disables Save (with a banner) until stored values actually load.

**3. Product cards only read one of two stored image shapes** (`lib/utils/product-image.ts`, `components/ProductCard.tsx`, `components/agent/ProductCard.tsx`)

`primary_image`/`media` are stored in two legitimate shapes — flat `{url}` and MACH `{file:{url}}` (written by the admin editor). Both cards read `img.url` only, so any product saved through the editor silently lost its card image to the placeholder while its PDP kept working. Adds a pure resolver both cards route through, preserving each card's existing placeholder path.

**4. nanoid advisory** (`package-lock.json`)

`npm audit fix --package-lock-only`: nanoid 3.3.17 → 3.3.18 (GHSA-2v37-7h3g-55p8, high). dompurify isn't flagged in this tree, so it's untouched.

## Not included

- The BeauTeas PDP-availability fix and order-email-thumbnail fix don't apply here: Mercora's PDP already computes `available_for_sale ?? isVariantAvailable(...)` (both respect the inventory flags), and Mercora has no `canonicalizeOrderItemsDisplay` path yet.
- **shadcn token gap:** Mercora's Switch has the same invisible-track bug (`bg-input` doesn't resolve), and it's broader — `components/ui/*` reference 18 color tokens but the runtime theme defines 5. Fixing it means adding tokens to the CSS-variable theme (`--store-*`), which is a theme-design decision, so it's filed separately as #80 rather than bundled here.

## Testing note

The `updateProduct` double-encode has a model-level regression test, the settings parser has unit coverage, and the image resolver has unit coverage. The `ProductEditor.handleSave` interaction fix ships without a new automated test: Mercora's unit suite runs in a `node` environment over `*.test.ts` only, with no DOM harness to drive a component interaction. The code change is small and mechanical, and BeauTeas covers it with an interactive test.

## Verification

`npm run lint`, `tsc --noEmit`, `vitest run tests/unit` (173 files, 1032 tests, +20 for the new coverage), and `npm run build` all pass locally. The workers/integration suites (which need the vitest-pool-workers env) weren't run locally; they're untouched by these changes.

https://claude.ai/code/session_015XWs3FzTzTNMPJfqnja9VS
